### PR TITLE
feat(data): Default synthetic samples to max_requests

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -89,6 +89,7 @@ async def benchmark_generative_text(
             else "infinite"  # default to infinite so we don't run out of data
         ),
         random_seed=random_seed,
+        max_requests=max_requests,
     )
     unique_requests = request_loader.num_unique_items(raise_err=False)
     console.print_line(

--- a/src/guidellm/dataset/creator.py
+++ b/src/guidellm/dataset/creator.py
@@ -85,6 +85,7 @@ class DatasetCreator(ABC):
         processor_args: Optional[dict[str, Any]],
         random_seed: int = 42,
         split_pref_order: Optional[list[str]] = None,
+        max_requests: Optional[int] = None,
     ) -> tuple[Union[Dataset, IterableDataset], dict[ColumnInputTypes, str]]:
         if not cls.is_supported(data, data_args):
             raise ValueError(f"Unsupported data type: {type(data)} given for {data}. ")
@@ -92,7 +93,7 @@ class DatasetCreator(ABC):
         split = cls.extract_args_split(data_args)
         column_mappings = cls.extract_args_column_mappings(data_args)
         dataset = cls.handle_create(
-            data, data_args, processor, processor_args, random_seed
+            data, data_args, processor, processor_args, random_seed, max_requests
         )
 
         if isinstance(dataset, (DatasetDict, IterableDatasetDict)):
@@ -210,4 +211,5 @@ class DatasetCreator(ABC):
         processor: Optional[Union[str, Path, PreTrainedTokenizerBase]],
         processor_args: Optional[dict[str, Any]],
         random_seed: int,
+        max_requests: Optional[int] = None,
     ) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]: ...

--- a/src/guidellm/dataset/entrypoints.py
+++ b/src/guidellm/dataset/entrypoints.py
@@ -20,6 +20,7 @@ def load_dataset(
     processor_args: Optional[dict[str, Any]],
     random_seed: int = 42,
     split_pref_order: Optional[list[str]] = None,
+    max_requests: Optional[int] = None,
 ) -> tuple[Union[Dataset, IterableDataset], dict[ColumnInputTypes, str]]:
     creators = [
         InMemoryDatasetCreator,
@@ -37,6 +38,7 @@ def load_dataset(
                 processor_args,
                 random_seed,
                 split_pref_order,
+                max_requests,
             )
 
     raise ValueError(f"Unsupported data type: {type(data)} given for {data}. ")

--- a/src/guidellm/dataset/file.py
+++ b/src/guidellm/dataset/file.py
@@ -45,6 +45,7 @@ class FileDatasetCreator(DatasetCreator):
         processor: Optional[Union[str, Path, PreTrainedTokenizerBase]],  # noqa: ARG003
         processor_args: Optional[dict[str, Any]],  # noqa: ARG003
         random_seed: int,  # noqa: ARG003
+        max_requests: Optional[int] = None,  # noqa: ARG003
     ) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]:
         if not isinstance(data, (str, Path)):
             raise ValueError(f"Unsupported data type: {type(data)} given for {data}. ")

--- a/src/guidellm/dataset/hf_datasets.py
+++ b/src/guidellm/dataset/hf_datasets.py
@@ -46,6 +46,7 @@ class HFDatasetsCreator(DatasetCreator):
         processor: Optional[Union[str, Path, PreTrainedTokenizerBase]],  # noqa: ARG003
         processor_args: Optional[dict[str, Any]],  # noqa: ARG003
         random_seed: int,  # noqa: ARG003
+        max_requests: Optional[int] = None,  # noqa: ARG003
     ) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]:
         if isinstance(data, (str, Path)):
             data = load_dataset(data, **(data_args or {}))

--- a/src/guidellm/dataset/in_memory.py
+++ b/src/guidellm/dataset/in_memory.py
@@ -28,6 +28,7 @@ class InMemoryDatasetCreator(DatasetCreator):
         processor: Optional[Union[str, Path, PreTrainedTokenizerBase]],  # noqa: ARG003
         processor_args: Optional[dict[str, Any]],  # noqa: ARG003
         random_seed: int,  # noqa: ARG003
+        max_requests: Optional[int] = None,  # noqa: ARG003
     ) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]:
         if not isinstance(data, Iterable):
             raise TypeError(

--- a/src/guidellm/dataset/synthetic.py
+++ b/src/guidellm/dataset/synthetic.py
@@ -252,6 +252,7 @@ class SyntheticDatasetCreator(DatasetCreator):
         processor: Optional[Union[str, Path, PreTrainedTokenizerBase]],
         processor_args: Optional[dict[str, Any]],
         random_seed: int,
+        max_requests: Optional[int] = None,
     ) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]:
         processor = check_load_processor(
             processor,
@@ -262,6 +263,8 @@ class SyntheticDatasetCreator(DatasetCreator):
         )
 
         config = SyntheticDatasetConfig.parse_str(data)
+        if "samples=" not in str(data) and max_requests is not None:
+            config.samples = max_requests
         generator = SyntheticTextItemsGenerator(config, processor, random_seed)
         items = list(generator)
 

--- a/src/guidellm/request/loader.py
+++ b/src/guidellm/request/loader.py
@@ -84,6 +84,7 @@ class GenerativeRequestLoader(RequestLoader):
         shuffle: bool = True,
         iter_type: Literal["finite", "infinite"] = "finite",
         random_seed: int = 42,
+        max_requests: Optional[int] = None,
     ):
         self.data = data
         self.data_args = data_args
@@ -93,6 +94,7 @@ class GenerativeRequestLoader(RequestLoader):
             processor,
             processor_args,
             random_seed,
+            max_requests=max_requests,
         )
         self.dataset = dataset
         self.processor = processor


### PR DESCRIPTION
## Summary

Pass `max_requests` to synthetic dataset creation so a request limit can replace the default of 1,000 generated samples. For example, the configuration below generates 50 samples for a 50-request benchmark.

## Details

The implementation preserves a sample count expressed with `samples=` and falls back to the existing default when `max_requests` is absent. It detects the explicit setting by searching `str(data)` for `samples=`. This does **not** preserve an explicit JSON setting such as `"samples": 5`: that value is overwritten when `max_requests` is set. This remains a limitation of the submitted implementation.

## Test Plan

The original PR describes this before/after check:

```bash
guidellm benchmark run --max-requests 50 --data='{"prompt_tokens":100, "output_tokens":100}'
```

Expected loader count: 1,000 before the change and 50 afterward. This description update did not rerun the historical benchmark or measure startup time.

## Related Issues

Refs #319.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)

<!-- begin:squash-data -->

---

# git log

commit 4afa1cf9da242a7becc471a913a2cb4a550f3f0c
Author: xinjun.jiang <xinjun.jiang@daocloud.io>
Date:   Fri Sep 12 14:09:26 2025 +0800

    feat(data): Default synthetic samples to max_requests
    
    Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>

---------

Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>
