### PR TITLE
Fix logging documentation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -272,18 +272,14 @@ Reference [https://www.npmjs.com/package/jest-runner-groups](jest-runner-groups)
 Logging is useful for learning how GuideLLM works and finding problems.
 
 Logging is set using the following environment variables:
-- `GUIDELLM__LOGGING__DISABLED`: Disable logging (default: false).
-- `GUIDELLM__LOGGING__CLEAR_LOGGERS`: Clear existing loggers
-    from loguru (default: true).
-- `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL`: Log level for console logging
-    (default: none, options: DEBUG, INFO, WARNING, ERROR, CRITICAL).
-- `GUIDELLM__LOGGING__LOG_FILE`: Path to the log file for file logging
-    (default: guidellm.log if log file level set else none)
-- `GUIDELLM__LOGGING__LOG_FILE_LEVEL`: Log level for file logging
-    (default: INFO if log file set else none).
 
-If logging isn't responding to the environment variables, run the `guidellm config`
-command to validate that the environment variables match and are being set correctly.
+- `GUIDELLM__LOGGING__DISABLED`: Disable logging (default: false).
+- `GUIDELLM__LOGGING__CLEAR_LOGGERS`: Clear existing loggers from loguru (default: true).
+- `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL`: Log level for console logging (default: none, options: DEBUG, INFO, WARNING, ERROR, CRITICAL).
+- `GUIDELLM__LOGGING__LOG_FILE`: Path to the log file for file logging (default: guidellm.log if log file level set else none)
+- `GUIDELLM__LOGGING__LOG_FILE_LEVEL`: Log level for file logging (default: INFO if log file set else none).
+
+If logging isn't responding to the environment variables, run the `guidellm config` command to validate that the environment variables match and are being set correctly.
 
 ## Additional Resources
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -267,6 +267,24 @@ Reference [https://www.npmjs.com/package/jest-runner-groups](jest-runner-groups)
  */
 ```
 
+### Logging
+
+Logging is useful for learning how GuideLLM works and finding problems.
+
+Logging is set using the following environment variables:
+- `GUIDELLM__LOGGING__DISABLED`: Disable logging (default: false).
+- `GUIDELLM__LOGGING__CLEAR_LOGGERS`: Clear existing loggers
+    from loguru (default: true).
+- `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL`: Log level for console logging
+    (default: none, options: DEBUG, INFO, WARNING, ERROR, CRITICAL).
+- `GUIDELLM__LOGGING__LOG_FILE`: Path to the log file for file logging
+    (default: guidellm.log if log file level set else none)
+- `GUIDELLM__LOGGING__LOG_FILE_LEVEL`: Log level for file logging
+    (default: INFO if log file set else none).
+
+If logging isn't responding to the environment variables, run the `guidellm config`
+command to validate that the environment variables match and are being set correctly.
+
 ## Additional Resources
 
 - [CONTRIBUTING.md](https://github.com/neuralmagic/guidellm/blob/main/CONTRIBUTING.md): Guidelines for contributing to the project.

--- a/src/guidellm/logger.py
+++ b/src/guidellm/logger.py
@@ -9,12 +9,15 @@ Environment Variables:
     - GUIDELLM__LOGGING__DISABLED: Disable logging (default: false).
     - GUIDELLM__LOGGING__CLEAR_LOGGERS: Clear existing loggers
         from loguru (default: true).
-    - GUIDELLM__LOGGING__LOG_LEVEL: Log level for console logging
+    - GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL: Log level for console logging
         (default: none, options: DEBUG, INFO, WARNING, ERROR, CRITICAL).
-    - GUIDELLM__LOGGING__FILE: Path to the log file for file logging
+    - GUIDELLM__LOGGING__LOG_FILE: Path to the log file for file logging
         (default: guidellm.log if log file level set else none)
-    - GUIDELLM__LOGGING__FILE_LEVEL: Log level for file logging
+    - GUIDELLM__LOGGING__LOG_FILE_LEVEL: Log level for file logging
         (default: INFO if log file set else none).
+
+If logging isn't responding to the environment variables, run the `guidellm config`
+command to validate that the environment variables match and are being set correctly.
 
 Usage:
     from guidellm import logger, configure_logger, LoggerConfig


### PR DESCRIPTION
The logging documentation is buried in a code file, and it's wrong, so this PR corrects that.