### PR TITLE
Add priority feature to Registry

### DIFF
--- a/src/guidellm/data/deserializers/deserializer.py
+++ b/src/guidellm/data/deserializers/deserializer.py
@@ -51,9 +51,7 @@ class DatasetDeserializerFactory(
 
         if type_ is None:
             for priority, objects in cls.get_priority_grouped_objects() :
-                print("Deserializing priorities:", priority)
                 for deserializer in objects:
-                    print("Deserializing deserializer:", deserializer.__name__)
                     deserializer_fn: DatasetDeserializer = (
                         deserializer() if isinstance(deserializer, type) else deserializer
                     )

--- a/src/guidellm/data/deserializers/huggingface.py
+++ b/src/guidellm/data/deserializers/huggingface.py
@@ -28,7 +28,7 @@ from guidellm.data.deserializers.deserializer import (
 __all__ = ["HuggingFaceDatasetDeserializer"]
 
 
-@DatasetDeserializerFactory.register("huggingface")
+@DatasetDeserializerFactory.register("huggingface", 3)
 class HuggingFaceDatasetDeserializer(DatasetDeserializer):
     def __call__(
         self,

--- a/src/guidellm/data/deserializers/memory.py
+++ b/src/guidellm/data/deserializers/memory.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 
-@DatasetDeserializerFactory.register("in_memory_dict")
+@DatasetDeserializerFactory.register("in_memory_dict", 2)
 class InMemoryDictDatasetDeserializer(DatasetDeserializer):
     def __call__(
         self,
@@ -127,7 +127,7 @@ class InMemoryItemListDatasetDeserializer(DatasetDeserializer):
         return Dataset.from_dict({column_name: data}, **data_kwargs)
 
 
-@DatasetDeserializerFactory.register("in_memory_json_str")
+@DatasetDeserializerFactory.register("in_memory_json_str", 2)
 class InMemoryJsonStrDatasetDeserializer(DatasetDeserializer):
     def __call__(
         self,

--- a/src/guidellm/scheduler/constraints.py
+++ b/src/guidellm/scheduler/constraints.py
@@ -146,7 +146,7 @@ class ConstraintsInitializerFactory(RegistryMixin[ConstraintInitializer]):
         if cls.registry is None or key not in cls.registry:
             raise ValueError(f"Unknown constraint initializer key: {key}")
 
-        initializer_class = cls.registry[key]
+        initializer_class = cls.get_registered_object(key)
 
         return (
             initializer_class(*args, **kwargs)  # type: ignore[operator]

--- a/src/guidellm/utils/pydantic_utils.py
+++ b/src/guidellm/utils/pydantic_utils.py
@@ -287,7 +287,7 @@ class PydanticClassRegistryMixin(
 
     @classmethod
     def register_decorator(
-        cls, clazz: RegisterClassT, name: str | list[str] | None = None
+        cls, clazz: RegisterClassT, name: str | list[str] | None = None, priority: int = 1,
     ) -> RegisterClassT:
         """
         Register a Pydantic model class with type validation and schema reload.
@@ -298,6 +298,7 @@ class PydanticClassRegistryMixin(
 
         :param clazz: Pydantic model class to register in the polymorphic hierarchy
         :param name: Registry identifier for the class. Uses class name if None
+        :param priority: The priority bucket to register the class in.
         :return: The registered class unchanged for decorator chaining
         :raises TypeError: If clazz is not a Pydantic BaseModel subclass
         """
@@ -307,7 +308,7 @@ class PydanticClassRegistryMixin(
                 "Pydantic BaseModel"
             )
 
-        super().register_decorator(clazz, name=name)
+        super().register_decorator(clazz, name=name, priority=priority)
         cls.reload_schema()
 
         return cast("RegisterClassT", clazz)
@@ -332,7 +333,7 @@ class PydanticClassRegistryMixin(
                 return cls.__pydantic_generate_base_schema__(handler)
 
             choices = {
-                name: handler(model_class) for name, model_class in cls.registry.items()
+                name: handler(model_class) for name, model_class in cls.get_registered_entries()
             }
 
             return core_schema.tagged_union_schema(
@@ -408,4 +409,4 @@ class PydanticClassRegistryMixin(
                 "registering classes with ClassRegistryMixin.register()."
             )
 
-        return tuple(cls.registry.values())
+        return tuple(cls.get_registered_objects())

--- a/tests/unit/utils/test_pydantic_utils.py
+++ b/tests/unit/utils/test_pydantic_utils.py
@@ -25,6 +25,7 @@ from guidellm.utils.pydantic_utils import (
     SuccessfulT,
     TotalT,
 )
+from guidellm.utils.registry import RegistryEntry
 
 
 @pytest.mark.smoke
@@ -608,7 +609,7 @@ class TestPydanticClassRegistryMixin:
 
         assert TestBaseModel.registry is not None  # type: ignore[misc]
         assert "TestSubModel" in TestBaseModel.registry  # type: ignore[misc]
-        assert TestBaseModel.registry["TestSubModel"] is TestSubModel  # type: ignore[misc]
+        assert TestBaseModel.registry["TestSubModel"].object is TestSubModel  # type: ignore[misc]
 
     @pytest.mark.sanity
     def test_register_decorator_with_name(self):
@@ -631,7 +632,7 @@ class TestPydanticClassRegistryMixin:
 
         assert TestBaseModel.registry is not None  # type: ignore[misc]
         assert "custom_name" in TestBaseModel.registry  # type: ignore[misc]
-        assert TestBaseModel.registry["custom_name"] is TestSubModel  # type: ignore[misc]
+        assert TestBaseModel.registry["custom_name"].object is TestSubModel  # type: ignore[misc]
 
     @pytest.mark.sanity
     def test_register_decorator_invalid_type(self):
@@ -732,7 +733,7 @@ class TestPydanticClassRegistryMixin:
             TestBaseModel, "auto_populate_registry"
         ) as mock_auto_populate:
             # Mock the registry to simulate registered classes
-            TestBaseModel.registry = {"test_class": type("TestClass", (), {})}
+            TestBaseModel.registry = {"test_class": RegistryEntry(type("TestClass", (), {}), priority=1)}
             mock_auto_populate.return_value = False
 
             registered = TestBaseModel.registered_classes()
@@ -995,8 +996,7 @@ class TestPydanticClassRegistryMixin:
         assert DocumentedModel.__qualname__.endswith("DocumentedModel")
 
         # Verify that the class is still properly integrated with the registry system
-        all_registered = TestBaseModel.registered_classes()
-        assert DocumentedModel in all_registered
+        assert TestBaseModel.is_registered("documented_model")
 
         # Test that the registered class is the same as the original
         assert registered_class is DocumentedModel

--- a/tests/unit/utils/test_registry.py
+++ b/tests/unit/utils/test_registry.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 from guidellm.utils import RegistryMixin
-from guidellm.utils.registry import RegisterT, RegistryObjT
+from guidellm.utils.registry import RegisterT, RegistryObjT, RegistryEntry
 
 
 def test_registry_obj_type():
@@ -106,10 +106,10 @@ class TestRegistryMixin:
         if isinstance(expected_key, list):
             for key in expected_key:
                 assert key in registry_class.registry
-                assert registry_class.registry[key] is TestClass
+                assert registry_class.registry[key].object is TestClass
         else:
             assert expected_key in registry_class.registry
-            assert registry_class.registry[expected_key] is TestClass
+            assert registry_class.registry[expected_key].object is TestClass
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -154,10 +154,10 @@ class TestRegistryMixin:
         if isinstance(expected_key, list):
             for key in expected_key:
                 assert key in registry_class.registry
-                assert registry_class.registry[key] is TestClass
+                assert registry_class.registry[key].object is TestClass
         else:
             assert expected_key in registry_class.registry
-            assert registry_class.registry[expected_key] is TestClass
+            assert registry_class.registry[expected_key].object is TestClass
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -350,7 +350,7 @@ class TestRegistryMixin:
         with mock.patch.object(
             TestAutoRegistry, "auto_populate_registry"
         ) as mock_populate:
-            TestAutoRegistry.registry = {"class1": "obj1", "class2": "obj2"}
+            TestAutoRegistry.registry = {"class1": RegistryEntry("obj1", 1), "class2": RegistryEntry("obj2", 1)}
             objects = TestAutoRegistry.registered_objects()
             mock_populate.assert_called_once()
             assert objects == ("obj1", "obj2")
@@ -414,9 +414,10 @@ class TestRegistryMixin:
         class TestClass:
             pass
 
-        registry_class.register_decorator(TestClass, name="")
+        registry_class.register_decorator(TestClass, name="", priority=2)
         assert "" in registry_class.registry
-        assert registry_class.registry[""] is TestClass
+        assert registry_class.registry[""].object is TestClass
+        assert registry_class.registry[""].priority == 2
 
     @pytest.mark.sanity
     def test_register_decorator_none_in_list(self, valid_instances):


### PR DESCRIPTION
## Summary

This feature is designed for use cases like deserialize, where we need to use some objects before others.

As a side effect of these changes, I lowered the code's reliance on class variables, and instead on functions which can provide a more stable API.

There are multiple ways of implementing a priority system, and I'm open to feedback if this is not the direction we want to go in.

Fixes an issue where JSON inputs would fail at the `InMemoryJsonStrDatasetDeserializer`. With this new design that deserializer has a priority of 2, so that the other deserializers run first.
This change also allows us to remove the huggingface special case in the code, and instead set it as priority 3.

## Details

- Adds a priority field to the registration of object
- Added functions to retrieve objects from the registry
- Added function to retrieve sorted groups of objects by priority.
- Adds relevant tests

## Test Plan

To test that this addresses the original concern, run GuideLLM with all types of data to ensure the proper priorities are set on the objects.

The tests were updated to reflect these changes.


---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
