### PR TITLE
Replace various key=value string parsers with a single utility

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -143,6 +143,7 @@ def benchmark():
     "--backend-kwargs",
     "--backend-args",  # legacy alias
     "backend_kwargs",
+    callback=cli_tools.parse_arguments,
     default=BenchmarkGenerativeTextArgs.get_default("backend_kwargs"),
     help=(
         "JSON string of arguments to pass to the backend. E.g., "
@@ -180,12 +181,14 @@ def benchmark():
 @click.option(
     "--processor-args",
     default=BenchmarkGenerativeTextArgs.get_default("processor_args"),
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to the processor constructor.",
 )
 @click.option(
     "--data-args",
     multiple=True,
     default=BenchmarkGenerativeTextArgs.get_default("data_args"),
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to dataset creation.",
 )
 @click.option(
@@ -200,6 +203,7 @@ def benchmark():
 @click.option(
     "--data-column-mapper",
     default=BenchmarkGenerativeTextArgs.get_default("data_column_mapper"),
+    callback=cli_tools.parse_arguments,
     help=(
         "JSON string of column mappings to apply to the dataset. "
         'E.g., \'{"column_mappings": {"text_column": "article", '
@@ -209,6 +213,7 @@ def benchmark():
 @click.option(
     "--data-preprocessors",
     default=BenchmarkGenerativeTextArgs.get_default("data_preprocessors"),
+    callback=cli_tools.parse_arguments,
     multiple=True,
     help=(
         "List of of preprocessors to apply to the dataset. E.g., "
@@ -217,11 +222,13 @@ def benchmark():
 )
 @click.option(
     "--data-preprocessors-kwargs",
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to all preprocessors.",
 )
 @click.option(
     "--data-finalizer",
     default=BenchmarkGenerativeTextArgs.get_default("data_finalizer"),
+    callback=cli_tools.parse_arguments,
     help=(
         "JSON string of finalizer to convert dataset rows to requests."
         " E.g., 'generative' or '{\"type\": \"generative\"}'"
@@ -242,6 +249,7 @@ def benchmark():
 @click.option(
     "--dataloader-kwargs",
     default=BenchmarkGenerativeTextArgs.get_default("dataloader_kwargs"),
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to the dataloader constructor.",
 )
 @click.option(
@@ -299,6 +307,7 @@ def benchmark():
     "--warmup-percent",  # legacy alias
     "warmup",
     default=BenchmarkGenerativeTextArgs.get_default("warmup"),
+    callback=cli_tools.parse_arguments,
     help=(
         "Warmup specification: int, float, or dict as string "
         "(json or key=value). "
@@ -313,6 +322,7 @@ def benchmark():
     "--cooldown-percent",  # legacy alias
     "cooldown",
     default=BenchmarkGenerativeTextArgs.get_default("cooldown"),
+    callback=cli_tools.parse_arguments,
     help=(
         "Cooldown specification: int, float, or dict as string "
         "(json or key=value). "
@@ -381,6 +391,7 @@ def benchmark():
 @click.option(
     "--over-saturation",
     "over_saturation",
+    callback=cli_tools.parse_arguments,
     default=None,
     help=(
         "Enable over-saturation detection. "
@@ -393,7 +404,7 @@ def benchmark():
     "--detect-saturation",
     "--default-over-saturation",
     "over_saturation",
-    callback=cli_tools.parse_json,
+    callback=cli_tools.parse_arguments,
     flag_value='{"enabled": true}',
     help="Enable over-saturation detection with default settings.",
 )
@@ -563,18 +574,18 @@ def preprocess():
 @click.option(
     "--processor-args",
     default=None,
-    callback=cli_tools.parse_json,
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to the processor constructor.",
 )
 @click.option(
     "--data-args",
-    callback=cli_tools.parse_json,
+    callback=cli_tools.parse_arguments,
     help="JSON string of arguments to pass to dataset creation.",
 )
 @click.option(
     "--data-column-mapper",
     default=None,
-    callback=cli_tools.parse_json,
+    callback=cli_tools.parse_arguments,
     help="JSON string of column mappings to apply to the dataset.",
 )
 @click.option(

--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -143,7 +143,6 @@ def benchmark():
     "--backend-kwargs",
     "--backend-args",  # legacy alias
     "backend_kwargs",
-    callback=cli_tools.parse_json,
     default=BenchmarkGenerativeTextArgs.get_default("backend_kwargs"),
     help=(
         "JSON string of arguments to pass to the backend. E.g., "
@@ -181,14 +180,12 @@ def benchmark():
 @click.option(
     "--processor-args",
     default=BenchmarkGenerativeTextArgs.get_default("processor_args"),
-    callback=cli_tools.parse_json,
     help="JSON string of arguments to pass to the processor constructor.",
 )
 @click.option(
     "--data-args",
     multiple=True,
     default=BenchmarkGenerativeTextArgs.get_default("data_args"),
-    callback=cli_tools.parse_json,
     help="JSON string of arguments to pass to dataset creation.",
 )
 @click.option(
@@ -203,7 +200,6 @@ def benchmark():
 @click.option(
     "--data-column-mapper",
     default=BenchmarkGenerativeTextArgs.get_default("data_column_mapper"),
-    callback=cli_tools.parse_json,
     help=(
         "JSON string of column mappings to apply to the dataset. "
         'E.g., \'{"column_mappings": {"text_column": "article", '
@@ -213,7 +209,6 @@ def benchmark():
 @click.option(
     "--data-preprocessors",
     default=BenchmarkGenerativeTextArgs.get_default("data_preprocessors"),
-    callback=cli_tools.parse_json_list,
     multiple=True,
     help=(
         "List of of preprocessors to apply to the dataset. E.g., "
@@ -222,13 +217,11 @@ def benchmark():
 )
 @click.option(
     "--data-preprocessors-kwargs",
-    callback=cli_tools.parse_json,
     help="JSON string of arguments to pass to all preprocessors.",
 )
 @click.option(
     "--data-finalizer",
     default=BenchmarkGenerativeTextArgs.get_default("data_finalizer"),
-    callback=cli_tools.parse_json,
     help=(
         "JSON string of finalizer to convert dataset rows to requests."
         " E.g., 'generative' or '{\"type\": \"generative\"}'"
@@ -249,7 +242,6 @@ def benchmark():
 @click.option(
     "--dataloader-kwargs",
     default=BenchmarkGenerativeTextArgs.get_default("dataloader_kwargs"),
-    callback=cli_tools.parse_json,
     help="JSON string of arguments to pass to the dataloader constructor.",
 )
 @click.option(
@@ -307,7 +299,6 @@ def benchmark():
     "--warmup-percent",  # legacy alias
     "warmup",
     default=BenchmarkGenerativeTextArgs.get_default("warmup"),
-    callback=cli_tools.parse_json,
     help=(
         "Warmup specification: int, float, or dict as string "
         "(json or key=value). "
@@ -322,7 +313,6 @@ def benchmark():
     "--cooldown-percent",  # legacy alias
     "cooldown",
     default=BenchmarkGenerativeTextArgs.get_default("cooldown"),
-    callback=cli_tools.parse_json,
     help=(
         "Cooldown specification: int, float, or dict as string "
         "(json or key=value). "
@@ -391,7 +381,6 @@ def benchmark():
 @click.option(
     "--over-saturation",
     "over_saturation",
-    callback=cli_tools.parse_json,
     default=None,
     help=(
         "Enable over-saturation detection. "

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -39,7 +39,6 @@ from guidellm.benchmark.schemas.base import TransientPhaseConfig
 from guidellm.data import DatasetFinalizer, DatasetPreprocessor
 from guidellm.scheduler import StrategyType
 from guidellm.schemas import StandardBaseModel
-from guidellm.utils import arg_string
 
 __all__ = [
     "BenchmarkGenerativeTextArgs",
@@ -375,52 +374,6 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
             )
 
         return data
-
-    @field_validator(
-        "backend_kwargs",
-        "processor_args",
-        "data_args",
-        "data_column_mapper",
-        "data_preprocessors",
-        "data_preprocessors_kwargs",
-        "data_finalizer",
-        "dataloader_kwargs",
-        "warmup",
-        "cooldown",
-        "over_saturation",
-        mode="wrap",
-    )
-    @classmethod
-    def parse_config_str(
-        cls,
-        value: Any,
-        handler: ValidatorFunctionWrapHandler,
-    ) -> Any:
-        """
-        Parse backend/profile from string to instance if necessary.
-
-        :param value: Input value for the 'backend' or 'profile' field
-        :return: Parsed backend/profile instance or original value
-        """
-        if isinstance(value, str):
-            try:
-                value_parsed = yaml.safe_load(value)
-            except yaml.YAMLError:
-                value_parsed = value
-            # If no change from YAML parsing, try arg_string parsing
-            if value_parsed == value:
-                try:
-                    value_parsed = arg_string.loads(value)
-                # If arg_string parsing fails, attempt to parse the original string
-                except arg_string.ArgStringParseError as e:
-                    try:
-                        return handler(value)
-                    except ValidationError as err:
-                        # If validation fails, re-raise from the arg_string error
-                        raise err from e
-            return handler(value_parsed)
-        else:
-            return handler(value)
 
     @field_serializer("backend")
     def serialize_backend(self, backend: str | Backend) -> str:

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -39,6 +39,7 @@ from guidellm.benchmark.schemas.base import TransientPhaseConfig
 from guidellm.data import DatasetFinalizer, DatasetPreprocessor
 from guidellm.scheduler import StrategyType
 from guidellm.schemas import StandardBaseModel
+from guidellm.utils import arg_string
 
 __all__ = [
     "BenchmarkGenerativeTextArgs",
@@ -374,6 +375,52 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
             )
 
         return data
+
+    @field_validator(
+        "backend_kwargs",
+        "processor_args",
+        "data_args",
+        "data_column_mapper",
+        "data_preprocessors",
+        "data_preprocessors_kwargs",
+        "data_finalizer",
+        "dataloader_kwargs",
+        "warmup",
+        "cooldown",
+        "over_saturation",
+        mode="wrap",
+    )
+    @classmethod
+    def parse_config_str(
+        cls,
+        value: Any,
+        handler: ValidatorFunctionWrapHandler,
+    ) -> Any:
+        """
+        Parse backend/profile from string to instance if necessary.
+
+        :param value: Input value for the 'backend' or 'profile' field
+        :return: Parsed backend/profile instance or original value
+        """
+        if isinstance(value, str):
+            try:
+                value_parsed = yaml.safe_load(value)
+            except yaml.YAMLError:
+                value_parsed = value
+            # If no change from YAML parsing, try arg_string parsing
+            if value_parsed == value:
+                try:
+                    value_parsed = arg_string.loads(value)
+                # If arg_string parsing fails, attempt to parse the original string
+                except arg_string.ArgStringParseError as e:
+                    try:
+                        return handler(value)
+                    except ValidationError as err:
+                        # If validation fails, re-raise from the arg_string error
+                        raise err from e
+            return handler(value_parsed)
+        else:
+            return handler(value)
 
     @field_serializer("backend")
     def serialize_backend(self, backend: str | Backend) -> str:

--- a/src/guidellm/data/config.py
+++ b/src/guidellm/data/config.py
@@ -7,6 +7,7 @@ import yaml
 from pydantic import ValidationError
 
 from guidellm.data.schemas import DataConfig, DataNotSupportedError
+from guidellm.utils import arg_string
 
 ConfigT = TypeVar("ConfigT", bound=DataConfig)
 
@@ -85,37 +86,24 @@ def _load_config_str(data: str, config_class: type[ConfigT]) -> ConfigT | None:
     if not isinstance(data, str):
         return None
 
-    data_str = data.strip()
-    error = None
-
-    if (data_str.startswith("{") and data_str.endswith("}")) or (
-        data_str.startswith("[") and data_str.endswith("]")
-    ):
-        try:
-            return config_class.model_validate_json(data_str)
-        except Exception as err:  # noqa: BLE001
-            error = err
-
-    if data_str.count("=") >= 1:
-        # key=value pairs separated by commas
-        try:
-            config_dict = {}
-            items = data_str.split(",")
-            for item in items:
-                key, value = item.split("=")
-                config_dict[key.strip()] = (
-                    int(value.strip()) if value.strip().isnumeric() else value.strip()
-                )
-
-            return config_class.model_validate(config_dict)
-        except Exception as err:  # noqa: BLE001
-            error = err
-
     err_message = (
         f"Unsupported string data for {config_class.__name__}, "
         f"expected JSON or key-value pairs, got {data}"
     )
-    if error is not None:
-        err_message += f" with error: {error}"
-        raise DataNotSupportedError(err_message) from error
-    raise DataNotSupportedError(err_message)
+
+    try:
+        data_parsed = yaml.safe_load(data)
+    except yaml.YAMLError:
+        data_parsed = data
+
+    # If no change from YAML parsing, try arg_string parsing
+    if data_parsed == data:
+        try:
+            data_parsed = arg_string.loads(data_parsed)
+        except arg_string.ArgStringParseError as e:
+            raise DataNotSupportedError(err_message) from e
+
+    try:
+        return config_class.model_validate(data_parsed)
+    except ValidationError as err:
+        raise DataNotSupportedError(err_message) from err

--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -57,6 +57,8 @@ class ArgStringParser:
         skip_invalid: bool = False,
         fill_value: Callable[[], Any] | None = None,
         allow_overwrite: bool = False,
+        key_delimiter: str = ".",
+        split_delimiter: str = ",",
     ):
         """
         Initialize the argument string parser.
@@ -70,6 +72,8 @@ class ArgStringParser:
         self.skip_invalid = skip_invalid
         self.fill_value = fill_value() if fill_value is not None else None
         self.allow_overwrite = allow_overwrite
+        self.key_delimiter = key_delimiter
+        self.split_delimiter = split_delimiter
 
     def decode(self, s: str) -> dict[str, Any]:
         """
@@ -110,7 +114,7 @@ class ArgStringParser:
             return result
 
         # Split by commas
-        pairs = s.split(",")
+        pairs = s.split(self.split_delimiter)
 
         for pair_raw in pairs:
             pair_stripped = pair_raw.strip()
@@ -176,19 +180,19 @@ class ArgStringParser:
         :raises KeyError: If a dictionary key in the path does not exist
         :raises IndexError: If a list index in the path is out of range
         """
-        path_list = path.split(".")
+        path_list = path.split(self.key_delimiter)
         segments = self._parse_key(path)
         current: Any = obj
 
         for i, (name, index) in enumerate(segments, 1):
             if not isinstance(current, dict) or name not in current:
-                path_so_far = ".".join(path_list[:i])
+                path_so_far = self.key_delimiter.join(path_list[:i])
                 raise KeyError(f"Key '{name}' not found in '{path_so_far}'")
             current = current[name]
 
             if index is not None:
                 if not isinstance(current, list) or index >= len(current):
-                    path_so_far = ".".join(path_list[:i])
+                    path_so_far = self.key_delimiter.join(path_list[:i])
                     raise IndexError(f"Index '{path_so_far}' out of range")
                 current = current[index]
 
@@ -208,7 +212,7 @@ class ArgStringParser:
         segments: list[tuple[str, int | None]] = []
 
         # Split by dots first
-        parts = key.split(".")
+        parts = key.split(self.key_delimiter)
 
         for part in parts:
             # Check if part has array notation: name[index]

--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -1,0 +1,384 @@
+"""
+Utilities for parsing argument strings into Python dictionaries.
+
+Provides functions to parse comma-separated key=value strings with support for
+simple key-value pairs, nested dictionaries using dot notation, list indexing
+with bracket notation, and combined syntax for complex nested structures.
+Automatically converts values to appropriate Python types (int, float, bool, str).
+
+Usage:
+::
+    from guidellm.utils import arg_string
+    result = arg_string.loads("prompt_tokens=10,output_tokens=30")
+    # {'prompt_tokens': 10, 'output_tokens': 30}
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+import yaml
+
+__all__ = [
+    "ArgStringParseError",
+    "ArgStringParser",
+    "loads",
+]
+
+
+class ArgStringParseError(Exception):
+    """Exception raised for errors during argument string parsing."""
+
+
+class ArgStringParser:
+    """
+    Decoder for converting argument strings to Python dictionaries.
+
+    Parses comma-separated key=value strings with support for nested dictionaries
+    (dot notation), list indexing (bracket notation), and automatic type conversion
+    using YAML safe_load. Similar to json.JSONDecoder.
+
+    Example:
+    ::
+        parser = ArgStringParser()
+        result = parser.decode("prompt_tokens=10,output_tokens=30")
+        # {'prompt_tokens': 10, 'output_tokens': 30}
+
+        # Custom fill value for sparse lists
+        parser = ArgStringParser(fill_value=lambda: 0)
+        result = parser.decode("items[5]=value")
+        # {'items': [0, 0, 0, 0, 0, 'value']}
+    """
+
+    def __init__(
+        self,
+        skip_invalid: bool = False,
+        fill_value: Callable[[], Any] | None = None,
+        allow_overwrite: bool = False,
+    ):
+        """
+        Initialize the argument string parser.
+
+        :param skip_invalid: If True, skips invalid key=value pairs rather than raising
+        :param fill_value: Callable that returns fill value for sparse lists.
+            Defaults to lambda: None.
+        :param allow_overwrite: If True, allows overwriting existing values.
+            Defaults to False, which raises an error on overwrites.
+        """
+        self.skip_invalid = skip_invalid
+        self.fill_value = fill_value() if fill_value is not None else None
+        self.allow_overwrite = allow_overwrite
+
+    def decode(self, s: str) -> dict[str, Any]:
+        """
+        Decode an arg string into a Python dictionary with automatic type conversion.
+
+        Converts comma-separated key=value pairs into nested dictionary structures.
+        Supports dot notation for nested dictionaries (parent.child=value), bracket
+        notation for lists (items[0]=value), and combined syntax.
+        Values are parsed using YAML safe_load for automatic type conversion.
+
+        :param s: Comma-separated list of key=value pairs supporting nested
+            structures via dot and bracket notation
+        :return: Parsed dictionary with appropriate types and nesting
+        :raises ArgStringParseError: If the string format is invalid
+
+        Example:
+        ::
+            parser = ArgStringParser()
+
+            parser.decode("prompt_tokens=10,output_tokens=30")
+            # {'prompt_tokens': 10, 'output_tokens': 30}
+
+            parser.decode("prompt.tokens=15,output.tokens=45")
+            # {'prompt': {'tokens': 15}, 'output': {'tokens': 45}}
+
+            parser.decode("fruit[0]=apple,fruit[1]=orange")
+            # {'fruit': ['apple', 'orange']}
+
+            parser.decode("fruit[0]=apple,fruit[3]=orange")
+            # {'fruit': ['apple', None, None, 'orange']}
+
+            parser.decode("items[0].weight=10,items[0].count=5")
+            # {'items': [{'weight': 10, 'count': 5}]}
+        """
+        result: dict[str, Any] = {}
+
+        if not s or not s.strip():
+            return result
+
+        # Split by commas
+        pairs = s.split(",")
+
+        for pair_raw in pairs:
+            pair_stripped = pair_raw.strip()
+            # Handle invalid pairs
+            if not pair_stripped or "=" not in pair_stripped:
+                if self.skip_invalid:
+                    continue
+                raise ArgStringParseError(f"Invalid key=value pair: '{pair_raw}'")
+
+            key, value = pair_stripped.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+
+            # Handle empty keys
+            if not key:
+                if self.skip_invalid:
+                    continue
+                raise ArgStringParseError(f"Empty key in pair: '{pair_raw}'")
+
+            # Parse the key into segments
+            segments = self._parse_key(key)
+
+            # Convert value to appropriate type
+            parsed_value = yaml.safe_load(value)
+
+            # Set the value in the nested structure
+            self._value_set_nested(result, segments, parsed_value)
+
+        return result
+
+    def _parse_key(self, key: str) -> list[tuple[str, int | None]]:
+        """
+        Parse a key string into segments with optional array indices.
+
+        Splits a key by dots and identifies array access patterns using
+        bracket notation. Returns a list of (name, index) tuples where index
+        is None for dictionary keys and an integer for list indices.
+
+        :param key: Key string to parse, may contain dots and brackets
+        :return: List of (name, index) tuples representing the parsed key segments
+        """
+        segments: list[tuple[str, int | None]] = []
+
+        # Split by dots first
+        parts = key.split(".")
+
+        for part in parts:
+            # Check if part has array notation: name[index]
+            match = re.match(r"^([^\[]+)\[(\d+)\]$", part)
+            if match:
+                name = match.group(1)
+                index = int(match.group(2))
+                segments.append((name, index))
+            else:
+                segments.append((part, None))
+
+        return segments
+
+    def _list_ensure_size(self, lst: list, index: int) -> None:
+        """
+        Ensure a list is large enough to access the given index.
+
+        Extends the list with fill values until it can safely accommodate
+        the specified index position.
+
+        :param lst: The list to resize if necessary
+        :param index: The minimum index that must be accessible
+        """
+        while len(lst) <= index:
+            lst.append(self.fill_value)
+
+    def _list_set_value(
+        self,
+        current: dict[str, Any],
+        name: str,
+        index: int,
+        value: Any,
+    ) -> None:
+        """
+        Set a value in a list at the given index within a dictionary.
+
+        Creates the list if it doesn't exist and ensures it's large enough
+        to accommodate the specified index before setting the value.
+
+        :param current: The current dictionary context containing the list
+        :param name: The key name for the list in the dictionary
+        :param index: The list index where the value should be set
+        :param value: The value to set at the specified index
+        :raises ArgStringParseError: If overwriting and allow_overwrite is False
+        """
+        if name not in current:
+            current[name] = []
+        elif not isinstance(current[name], list):
+            # Trying to replace non-list with list
+            if not self.allow_overwrite:
+                raise ArgStringParseError(
+                    f"Cannot overwrite non-list value at '{name}' with list"
+                )
+            current[name] = []
+
+        self._list_ensure_size(current[name], index)
+
+        # Check for overwrite of non-fill values
+        existing_value = current[name][index]
+        if not self.allow_overwrite and existing_value != self.fill_value:
+            raise ArgStringParseError(
+                f"Cannot overwrite existing value at '{name}[{index}]'"
+            )
+
+        current[name][index] = value
+
+    def _list_navigate_to_element(
+        self,
+        current: dict[str, Any],
+        name: str,
+        index: int,
+    ) -> Any:
+        """
+        Navigate to or create a list element for intermediate path segments.
+
+        Creates the list if it doesn't exist, ensures it's large enough for the index,
+        and initializes the element as an empty dictionary if needed. Returns the
+        element for further navigation.
+
+        :param current: The current dictionary context containing the list
+        :param name: The key name for the list in the dictionary
+        :param index: The list index to navigate to
+        :return: The element at the given index (creating empty dict if needed)
+        :raises ArgStringParseError: If overwriting and allow_overwrite is False
+        """
+        if name not in current:
+            current[name] = []
+        elif not isinstance(current[name], list):
+            # Trying to replace non-list with list
+            if not self.allow_overwrite:
+                raise ArgStringParseError(
+                    f"Cannot overwrite non-list value at '{name}' with list"
+                )
+            current[name] = []
+
+        self._list_ensure_size(current[name], index)
+
+        # Create nested structure if needed (only for fill values)
+        existing_value = current[name][index]
+        if existing_value == self.fill_value:
+            current[name][index] = {}
+        elif not isinstance(existing_value, dict):
+            # Trying to navigate into non-dict value
+            if not self.allow_overwrite:
+                raise ArgStringParseError(
+                    f"Cannot overwrite non-dict value at '{name}[{index}]' with dict"
+                )
+            current[name][index] = {}
+
+        return current[name][index]
+
+    def _dict_navigate_to_key(
+        self,
+        current: dict[str, Any],
+        name: str,
+    ) -> dict[str, Any]:
+        """
+        Navigate to or create a dictionary key for intermediate path segments.
+
+        Creates the dictionary key if it doesn't exist and returns the nested
+        dictionary for further navigation.
+
+        :param current: The current dictionary context
+        :param name: The key name to navigate to
+        :return: The nested dictionary at the given key
+        :raises ArgStringParseError: If overwriting and allow_overwrite is False
+        """
+        if name not in current:
+            current[name] = {}
+        elif not isinstance(current[name], dict):
+            # Trying to navigate into non-dict value
+            if not self.allow_overwrite:
+                raise ArgStringParseError(
+                    f"Cannot overwrite non-dict value at '{name}' with dict"
+                )
+            current[name] = {}
+
+        return current[name]
+
+    def _value_set_nested(
+        self,
+        result: dict[str, Any],
+        segments: list[tuple[str, int | None]],
+        value: Any,
+    ) -> None:
+        """
+        Set a value in a nested dictionary and list structure.
+
+        Navigates through the segment path, creating intermediate dictionaries and lists
+        as needed. For sparse lists, fills gaps with fill values. Supports mixed nesting
+        of dictionaries and lists.
+
+        :param result: The root dictionary to modify in place
+        :param segments: List of (name, index) tuples representing the navigation path
+        :param value: The value to set at the final destination
+        :raises ArgStringParseError: If overwriting and allow_overwrite is False
+        """
+        current: Any = result
+
+        for i, (name, index) in enumerate(segments):
+            is_last = i == len(segments) - 1
+
+            if is_last:
+                # If we are at the last segment, set the value
+                if index is not None:
+                    self._list_set_value(current, name, index, value)
+                else:
+                    if name in current and not self.allow_overwrite:
+                        raise ArgStringParseError(
+                            f"Cannot overwrite existing value at key '{name}'"
+                        )
+                    current[name] = value
+            # If not last, navigate/create intermediate structures
+            elif index is not None:
+                # Intermediate segment with array access
+                current = self._list_navigate_to_element(current, name, index)
+            else:
+                # Intermediate segment with dict access
+                current = self._dict_navigate_to_key(current, name)
+
+
+def loads(
+    s: str,
+    *,
+    cls: type[ArgStringParser] | None = None,
+    **kwargs,
+) -> dict[str, Any]:
+    """
+    Parse an arg string into a Python dictionary with automatic type conversion.
+
+    This function follows the json.loads pattern, allowing customization through
+    a custom decoder class. By default, uses ArgStringParser.
+
+    :param s: Comma-separated list of key=value pairs supporting nested
+        structures via dot and bracket notation
+    :param cls: Custom decoder class to use (must have a decode method).
+        Defaults to ArgStringParser.
+    :param kwargs: Additional keyword arguments passed to the decoder class
+        constructor (e.g., fill_value)
+    :return: Parsed dictionary with appropriate types and nesting
+    :raises ArgStringParseError: If the string format is invalid
+
+    Example:
+    ::
+        import guidellm.utils.arg_string as arg_string
+
+        arg_string.loads("prompt_tokens=10,output_tokens=30")
+        # {'prompt_tokens': 10, 'output_tokens': 30}
+
+        # With custom fill value
+        arg_string.loads("items[5]=value", fill_value=lambda: 0)
+        # {'items': [0, 0, 0, 0, 0, 'value']}
+
+        # With custom decoder class
+        class CustomParser(arg_string.ArgStringParser):
+            def decode(self, s):
+                result = super().decode(s)
+                # Custom post-processing
+                return result
+
+        arg_string.loads("a=1,b=2", cls=CustomParser)
+    """
+    if cls is None:
+        cls = ArgStringParser
+
+    return cls(**kwargs).decode(s)

--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -123,7 +123,7 @@ class ArgStringParser:
                 if self.skip_invalid:
                     continue
                 raise ArgStringParseError(
-                    f"Invalid key=value expression at {idx}:\n'{s}'"
+                    f"Invalid key=value expression at {idx}: '{s}'"
                 )
 
             key_raw, value_raw = pair.split("=", 1)
@@ -135,7 +135,7 @@ class ArgStringParser:
                 if self.skip_invalid:
                     continue
                 raise ArgStringParseError(
-                    f"Empty key in key=value expression at {idx}:\n'{s}'"
+                    f"Empty key in key=value expression at {idx}: '{s}'"
                 )
 
             # Parse the key into segments

--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -8,7 +8,7 @@ Automatically converts values to appropriate Python types (int, float, bool, str
 
 Usage:
 ::
-    from guidellm.utils import arg_string
+    import guidellm.utils.arg_string as arg_string
     result = arg_string.loads("prompt_tokens=10,output_tokens=30")
     # {'prompt_tokens': 10, 'output_tokens': 30}
 """
@@ -140,6 +140,59 @@ class ArgStringParser:
             self._value_set_nested(result, segments, parsed_value)
 
         return result
+
+    def set(self, obj: dict, path: str, value: Any) -> None:
+        """
+        Update a nested dictionary with a value at the specified path.
+
+        This method allows updating a nested dictionary structure using a path
+        string that supports dot notation for nested dictionaries and bracket
+        notation for list indices. It creates intermediate dictionaries and lists
+        as needed, filling sparse list gaps with the specified fill value.
+
+        :param obj: The dictionary to update in place
+        :param path: The path string indicating where to set the value, e.g.,
+            "parent.child[0].name"
+        :param value: The value to set at the specified path
+        :raises ArgStringParseError: If the path format is invalid or if overwriting
+            existing values is not allowed based on the parser's configuration
+        """
+        segments = self._parse_key(path)
+        self._value_set_nested(obj, segments, value)
+
+    def get(self, obj: dict, path: str) -> Any:
+        """
+        Retrieve a value from a nested dictionary using a path string.
+
+        This method allows retrieving values from a nested dictionary structure
+        using a path string that supports dot notation for nested dictionaries and
+        bracket notation for list indices.
+
+        :param obj: The dictionary to retrieve the value from
+        :param path: The path string indicating where to get the value, e.g.,
+            "parent.child[0].name"
+        :return: The value at the specified path, or None if the path does not exist
+        :raises ArgStringParseError: If the path format is invalid
+        :raises KeyError: If a dictionary key in the path does not exist
+        :raises IndexError: If a list index in the path is out of range
+        """
+        path_list = path.split(".")
+        segments = self._parse_key(path)
+        current: Any = obj
+
+        for i, (name, index) in enumerate(segments, 1):
+            if not isinstance(current, dict) or name not in current:
+                path_so_far = ".".join(path_list[:i])
+                raise KeyError(f"Key '{name}' not found in '{path_so_far}'")
+            current = current[name]
+
+            if index is not None:
+                if not isinstance(current, list) or index >= len(current):
+                    path_so_far = ".".join(path_list[:i])
+                    raise IndexError(f"Index '{path_so_far}' out of range")
+                current = current[index]
+
+        return current
 
     def _parse_key(self, key: str) -> list[tuple[str, int | None]]:
         """

--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -116,23 +116,27 @@ class ArgStringParser:
         # Split by commas
         pairs = s.split(self.split_delimiter)
 
-        for pair_raw in pairs:
-            pair_stripped = pair_raw.strip()
+        for idx, pair_raw in enumerate(pairs):
+            pair = pair_raw.strip()
             # Handle invalid pairs
-            if not pair_stripped or "=" not in pair_stripped:
+            if not pair or "=" not in pair:
                 if self.skip_invalid:
                     continue
-                raise ArgStringParseError(f"Invalid key=value pair: '{pair_raw}'")
+                raise ArgStringParseError(
+                    f"Invalid key=value expression at {idx}:\n'{s}'"
+                )
 
-            key, value = pair_stripped.split("=", 1)
-            key = key.strip()
-            value = value.strip()
+            key_raw, value_raw = pair.split("=", 1)
+            key = key_raw.strip()
+            value = value_raw.strip()
 
             # Handle empty keys
             if not key:
                 if self.skip_invalid:
                     continue
-                raise ArgStringParseError(f"Empty key in pair: '{pair_raw}'")
+                raise ArgStringParseError(
+                    f"Empty key in key=value expression at {idx}:\n'{s}'"
+                )
 
             # Parse the key into segments
             segments = self._parse_key(key)
@@ -214,8 +218,9 @@ class ArgStringParser:
         # Split by dots first
         parts = key.split(self.key_delimiter)
 
-        for part in parts:
+        for part_raw in parts:
             # Check if part has array notation: name[index]
+            part = part_raw.strip()
             match = re.match(r"^([^\[]+)\[(\d+)\]$", part)
             if match:
                 name = match.group(1)

--- a/src/guidellm/utils/cli.py
+++ b/src/guidellm/utils/cli.py
@@ -3,6 +3,9 @@ import json
 from typing import Any
 
 import click
+import yaml
+
+from guidellm.utils import arg_string
 
 __all__ = [
     "Union",
@@ -108,6 +111,43 @@ def parse_json_list(ctx, param, value):
         return None
 
     return [parse_json(ctx, param, item) for item in list_value]
+
+
+def parse_arguments(
+    ctx: click.Context, param: click.Parameter, value: list[str] | tuple[str, ...] | str
+) -> Any:
+    """
+    Parse a string value into a Python object using YAML, JSON, or key=value pairs.
+
+    This functions uses a combination of YAML and arg_string parsers to handle any input
+    format since PyYAML will parse JSON and raw types.
+
+    :param ctx: Click context
+    :param param: Click parameter
+    :param value: The input value to parse, string or list/tuple of strings
+    """
+    if isinstance(value, list | tuple):
+        return [parse_arguments(ctx, param, val) for val in value]
+    if isinstance(value, str):
+        yaml_parsed = False
+        try:
+            value_parsed = yaml.safe_load(value)
+            yaml_parsed = True
+        except yaml.YAMLError:
+            value_parsed = value
+        # If no change from YAML parsing, try arg_string parsing
+        if value_parsed == value:
+            try:
+                value_parsed = arg_string.loads(value)
+            # If arg_string parsing fails, attempt to parse the original string
+            except arg_string.ArgStringParseError as e:
+                if not yaml_parsed:
+                    raise click.BadParameter(
+                        f"{param.name} must be a valid YAML, JSON, or key=value string."
+                    ) from e
+        return value_parsed
+
+    return value
 
 
 def set_if_not_default(ctx: click.Context, **kwargs) -> dict[str, Any]:

--- a/tests/unit/utils/test_arg_string.py
+++ b/tests/unit/utils/test_arg_string.py
@@ -1,0 +1,648 @@
+"""
+Tests for arg string parsing utilities.
+"""
+
+import pytest
+
+from guidellm.utils import arg_string
+
+
+class TestArgStringParser:
+    """Test cases for ArgStringParser class."""
+
+    @pytest.mark.smoke
+    def test_parser_decode_simple(self):
+        """
+        Test using ArgStringParser.decode() directly with simple input.
+
+        ### WRITTEN BY AI ###
+        """
+        parser = arg_string.ArgStringParser()
+        result = parser.decode("key=value,count=42")
+        assert result == {"key": "value", "count": 42}
+
+    @pytest.mark.sanity
+    def test_parser_decode_nested(self):
+        """
+        Test using ArgStringParser.decode() with nested structures.
+
+        ### WRITTEN BY AI ###
+        """
+        parser = arg_string.ArgStringParser()
+        result = parser.decode("items[0].name=apple,items[0].count=5")
+        assert result == {"items": [{"name": "apple", "count": 5}]}
+
+    @pytest.mark.sanity
+    def test_parser_custom_fill_value(self):
+        """
+        Test ArgStringParser with custom fill_value for sparse lists.
+
+        ### WRITTEN BY AI ###
+        """
+        parser = arg_string.ArgStringParser(fill_value=lambda: 0)
+        result = parser.decode("items[5]=value")
+        assert result == {"items": [0, 0, 0, 0, 0, "value"]}
+
+
+class TestArgStringLoads:
+    """Test cases for arg_string.loads function."""
+
+    @pytest.mark.smoke
+    def test_loads_simple(self):
+        """
+        Test using arg_string.loads with simple input.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("key=value,count=42")
+        assert result == {"key": "value", "count": 42}
+
+    @pytest.mark.sanity
+    def test_loads_nested(self):
+        """
+        Test using arg_string.loads with nested structures.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("items[0].name=apple,items[0].count=5")
+        assert result == {"items": [{"name": "apple", "count": 5}]}
+
+    @pytest.mark.sanity
+    def test_loads_with_fill_value(self):
+        """
+        Test arg_string.loads with custom fill_value parameter.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("items[3]=value", fill_value=lambda: "empty")
+        assert result == {"items": ["empty", "empty", "empty", "value"]}
+
+    @pytest.mark.sanity
+    def test_loads_with_custom_class(self):
+        """
+        Test arg_string.loads with custom decoder class.
+
+        ### WRITTEN BY AI ###
+        """
+
+        class CustomParser(arg_string.ArgStringParser):
+            def decode(self, s):
+                result = super().decode(s)
+                # Add a custom metadata field
+                result["_custom"] = True
+                return result
+
+        result = arg_string.loads("a=1,b=2", cls=CustomParser)
+        assert result == {"a": 1, "b": 2, "_custom": True}
+
+    @pytest.mark.smoke
+    def test_simple_key_value_pairs(self):
+        """
+        Test parsing simple key=value pairs with type conversion.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("prompt_tokens=10,output_tokens=30")
+        assert result == {"prompt_tokens": 10, "output_tokens": 30}
+
+    @pytest.mark.smoke
+    def test_nested_dictionaries(self):
+        """
+        Test parsing nested dictionaries using dot notation.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("prompt.tokens=15,output.tokens=45")
+        assert result == {"prompt": {"tokens": 15}, "output": {"tokens": 45}}
+
+    @pytest.mark.smoke
+    def test_list_indexing(self):
+        """
+        Test parsing list items with bracket notation.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("fruit[0]=apple,fruit[1]=orange")
+        assert result == {"fruit": ["apple", "orange"]}
+
+    @pytest.mark.smoke
+    def test_sparse_list_with_none_filling(self):
+        """
+        Test parsing sparse lists with None values filling gaps.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("fruit[0]=apple,fruit[3]=orange")
+        assert result == {"fruit": ["apple", None, None, "orange"]}
+
+    @pytest.mark.smoke
+    def test_combined_list_and_nested_dict(self):
+        """
+        Test parsing complex structures combining lists and nested dicts.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads(
+            "prefix_buckets[0].bucket_weight=10,"
+            "prefix_buckets[0].prefix_count=10,"
+            "prefix_buckets[1].bucket_weight=20,"
+            "prefix_buckets[1].prefix_count=4",
+        )
+        expected = {
+            "prefix_buckets": [
+                {"bucket_weight": 10, "prefix_count": 10},
+                {"bucket_weight": 20, "prefix_count": 4},
+            ]
+        }
+        assert result == expected
+
+    @pytest.mark.sanity
+    def test_type_conversion_int(self):
+        """
+        Test that integer strings are converted to int type.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("count=42")
+        assert result == {"count": 42}
+        assert isinstance(result["count"], int)
+
+    @pytest.mark.sanity
+    def test_type_conversion_float(self):
+        """
+        Test that float strings are converted to float type.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("temperature=0.7")
+        assert result == {"temperature": 0.7}
+        assert isinstance(result["temperature"], float)
+
+    @pytest.mark.sanity
+    def test_type_conversion_bool_true(self):
+        """
+        Test that 'true' is converted to bool True.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("enabled=true")
+        assert result == {"enabled": True}
+        assert isinstance(result["enabled"], bool)
+
+    @pytest.mark.sanity
+    def test_type_conversion_bool_false(self):
+        """
+        Test that 'false' is converted to bool False.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("enabled=false")
+        assert result == {"enabled": False}
+        assert isinstance(result["enabled"], bool)
+
+    @pytest.mark.sanity
+    def test_type_conversion_bool_case_insensitive(self):
+        """
+        Test that boolean conversion is case-insensitive.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("a=True,b=FALSE,c=true")
+        assert result == {"a": True, "b": False, "c": True}
+
+    @pytest.mark.sanity
+    def test_type_conversion_string(self):
+        """
+        Test that non-numeric strings remain as strings.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("name=hello")
+        assert result == {"name": "hello"}
+        assert isinstance(result["name"], str)
+
+    @pytest.mark.sanity
+    def test_empty_string(self):
+        """
+        Test parsing an empty string returns empty dict.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("")
+        assert result == {}
+
+    @pytest.mark.sanity
+    def test_whitespace_only(self):
+        """
+        Test parsing whitespace-only string returns empty dict.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("   ")
+        assert result == {}
+
+    @pytest.mark.sanity
+    def test_whitespace_handling(self):
+        """
+        Test that whitespace around keys and values is stripped.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads(" key1 = value1 , key2 = value2 ")
+        assert result == {"key1": "value1", "key2": "value2"}
+
+    @pytest.mark.sanity
+    def test_deep_nesting(self):
+        """
+        Test parsing deeply nested dictionary structures.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("a.b.c.d=value")
+        assert result == {"a": {"b": {"c": {"d": "value"}}}}
+
+    @pytest.mark.sanity
+    def test_multiple_lists(self):
+        """
+        Test parsing multiple separate lists.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("colors[0]=red,colors[1]=blue,sizes[0]=small")
+        assert result == {
+            "colors": ["red", "blue"],
+            "sizes": ["small"],
+        }
+
+    @pytest.mark.sanity
+    def test_overwrite_error_dict_key(self):
+        """
+        Test that overwriting a dict key raises an error by default.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at key 'key'",
+        ):
+            arg_string.loads("key=first,key=second")
+
+    @pytest.mark.sanity
+    def test_overwrite_error_nested_dict_key(self):
+        """
+        Test that overwriting a nested dict key raises an error by default.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at key 'b'",
+        ):
+            arg_string.loads("a.b=1,a.b=2")
+
+    @pytest.mark.sanity
+    def test_overwrite_error_list_value(self):
+        """
+        Test that overwriting a list value raises an error by default.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at 'items\\[0\\]'",
+        ):
+            arg_string.loads("items[0]=first,items[0]=second")
+
+    @pytest.mark.regression
+    def test_mixed_value_types(self):
+        """
+        Test parsing with mixed value types in a single string.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("count=42,temperature=0.7,enabled=true,name=test")
+        assert result == {
+            "count": 42,
+            "temperature": 0.7,
+            "enabled": True,
+            "name": "test",
+        }
+
+    @pytest.mark.regression
+    def test_complex_nested_structure(self):
+        """
+        Test parsing complex nested structure with multiple levels.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads(
+            "config.server[0].host=localhost,"
+            "config.server[0].port=8080,"
+            "config.server[1].host=remote,"
+            "config.server[1].port=9090"
+        )
+        expected = {
+            "config": {
+                "server": [
+                    {"host": "localhost", "port": 8080},
+                    {"host": "remote", "port": 9090},
+                ]
+            }
+        }
+        assert result == expected
+
+    @pytest.mark.regression
+    def test_value_with_equals_sign(self):
+        """
+        Test parsing values that contain equals signs.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("equation=a=b+c")
+        assert result == {"equation": "a=b+c"}
+
+    @pytest.mark.regression
+    def test_numeric_string_key(self):
+        """
+        Test that numeric keys remain as strings in dict keys.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("123=value")
+        assert result == {"123": "value"}
+
+    @pytest.mark.regression
+    def test_underscore_in_keys(self):
+        """
+        Test that underscores in keys are preserved.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("my_key_name=value")
+        assert result == {"my_key_name": "value"}
+
+    @pytest.mark.regression
+    def test_list_with_missing_first_element(self):
+        """
+        Test creating a list starting at index > 0.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("items[2]=third")
+        assert result == {"items": [None, None, "third"]}
+
+    @pytest.mark.regression
+    def test_nested_dict_in_list_element(self):
+        """
+        Test nested dictionaries within list elements.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("items[0].config.name=first,items[0].config.value=10")
+        assert result == {"items": [{"config": {"name": "first", "value": 10}}]}
+
+    @pytest.mark.regression
+    def test_invalid_pair_no_equals(self):
+        """
+        Test that pairs without '=' raise an error.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Invalid key=value pair",
+        ):
+            arg_string.loads("invalidpair,key=value2")
+
+    @pytest.mark.regression
+    def test_invalid_key_pair_skip(self):
+        """
+        Test that pairs with invalid keys are skipped
+        when skip_invalid is True.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads(
+            "valid_key=value,invalid-pair,key2=value2",
+            skip_invalid=True,
+        )
+        assert result == {"valid_key": "value", "key2": "value2"}
+
+    @pytest.mark.regression
+    def test_empty_key(self):
+        """
+        Test handling of empty keys
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Empty key in pair",
+        ):
+            arg_string.loads("=value,key=value2")
+
+    @pytest.mark.regression
+    def test_empty_key_skip(self):
+        """
+        Test that empty keys are skipped when skip_invalid is True.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("=value,key=value2", skip_invalid=True)
+        assert result == {"key": "value2"}
+
+    @pytest.mark.regression
+    def test_empty_value(self):
+        """
+        Test handling of empty values.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("key=")
+        assert result == {"key": None}
+
+    @pytest.mark.regression
+    def test_special_characters_in_string_value(self):
+        """
+        Test that special characters in string values are preserved.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("path=/usr/local/bin,url=http://example.com")
+        assert result == {
+            "path": "/usr/local/bin",
+            "url": "http://example.com",
+        }
+
+    @pytest.mark.regression
+    def test_overwrite_error_replace_value_with_dict(self):
+        """
+        Test that replacing a raw value with a dict raises an error.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-dict value at 'key' with dict",
+        ):
+            arg_string.loads("key=value,key.subkey=other")
+
+    @pytest.mark.regression
+    def test_overwrite_error_replace_value_with_list(self):
+        """
+        Test that replacing a raw value with a list raises an error.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-list value at 'key' with list",
+        ):
+            arg_string.loads("key=value,key[0]=item")
+
+    @pytest.mark.regression
+    def test_overwrite_error_replace_list_value_with_dict(self):
+        """
+        Test that replacing a list value with a dict raises an error.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-dict value at 'items\\[0\\]' with dict",
+        ):
+            arg_string.loads("items[0]=value,items[0].field=other")
+
+    @pytest.mark.regression
+    def test_no_overwrite_error_for_fill_values(self):
+        """
+        Test that setting values in sparse lists doesn't raise overwrite errors.
+
+        ### WRITTEN BY AI ###
+        """
+        # This should NOT raise an error because items[0-4] are fill values
+        result = arg_string.loads("items[5]=value")
+        assert result == {"items": [None, None, None, None, None, "value"]}
+
+    @pytest.mark.regression
+    def test_no_overwrite_error_for_fill_values_with_nested(self):
+        """
+        Test that navigating through fill values doesn't raise overwrite errors.
+
+        ### WRITTEN BY AI ###
+        """
+        # This should NOT raise an error because items[0] is a fill value
+        result = arg_string.loads("items[2].field=value")
+        assert result == {"items": [None, None, {"field": "value"}]}
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_dict_key(self):
+        """
+        Test that allow_overwrite=False raises error for dict key overwrites.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at key 'key'",
+        ):
+            arg_string.loads("key=first,key=second", allow_overwrite=False)
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_nested_dict_key(self):
+        """
+        Test that allow_overwrite=False raises error for nested dict overwrites.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at key 'b'",
+        ):
+            arg_string.loads("a.b=1,a.b=2", allow_overwrite=False)
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_list_value(self):
+        """
+        Test that allow_overwrite=False raises error for list value overwrites.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at 'items\\[0\\]'",
+        ):
+            arg_string.loads("items[0]=first,items[0]=second", allow_overwrite=False)
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_value_to_dict(self):
+        """
+        Test that allow_overwrite=False raises error for value to dict conversion.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-dict value at 'key' with dict",
+        ):
+            arg_string.loads("key=value,key.subkey=other", allow_overwrite=False)
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_value_to_list(self):
+        """
+        Test that allow_overwrite=False raises error for value to list conversion.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-list value at 'key' with list",
+        ):
+            arg_string.loads("key=value,key[0]=item", allow_overwrite=False)
+
+    @pytest.mark.regression
+    def test_allow_overwrite_false_list_value_to_dict(self):
+        """
+        Test that allow_overwrite=False raises error for list value to dict.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-dict value at 'items\\[0\\]' with dict",
+        ):
+            arg_string.loads(
+                "items[0]=value,items[0].field=other", allow_overwrite=False
+            )
+
+    @pytest.mark.regression
+    def test_overwrite_value(self):
+        """
+        Test that later values overwrite earlier ones for the same key.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("key=first,key=second", allow_overwrite=True)
+        assert result == {"key": "second"}
+
+    @pytest.mark.regression
+    def test_overwrite_in_nested_structure(self):
+        """
+        Test overwriting values in nested structures.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads("a.b=1,a.b=2", allow_overwrite=True)
+        assert result == {"a": {"b": 2}}
+
+    @pytest.mark.regression
+    def test_overwrite_in_list(self):
+        """
+        Test overwriting values in list elements.
+
+        ### WRITTEN BY AI ###
+        """
+        result = arg_string.loads(
+            "items[0]=first,items[0]=second", allow_overwrite=True
+        )
+        assert result == {"items": ["second"]}

--- a/tests/unit/utils/test_arg_string.py
+++ b/tests/unit/utils/test_arg_string.py
@@ -410,9 +410,9 @@ class TestArgStringLoads:
         """
         with pytest.raises(
             arg_string.ArgStringParseError,
-            match="Invalid key=value pair",
+            match="Invalid key=value expression at 1:",
         ):
-            arg_string.loads("invalidpair,key=value2")
+            arg_string.loads("key=value2,invalidpair")
 
     @pytest.mark.regression
     def test_invalid_key_pair_skip(self):
@@ -437,9 +437,9 @@ class TestArgStringLoads:
         """
         with pytest.raises(
             arg_string.ArgStringParseError,
-            match="Empty key in pair",
+            match="Empty key in key=value expression at 1:",
         ):
-            arg_string.loads("=value,key=value2")
+            arg_string.loads("key=value2,=value")
 
     @pytest.mark.regression
     def test_empty_key_skip(self):


### PR DESCRIPTION
## Summary

Replaces various config string handlers with a new `ArgString` format. 

## Details

Replaces the dataset config parser with a more advance "arg_string" parser with support for nested and list config structures. For example:

```
prefix_buckets[0].bucket_weight=10,prefix_buckets[0].prefix_count=10,prefix_buckets[1].bucket_weight=20,prefix_buckets[1].prefix_count=4
```

Renders to

```python
{
    "prefix_buckets": [
        {"bucket_weight": 10, "prefix_count": 10},
        {"bucket_weight": 20, "prefix_count": 4},
     ]
}
```

Also added some glue logic to allow this format anywhere on the CLI that supports JSON. This code should be considered temporary as it will mostly be replaced through the rest of the CLI refactor.

Also open to suggestions for a better name then "arg_string"; a 2-4 letter acronym like JSON or YAML would be good.

## Test Plan

The following benchmark should run without errors and have ~384 ISL per request (make sure to check startup logs confirm `backend-kwargs` and `warmup` are configured):

```sh
guidellm benchmark run \
    --profile concurrent \
    --data "prompt_tokens=256,output_tokens=256,prefix_buckets[0].bucket_weight=10,prefix_buckets[0].prefix_tokens=128,prefix_buckets[0].prefix_count=10" \
    --request-format /v1/completions \
    --backend-kwargs '{"timeout":120}' \
    --warmup percent=0.1,value=20 \
    --max-seconds 30 \
    --rate 30
```

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
