### PR TITLE
cpu - sweep saturation detection

### DIFF
--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -172,11 +172,11 @@ The sweep profile includes advanced configuration options for optimizing benchma
 
 **Available Parameters:**
 
-| Parameter                       | Description                                           | Default | Environment Variable                     |
-| ------------------------------- | ----------------------------------------------------- | ------- | ---------------------------------------- |
-| `--exclude-throughput-target`   | Stop constant-rate tests before throughput level      | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_TARGET`    |
-| `--exclude-throughput-result`   | Exclude throughput benchmark from saved results       | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_RESULT`    |
-| `--saturation-threshold`        | Efficiency threshold for stopping sweep (0.0-1.0)     | `0.98`  | `GUIDELLM__SATURATION_THRESHOLD`         |
+| Parameter                     | Description                                       | Default | Environment Variable                  |
+| ----------------------------- | ------------------------------------------------- | ------- | ------------------------------------- |
+| `--exclude-throughput-target` | Stop constant-rate tests before throughput level  | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_TARGET` |
+| `--exclude-throughput-result` | Exclude throughput benchmark from saved results   | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_RESULT` |
+| `--saturation-threshold`      | Efficiency threshold for stopping sweep (0.0-1.0) | `0.98`  | `GUIDELLM__SATURATION_THRESHOLD`      |
 
 **When to Use:**
 
@@ -212,6 +212,7 @@ guidellm benchmark \
 **How It Works:**
 
 The sweep profile runs tests in this order:
+
 1. **Synchronous test**: Measures baseline single-request performance
 2. **Throughput test**: Discovers maximum server capacity with parallel requests
 3. **Constant-rate tests**: Tests at interpolated rates between synchronous and throughput
@@ -219,20 +220,24 @@ The sweep profile runs tests in this order:
 Each parameter optimizes a different aspect:
 
 - **`exclude-throughput-target`**: Prevents generating a constant-rate test at the throughput level itself
+
   - **Why**: The highest constant-rate test would target the same rate as the throughput test, creating redundant "elbow" artifacts in graphs
   - **Effect**: Stops constant-rate tests just before reaching throughput rate
 
 - **`exclude-throughput-result`**: Removes the throughput benchmark from saved results
+
   - **Why**: Throughput tests measure burst capacity with severe queuing (e.g., 23+ second TTFT), creating extreme outliers in graphs
   - **Effect**: Graphs only show sustainable performance metrics from constant-rate tests
 
 - **`saturation-threshold`**: Stops the sweep when efficiency drops below threshold
+
   - **Why**: Once saturation is detected (achieved rate < target rate × threshold), further tests provide diminishing returns
   - **Effect**: Saves time by stopping early when the server can no longer meet target rates
 
 **Why use all three together?**
 
 For CPU deployments, all three parameters work synergistically:
+
 - `saturation-threshold` stops the sweep efficiently when saturation is detected
 - `exclude-throughput-target` prevents testing at the unsustainable throughput rate
 - `exclude-throughput-result` removes the anomalous throughput spike from graphs

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -217,6 +217,10 @@ guidellm benchmark \
 
 These parameters are particularly useful for CPU deployments where saturation occurs at lower rates than burst capacity, creating misleading graph patterns if throughput measurements are included.
 
+**Important Note:**
+
+Do not set `--max-concurrency` or `GUIDELLM__MAX_CONCURRENCY` when running sweep tests. The sweep profile uses the throughput test to discover the server's true capacity, and artificially limiting concurrency will result in an underestimated throughput measurement. This causes the constant-rate tests to run at rates far below the actual server capacity, preventing proper saturation detection and producing misleading results where TTFT may decrease instead of increase.
+
 ## Data Options
 
 ### Synthetic Data Options

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -180,8 +180,8 @@ The sweep profile includes advanced configuration options for optimizing benchma
 
 **When to Use:**
 
-- **CPU Deployments**: Enable `exclude-throughput-target` and `exclude-throughput-result` to prevent anomalous data points in performance graphs (TTFT spikes, inter-token latency anomalies)
-- **GPU Deployments**: Use default settings (all disabled)
+- **CPU based system under test**: Enable `exclude-throughput-target` and `exclude-throughput-result` to prevent anomalous data points in performance graphs (TTFT spikes, inter-token latency anomalies)
+- **GPU based system under test**: Use default settings (all disabled)
 
 **Example for CPU-optimized benchmarking:**
 
@@ -236,7 +236,7 @@ Each parameter optimizes a different aspect:
 
 **Why use all three together?**
 
