### PR TITLE
Run development workflow from target branch scope

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -156,8 +156,6 @@ jobs:
         run: npm run test:integration
 
   build:
-    # Only build if the PR branch is local
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -156,6 +156,8 @@ jobs:
         run: npm run test:integration
 
   build:
+    # Only build if the PR branch is local
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,7 +1,7 @@
 name: Development
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
Run the development workflow on the `pull_request_target` trigger which runs the workflow from the scope of the target branch rather than the merge branch. This should solve the permission failure in the build job.