### PR TITLE
[GuideLLM Refactor] Fix from-file

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -497,7 +497,7 @@ def from_file(path, output_path):
     to different output formats. Supports JSON, YAML, and CSV export formats
     based on the output file extension.
     """
-    reimport_benchmarks_report(path, output_path)
+    asyncio.run(reimport_benchmarks_report(path, output_path))
 
 
 @cli.command(

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -473,23 +473,30 @@ def run(
 )
 @click.option(
     "--output-path",
-    type=click.Path(file_okay=True, dir_okay=True, exists=False),
-    default=None,
-    is_flag=False,
-    flag_value=Path.cwd() / "benchmarks_reexported.json",
+    type=click.Path(),
+    default=Path.cwd(),
     help=(
-        "Allows re-exporting the benchmarks to another format. "
-        "The path to save the output to. If it is a directory, "
-        "it will save benchmarks.json under it. "
-        "Otherwise, json, yaml, or csv files are supported for output types "
-        "which will be read from the extension for the file path. "
-        "This input is optional. If the output path flag is not provided, "
-        "the benchmarks will not be reexported. If the flag is present but "
-        "no value is specified, it will default to the current directory "
-        "with the file name `benchmarks_reexported.json`."
+        "Allows re-exporting the benchmarks to other formats. "
+        "The path to save the output formats to, if the format is a file type. "
+        "If it is a directory, it will save all output formats selected under it. "
+        "If it is a file, it will save the corresponding output format to that file. "
+        "Any output formats that were given that do not match the file extension will "
+        "be saved in the parent directory of the file path. "
+        "Defaults to the current working directory. "
     ),
 )
-def from_file(path, output_path):
+@click.option(
+    "--output-formats",
+    multiple=True,
+    type=str,
+    default=("console", "json"),  # ("console", "json", "html", "csv")
+    help=(
+        "The output formats to use for the benchmark results. "
+        "Defaults to console, json, html, and csv where the file formats "
+        "will be saved at the specified output path."
+    ),
+)
+def from_file(path, output_path, output_formats):
     """
     Load and optionally re-export a previously saved benchmark report.
 
@@ -497,7 +504,7 @@ def from_file(path, output_path):
     to different output formats. Supports JSON, YAML, and CSV export formats
     based on the output file extension.
     """
-    asyncio.run(reimport_benchmarks_report(path, output_path))
+    asyncio.run(reimport_benchmarks_report(path, output_path, output_formats))
 
 
 @cli.command(

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -26,7 +26,6 @@ from guidellm.benchmark.aggregator import (
 from guidellm.benchmark.benchmarker import Benchmarker
 from guidellm.benchmark.objects import GenerativeBenchmark, GenerativeBenchmarksReport
 from guidellm.benchmark.output import (
-    GenerativeBenchmarkerConsole,
     GenerativeBenchmarkerOutput,
 )
 from guidellm.benchmark.profile import Profile, ProfileType
@@ -52,6 +51,9 @@ __all__ = [
 
 _CURRENT_WORKING_DIR = Path.cwd()
 
+
+# Data types
+
 DataType = (
     Iterable[str]
     | Iterable[dict[str, Any]]
@@ -70,6 +72,8 @@ OutputFormatType = (
     | None
 )
 
+
+# Helper functions
 
 async def initialize_backend(
     backend: BackendType | Backend,
@@ -136,6 +140,8 @@ async def finalize_outputs(
         output_format_results[key] = output_result
     return output_format_results
 
+
+# Complete entrypoints
 
 async def benchmark_with_scenario(scenario: Scenario, **kwargs):
     """


### PR DESCRIPTION
## Summary

This PR ports the new functionality from `benchmark run` to `benchmark from-file`, and does so in a way that reuses as much code as practical to have one source of truth.

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- Fixes from-file by making it to use the new output format.
- Moves code related to the new output formats to separate functions that are called from both benchmark entrypoints.
- Moves additional chunks of code out of the large benchmark run entrypoint function for modularity.

## Test Plan

Run a benchmark with an output of json or yaml, and use `from-file` to re-import it and export it. You can select any output type supported by `benchmark run`.

`guidellm benchmark from-file ./result.json --output-formats console`
`guidellm benchmark from-file ./result.yaml --output-formats yaml`

## Related Issues

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