-For CPU deployments, all three parameters work synergistically:
+For CPU based system under test, all three parameters work synergistically:
 
 - `saturation-threshold` stops the sweep efficiently when saturation is detected
 - `exclude-throughput-target` prevents testing at the unsustainable throughput rate

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -211,11 +211,33 @@ guidellm benchmark \
 
 **How It Works:**
 
-- `exclude-throughput-target`: Prevents generating a constant-rate test at the throughput level, avoiding "elbow" artifacts in graphs
-- `exclude-throughput-result`: Removes the throughput benchmark from saved results, eliminating visual anomalies caused by burst capacity measurements
-- `saturation-threshold`: Automatically stops the sweep when achieved rate falls below this percentage of target rate (e.g., 0.98 = 98%)
+The sweep profile runs tests in this order:
+1. **Synchronous test**: Measures baseline single-request performance
+2. **Throughput test**: Discovers maximum server capacity with parallel requests
+3. **Constant-rate tests**: Tests at interpolated rates between synchronous and throughput
 
-These parameters are particularly useful for CPU deployments where saturation occurs at lower rates than burst capacity, creating misleading graph patterns if throughput measurements are included.
+Each parameter optimizes a different aspect:
+
+- **`exclude-throughput-target`**: Prevents generating a constant-rate test at the throughput level itself
+  - **Why**: The highest constant-rate test would target the same rate as the throughput test, creating redundant "elbow" artifacts in graphs
+  - **Effect**: Stops constant-rate tests just before reaching throughput rate
+
+- **`exclude-throughput-result`**: Removes the throughput benchmark from saved results
+  - **Why**: Throughput tests measure burst capacity with severe queuing (e.g., 23+ second TTFT), creating extreme outliers in graphs
+  - **Effect**: Graphs only show sustainable performance metrics from constant-rate tests
+
+- **`saturation-threshold`**: Stops the sweep when efficiency drops below threshold
+  - **Why**: Once saturation is detected (achieved rate < target rate × threshold), further tests provide diminishing returns
+  - **Effect**: Saves time by stopping early when the server can no longer meet target rates
+
+**Why use all three together?**
+
+For CPU deployments, all three parameters work synergistically:
+- `saturation-threshold` stops the sweep efficiently when saturation is detected
+- `exclude-throughput-target` prevents testing at the unsustainable throughput rate
+- `exclude-throughput-result` removes the anomalous throughput spike from graphs
+
+This combination produces clean, efficient benchmarks that focus on sustainable performance ranges.
 
 **Important Note:**
 

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -166,6 +166,57 @@ guidellm benchmark --profile sweep
 | `--rate`           | Number of strategies to run in the sweep (including synchronous and throughput). | `--rate 10`   |
 | `--rampup`         | Rate rampup duration in seconds for throughput and constant strategy steps.      | `--rampup 10` |
 
