### PR TITLE
fix(backend): Prevent redundant backend validation in worker processes

### DIFF
--- a/src/guidellm/backend/backend.py
+++ b/src/guidellm/backend/backend.py
@@ -79,6 +79,7 @@ class Backend(ABC):
 
     def __init__(self, type_: BackendType):
         self._type = type_
+        self._validated = False
 
     @property
     def type_(self) -> BackendType:
@@ -124,6 +125,8 @@ class Backend(ABC):
         Handle final setup and validate the backend is ready for use.
         If not successful, raises the appropriate exception.
         """
+        if self._validated:
+            return
         logger.info("{} validating backend {}", self.__class__.__name__, self.type_)
         await self.check_setup()
         models = await self.available_models()
@@ -146,6 +149,7 @@ class Backend(ABC):
                 pass
 
         await self.reset()
+        self._validated = True
 
     @abstractmethod
     async def check_setup(self):


### PR DESCRIPTION
## Summary

Make `Backend.validate()` return early after successful validation. This avoids repeating setup checks and connection-test requests when a validated backend is copied into benchmark workers.

## Details

Initialize `_validated` to `False` and set it to `True` after validation and reset complete successfully. Subsequent calls on that backend skip validation; a call that raises before completion leaves the flag unset.

## Test Plan

The original PR reports a concurrent benchmark with Qwen3-0.6B, rate 5, five requests, and 16 prompt/output tokens. Its logs show five repeated worker validation messages before the change and one validation message after the change.

```bash
guidellm benchmark \
  --target "http://10.64.24.34:8000" \
  --processor "Qwen/Qwen3-0.6B" \
  --rate-type=concurrent --rate=5 --max-requests 5 \
  --data='{"prompt_tokens":16, "output_tokens":16}'
```

These are the original PR's reported results; the historical endpoint was not rerun for this description update.

## Related Issues

Refs #322.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)

<!-- begin:squash-data -->

---

# git log

commit 70c904c188a3e24779d6b84495e5d377a3efd70f
Author: xinjun.jiang <xinjun.jiang@daocloud.io>
Date:   Fri Sep 12 15:53:49 2025 +0800

    fix(backend): Prevent redundant backend validation in worker processes
    
    When running a concurrent benchmark, each worker process currently re-validates the backend instance. This leads to multiple, unnecessary "Test connection" requests being sent to the target endpoint, adding startup latency and log verbosity.
    
    Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>

---------

Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>
