### PR TITLE
Lock pydantic to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "numpy",
     "pillow",
     "protobuf",
-    "pydantic>=2.0.0",
+    "pydantic>=2.11.7",
     "pydantic-settings>=2.0.0",
     "pyyaml>=6.0.0",
     "rich",


### PR DESCRIPTION
Based on #221, there are pydantic bugs that affect the use of GuideLLM.

This PR sets PyDantic to the latest major and patch version because that is the version that is least likely to cause problems for users. If there is a specific reason to use a lower version, more time would need to be spent testing old versions and figuring out what version fixed the problem demonstrated in #221 

Closes #221