### PR TITLE
chore/default-to-chat-completions

### DIFF
--- a/src/guidellm/config.py
+++ b/src/guidellm/config.py
@@ -151,7 +151,7 @@ class Settings(BaseSettings):
     ] = "response"
     preferred_backend: Literal["openai"] = "openai"
     preferred_route: Literal["text_completions", "chat_completions"] = (
-        "text_completions"
+        "chat_completions"
     )
     openai: OpenAISettings = OpenAISettings()
 


### PR DESCRIPTION
## Summary

Change the default preferred route from `text_completions` to `chat_completions`, targeting `/v1/chat/completions` by default.

## Details

Services that only support `/v1/completions` must explicitly set `GUIDELLM__PREFERRED_ROUTE="text_completions"`. The configuration override remains available, but the default routing behavior changes.

## Test Plan

The original PR reports manual verification of both configurations:

1. Without the environment override, benchmark logs show requests to `/v1/chat/completions`.
2. With `GUIDELLM__PREFERRED_ROUTE="text_completions"`, requests use `/v1/completions`.

Those historical checks were not rerun for this description update.

## Related Issues

Refs #324.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)

<!-- begin:squash-data -->

---

# git log

commit 63eaa7e21a5f9f7c2c6c2c9ce8d8366d2794a2cd
Author: xinjun.jiang <xinjun.jiang@daocloud.io>
Date:   Fri Sep 12 18:35:11 2025 +0800

    chore/default-to-chat-completions
    
    Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>

---------

Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>
