### PR TITLE
Automatically resolve pylock if check fails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   hooks:
     - id: pdm-lock-check
       name: check lock file matches pyproject
+      entry: sh -c "pdm lock -v --check || pdm lock --update-reuse"
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.7
   hooks:


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
Currently if the package requirements change in `pyproject.toml` the pylock pre-commit hook will fail and require the user to manually apply a pylock update. This change automates the pylock update so the user should only need to add and commit the updated pylock.

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- Update pylock pre-commit hook to attempt to update the pylock file when `pdm lock --check` fails.

## Test Plan

<!--
List the steps needed to test this PR.
-->
1. Adjust package dependencies in `pyproject.toml`
2. Run `pdm run pre-commit run pdm-lock-check --all-files` and validate that the pylock changed
4. Run `pdm run pre-commit run pdm-lock-check --all-files` and validate that the check passes

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
