### PR TITLE
Drop request count check from throughput sweep profile

### DIFF
--- a/src/guidellm/executor/profile_generator.py
+++ b/src/guidellm/executor/profile_generator.py
@@ -324,9 +324,6 @@ class ProfileGenerator:
 
         if index == 1:
             throughput_profile: Profile = ProfileGenerator.create_throughput_profile(0)  # type: ignore  # noqa: PGH003
-            # set the max number of requests to 5 times the number of requests
-            # incase it is not set for the sweep to limit the number of requests
-            throughput_profile.args = {"max_number": sync_benchmark.request_count * 5}
             return throughput_profile
 
         if not throughput_benchmark:


### PR DESCRIPTION
The throughput profile limits its max requests based on the number of successful requests in the previous synchronous profile run. This seems to be left over from previous behavior.

Fixes #88 