### PR TITLE
Add Ubi container

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -37,7 +37,8 @@ LABEL org.opencontainers.image.source="https://github.com/neuralmagic/guidellm" 
 
 # Set the environment variable for the benchmark script
 # TODO: Replace with scenario environment variables
-ENV GUIDELLM_TARGET="http://localhost:8000" \
+ENV GUIDELLM_BIN="/opt/guidellm/bin/guidellm" \
+    GUIDELLM_TARGET="http://localhost:8000" \
     GUIDELLM_MODEL="neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16" \
     GUIDELLM_RATE_TYPE="sweep" \
     GUIDELLM_DATA="prompt_tokens=256,output_tokens=128" \

--- a/deploy/Containerfile.ubi
+++ b/deploy/Containerfile.ubi
@@ -1,0 +1,54 @@
+ARG PYTHON=312
+
+# Use a multi-stage build to create a lightweight production image
+
+FROM registry.access.redhat.com/ubi9/python-${PYTHON}-minimal as builder
+
+USER root
+
+# Copy repository files
+COPY / /opt/app-root/src
+
+# Create a venv and install guidellm
+RUN python3 -m venv /opt/app-root/guidellm \
+    && /opt/app-root/guidellm/bin/pip install --no-cache-dir /opt/app-root/src
+
+# Copy entrypoint script into the venv bin directory
+RUN install -m0755 /opt/app-root/src/deploy/entrypoint.sh /opt/app-root/guidellm/bin/entrypoint.sh
+
+# Prod image
+FROM registry.access.redhat.com/ubi9/python-${PYTHON}-minimal
+
+USER root
+
+# Copy the virtual environment from the builder stage
+COPY --from=builder /opt/app-root/guidellm /opt/app-root/guidellm
+
+# Add guidellm bin to PATH
+ENV PATH="/opt/app-root/guidellm/bin:$PATH"
+
+# Create a non-root user
+RUN useradd -md /results guidellm
+
+# Switch to non-root user
+USER guidellm
+
+# Set working directory
+WORKDIR /results
+
+# Metadata
+LABEL org.opencontainers.image.source="https://github.com/neuralmagic/guidellm" \
+      org.opencontainers.image.description="GuideLLM Performance Benchmarking Container"
+
+# Set the environment variable for the benchmark script
+# TODO: Replace with scenario environment variables
+ENV GUIDELLM_BIN="/opt/app-root/guidellm/bin/guidellm" \
+    GUIDELLM_TARGET="http://localhost:8000" \
+    GUIDELLM_MODEL="neuralmagic/Meta-Llama-3.1-8B-Instruct-quantized.w4a16" \
+    GUIDELLM_RATE_TYPE="sweep" \
+    GUIDELLM_DATA="prompt_tokens=256,output_tokens=128" \
+    GUIDELLM_MAX_REQUESTS="100" \
+    GUIDELLM_MAX_SECONDS="" \
+    GUIDELLM_OUTPUT_PATH="/results/results.json"
+
+ENTRYPOINT [ "/opt/app-root/guidellm/bin/entrypoint.sh" ]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Path to the guidellm binary
-guidellm_bin="/opt/guidellm/bin/guidellm"
+# guidellm executable with default
+guidellm_bin="${GUIDELLM_BIN:-/opt/guidellm/bin/guidellm}"
 
 # If we receive any arguments switch to guidellm command
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
This PR adds a new UBI based containerfile as an alternative to the current docker python container.

UBI generally recommends utilizing `/opt/app-root` as the default location for installing/configuring end user application software so this PR also makes the entrypoint.sh able to utilize a GUIDELLM_BIN environment variable to allow the correct bin location to be defined in the container.