+##### Sweep Profile Configuration
+
+The sweep profile includes advanced configuration options for optimizing benchmarks on CPU-based deployments. These parameters help manage saturation detection and prevent graph artifacts:
+
+**Available Parameters:**
+
+| Parameter                       | Description                                           | Default | Environment Variable                     |
+| ------------------------------- | ----------------------------------------------------- | ------- | ---------------------------------------- |
+| `--exclude-throughput-target`   | Stop constant-rate tests before throughput level      | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_TARGET`    |
+| `--exclude-throughput-result`   | Exclude throughput benchmark from saved results       | `false` | `GUIDELLM__EXCLUDE_THROUGHPUT_RESULT`    |
+| `--saturation-threshold`        | Efficiency threshold for stopping sweep (0.0-1.0)     | `0.98`  | `GUIDELLM__SATURATION_THRESHOLD`         |
+
+**When to Use:**
+
+- **CPU Deployments**: Enable `exclude-throughput-target` and `exclude-throughput-result` to prevent anomalous data points in performance graphs (TTFT spikes, inter-token latency anomalies)
+- **GPU Deployments**: Use default settings (all disabled)
+
+**Example for CPU-optimized benchmarking:**
+
+```bash
+guidellm benchmark \
+  --target "http://localhost:8000" \
+  --profile sweep \
+  --exclude-throughput-target true \
+  --exclude-throughput-result true \
+  --saturation-threshold 0.98 \
+  --data "prompt_tokens=256,output_tokens=128" \
+  --max-seconds 300
+```
+
+**Using Environment Variables:**
+
+```bash
+export GUIDELLM__EXCLUDE_THROUGHPUT_TARGET=true
+export GUIDELLM__EXCLUDE_THROUGHPUT_RESULT=true
+export GUIDELLM__SATURATION_THRESHOLD=0.98
+
+guidellm benchmark \
+  --target "http://localhost:8000" \
+  --profile sweep \
+  --data "prompt_tokens=256,output_tokens=128"
+```
+
+**How It Works:**
+
+- `exclude-throughput-target`: Prevents generating a constant-rate test at the throughput level, avoiding "elbow" artifacts in graphs
+- `exclude-throughput-result`: Removes the throughput benchmark from saved results, eliminating visual anomalies caused by burst capacity measurements
+- `saturation-threshold`: Automatically stops the sweep when achieved rate falls below this percentage of target rate (e.g., 0.98 = 98%)
+
+These parameters are particularly useful for CPU deployments where saturation occurs at lower rates than burst capacity, creating misleading graph patterns if throughput measurements are included.
+
 ## Data Options
 
 ### Synthetic Data Options

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -565,7 +565,14 @@ async def benchmark_generative_text(
         prefer_response_metrics=args.prefer_response_metrics,
     ):
         if benchmark:
-            report.benchmarks.append(benchmark)
+            # Check if we should exclude the throughput benchmark
+            should_exclude = (
+                hasattr(profile, "exclude_throughput_result")
+                and profile.exclude_throughput_result
+                and benchmark.config.strategy.type_ == "throughput"
+            )
+            if not should_exclude:
+                report.benchmarks.append(benchmark)
 
     output_format_results = {}
     for key, output in output_formats.items():

--- a/src/guidellm/benchmark/profiles.py
+++ b/src/guidellm/benchmark/profiles.py
@@ -773,9 +773,11 @@ class SweepProfile(Profile):
             prev_strategy
             and prev_strategy.type_ in ["constant", "poisson"]
             and prev_benchmark
+            and hasattr(prev_strategy, "rate")
+            and hasattr(prev_benchmark, "metrics")
         ):
-            target_rate = prev_strategy.rate
-            achieved_rate = prev_benchmark.metrics.requests_per_second.successful.mean
+            target_rate = prev_strategy.rate  # type: ignore[attr-defined]
+            achieved_rate = prev_benchmark.metrics.requests_per_second.successful.mean  # type: ignore[attr-defined]
 
             # If achieved rate is below threshold, system is saturated
             if achieved_rate < (target_rate * self.saturation_threshold):

--- a/src/guidellm/benchmark/profiles.py
+++ b/src/guidellm/benchmark/profiles.py
@@ -610,7 +610,7 @@ class SweepProfile(Profile):
             "Exclude throughput benchmark from saved results. "
             "When True, the throughput benchmark is not saved to the report, "
             "preventing anomalous data points in graphs. "
-            "Recommended for CPU-based deployments when saturation is detected."
+            "Recommended for CPU based system under test when saturation is detected."
         ),
     )
     saturation_threshold: float = Field(
@@ -620,7 +620,7 @@ class SweepProfile(Profile):
         description=(
             "Efficiency threshold for saturation detection (achieved/target rate). "
             "Sweep stops when efficiency drops below this value. "
-            "Default 0.98 (98%) is recommended for CPU deployments. "
+            "Default 0.98 (98%) is recommended for CPU based system under test. "
             "Use 0.95 (95%) for noisier systems, 0.99 (99%) for very stable systems."
         ),
     )

--- a/src/guidellm/benchmark/profiles.py
+++ b/src/guidellm/benchmark/profiles.py
@@ -595,6 +595,35 @@ class SweepProfile(Profile):
         default=42,
         description="Random seed for Poisson distribution strategy",
     )
+    exclude_throughput_target: bool = Field(
+        default=False,
+        description=(
+            "Exclude constant-rate test at throughput level. "
+            "When True, constant-rate tests stop before reaching throughput rate, "
+            "preventing 'elbow' artifacts in performance graphs. "
+            "Recommended for CPU-based deployments."
+        ),
+    )
+    exclude_throughput_result: bool = Field(
+        default=False,
+        description=(
+            "Exclude throughput benchmark from saved results. "
+            "When True, the throughput benchmark is not saved to the report, "
+            "preventing anomalous data points in graphs. "
+            "Recommended for CPU-based deployments when saturation is detected."
+        ),
+    )
+    saturation_threshold: float = Field(
+        default=0.98,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Efficiency threshold for saturation detection (achieved/target rate). "
+            "Sweep stops when efficiency drops below this value. "
+            "Default 0.98 (98%) is recommended for CPU deployments. "
+            "Use 0.95 (95%) for noisier systems, 0.99 (99%) for very stable systems."
+        ),
+    )
     synchronous_rate: float = Field(
         default=-1.0,
         description="Measured rate from synchronous strategy execution",
@@ -634,6 +663,24 @@ class SweepProfile(Profile):
         kwargs["random_seed"] = random_seed
         if rate_type in ["constant", "poisson"]:
             kwargs["strategy_type"] = rate_type
+
+        # Resolve sweep profile parameters from settings if not provided
+        if (
+            "exclude_throughput_target" not in kwargs
+            or kwargs["exclude_throughput_target"] is None
+        ):
+            kwargs["exclude_throughput_target"] = settings.exclude_throughput_target
+        if (
+            "exclude_throughput_result" not in kwargs
+            or kwargs["exclude_throughput_result"] is None
+        ):
+            kwargs["exclude_throughput_result"] = settings.exclude_throughput_result
+        if (
+            "saturation_threshold" not in kwargs
+            or kwargs["saturation_threshold"] is None
+        ):
+            kwargs["saturation_threshold"] = settings.saturation_threshold
+
         return kwargs
 
     @property
@@ -645,7 +692,7 @@ class SweepProfile(Profile):
         types += [self.strategy_type] * (self.sweep_size - len(types))
         return types
 
-    def next_strategy(
+    def next_strategy(  # noqa: C901
         self,
         prev_strategy: SchedulingStrategy | None,
         prev_benchmark: Benchmark | None,
@@ -685,13 +732,55 @@ class SweepProfile(Profile):
                     "Invalid rates in sweep; aborting. "
                     "Were there any successful requests?"
                 )
-            self.measured_rates = list(
-                np.linspace(
-                    self.synchronous_rate,
-                    self.throughput_rate,
-                    self.sweep_size - 1,
-                )
-            )[1:]  # don't rerun synchronous
+
+            # Generate interpolated rates between synchronous and throughput.
+            # The behavior depends on exclude_throughput_target setting:
+            #
+            # When exclude_throughput_target=False (default, GPU mode):
+            #   - Generate (sweep_size - 1) points from sync to throughput
+            #   - Remove sync (already tested), keep throughput-level test
+            #   - Example: sweep_size=10 -> 9 points, remove 1 = 8 async tests
+            #   - Last async test targets throughput_rate
+            #
+            # When exclude_throughput_target=True (CPU mode):
+            #   - Generate (sweep_size) points from sync to throughput
+            #   - Remove sync AND throughput-level test
+            #   - Example: sweep_size=10 -> 10 points, remove 2 = 8 async tests
+            #   - Last async test stops before throughput_rate
+            #   - Prevents "elbow" artifact in graphs
+            if self.exclude_throughput_target:
+                # CPU mode: stop before throughput level
+                self.measured_rates = list(
+                    np.linspace(
+                        self.synchronous_rate,
+                        self.throughput_rate,
+                        self.sweep_size,
+                    )
+                )[1:-1]
+            else:
+                # GPU mode: include throughput level
+                self.measured_rates = list(
+                    np.linspace(
+                        self.synchronous_rate,
+                        self.throughput_rate,
+                        self.sweep_size - 1,
+                    )
+                )[1:]
+
+        # Check for saturation: if the previous constant-rate test couldn't
+        # achieve its target rate, the system has saturated
+        if (
+            prev_strategy
+            and prev_strategy.type_ in ["constant", "poisson"]
+            and prev_benchmark
+        ):
+            target_rate = prev_strategy.rate
+            achieved_rate = prev_benchmark.metrics.requests_per_second.successful.mean
+
+            # If achieved rate is below threshold, system is saturated
+            if achieved_rate < (target_rate * self.saturation_threshold):
+                # System saturated - don't test higher rates
+                return None
 
         next_index = (
             len(self.completed_strategies) - 1 - 1

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -235,6 +235,33 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
         default=None, description="Additional dataloader configuration arguments"
     )
     random_seed: int = Field(default=42, description="Random seed for reproducibility")
+    # Sweep profile configuration
+    exclude_throughput_target: bool | None = Field(
+        default=None,
+        description=(
+            "Exclude constant-rate test at throughput level. "
+            "When True, constant-rate tests stop before reaching throughput rate. "
+            "Recommended for CPU-based deployments."
+        ),
+    )
+    exclude_throughput_result: bool | None = Field(
+        default=None,
+        description=(
+            "Exclude throughput benchmark from saved results. "
+            "When True, throughput benchmark is not saved to the report. "
+            "Recommended for CPU-based deployments when saturation is detected."
+        ),
+    )
+    saturation_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Efficiency threshold for saturation detection (achieved/target rate). "
+            "Sweep stops when efficiency drops below this value. "
+            "Default 0.98 (98%) is recommended for CPU deployments."
+        ),
+    )
     # Output configuration
     outputs: list[str] | tuple[str] = Field(
         default_factory=lambda: ["json", "csv"],

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -259,7 +259,7 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
         description=(
             "Efficiency threshold for saturation detection (achieved/target rate). "
             "Sweep stops when efficiency drops below this value. "
-            "Default 0.98 (98%) is recommended for CPU deployments."
+            "Default 0.98 (98%) is recommended for CPU based system under test."
         ),
     )
     # Output configuration

--- a/src/guidellm/data/builders.py
+++ b/src/guidellm/data/builders.py
@@ -320,13 +320,10 @@ def _extract_column_names(
     except (KeyError, IndexError):
         prefix_column = None
 
-    try:
-        output_mappings = column_mapper.datasets_column_mappings[
-            ("output_tokens_count_column", 0)
-        ]
-        output_column = output_mappings[0][1]
-    except (KeyError, IndexError):
-        output_column = "output_tokens_count"
+    output_mappings = column_mapper.datasets_column_mappings.get(
+        ("output_tokens_count_column", 0), []
+    )
+    output_column = output_mappings[0][1] if output_mappings else "output_tokens_count"
 
     return prompt_column, prefix_column, output_column
 

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -105,6 +105,11 @@ class Settings(BaseSettings):
     constraint_error_window_size: float = 30
     constraint_error_min_processed: float = 30
 
+    # Sweep profile settings
+    exclude_throughput_target: bool = False
+    exclude_throughput_result: bool = False
+    saturation_threshold: float = 0.98
+
     # Data settings
     dataset: DatasetSettings = DatasetSettings()
 


### PR DESCRIPTION
## Summary

This PR adds configurable saturation detection and optimisation parameters for testing CPU-based deployments/SUTs (vllm-cpu) with the sweep profile. CPU deployments saturate at much lower concurrency rates than GPU deployments (e.g., 16 concurrent requests vs 512), causing sweep tests to continue measuring beyond saturation and producing misleading "knee bend" artifacts in performance graphs. The new parameters allow users to detect saturation early, stop tests efficiently, and exclude anomalous throughput measurements from results.

## Details

- Added three new configurable parameters to SweepProfile:
  - exclude_throughput_target (default: false) - Stops constant-rate tests before reaching throughput level
  - exclude_throughput_result (default: false) - Excludes throughput benchmark from saved results
  - saturation_threshold (default: 0.98) - Efficiency threshold for detecting saturation (achieved/target rate)
- Implemented saturation detection logic in SweepProfile.next_strategy() that stops sweep when efficiency drops below threshold
- Added parameter propagation through:
  - Settings class for environment variable configuration (GUIDELLM__*)
  - CLI parameters in GenerativeBenchmarkEntrypoint
  - Profile resolution in SweepProfile.resolve_args()
- Modified rate interpolation logic to support both GPU mode (include throughput target) and CPU mode (exclude throughput target)
- Added comprehensive documentation in docs/getting-started/benchmark.md

## Test Plan

Verified with vLLM-CPU deployment
**Test saturation detection works correctly:**

```bash
guidellm benchmark \
  --target "http://localhost:8000" \
  --profile sweep \
  --exclude-throughput-target true \
  --exclude-throughput-result true \
  --saturation-threshold 0.98 \
  --data "prompt_tokens=256,output_tokens=128" \
  --max-seconds 180
```

- ✅ Sweep stopped at test #5 when efficiency dropped to 97% (below 98% threshold)
- ✅ TTFT increased correctly: 67.65 → 69.34 → 70.82 → 73.49 → 80.53ms
- ✅ Throughput benchmark excluded from saved results
- ✅ No anomalous data points in graphs


** Test that defaults work for GPU deployments**

```bash
guidellm benchmark \
  --target "http://localhost:8000" \
  --profile sweep \
  --data "prompt_tokens=256,output_tokens=128"
```

- ✅ All parameters default to false/0.98 (GPU-friendly behavior)
- ✅ Full sweep completes with throughput benchmark included

** Verify environment variable configuration **

```bash
export GUIDELLM__EXCLUDE_THROUGHPUT_TARGET=true
export GUIDELLM__EXCLUDE_THROUGHPUT_RESULT=true
export GUIDELLM__SATURATION_THRESHOLD=0.98

guidellm benchmark --target "http://localhost:8000" --profile sweep
```

- ✅ Parameters correctly inherited from environment variables


** Run unit tests**

```bash
pytest tests/unit/data/test_builders.py tests/unit/test_settings.py -v
```

- ✅ All 54 tests passed

**Run pre-commit checks**

```bash
pre-commit run --all-files
```

- ✅ All checks passed (linter, formatter, whitespace, EOF)


## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
