### PR TITLE
Feat/cross rate early exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ guidellm run \
 **Key parameters:**
 
 - `--profile kind=<type>`: Defines the traffic pattern — `synchronous`, `concurrent`, `throughput`, `constant`, `poisson`, or `sweep`
-- `--profile kind=constant,rate=10`: For `constant`/`poisson`, set requests per second in the profile config; for `concurrent`, use `streams=`; for `throughput`, use `max_concurrency=`. For `constant`, `poisson`, and `concurrent`, multiple rates can be specified as a JSON list (e.g., `rate=[1,5,10]`). Rates are sorted ascending, and if a failure constraint (over-saturation, errors) triggers at a given rate, remaining higher rates are skipped.
+- `--profile kind=constant,rate=10`: For `constant`/`poisson`, set requests per second in the profile config; for `concurrent`, use `streams=`; for `throughput`, use `max_concurrency=`
 - `--constraint kind=max_duration,seconds=<seconds>` or `--constraint kind=max_requests,count=<count>`: Limit each strategy by time or request count
 
 ### Dataset Sources

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ guidellm run \
 **Key parameters:**
 
 - `--profile kind=<type>`: Defines the traffic pattern — `synchronous`, `concurrent`, `throughput`, `constant`, `poisson`, or `sweep`
-- `--profile kind=constant,rate=10`: For `constant`/`poisson`, set requests per second in the profile config; for `concurrent`, use `streams=`; for `throughput`, use `max_concurrency=`
+- `--profile kind=constant,rate=10`: For `constant`/`poisson`, set requests per second in the profile config; for `concurrent`, use `streams=`; for `throughput`, use `max_concurrency=`. For `constant`, `poisson`, and `concurrent`, multiple rates can be specified as a JSON list (e.g., `rate=[1,5,10]`). Rates are sorted ascending, and if a failure constraint (over-saturation, errors) triggers at a given rate, remaining higher rates are skipped.
 - `--constraint kind=max_duration,seconds=<seconds>` or `--constraint kind=max_requests,count=<count>`: Limit each strategy by time or request count
 
 ### Dataset Sources

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -178,7 +178,7 @@ guidellm run --profile kind=poisson,rate=16 --seed kind=static,value=42
 | `rate`            | Target rate(s) in requests per second   | `--profile kind=poisson,rate=10` or `--profile '{"kind":"poisson","rate":[10,20]}'` |
 | `max_concurrency` | Maximum concurrent requests to schedule | `--profile kind=poisson,rate=10,max_concurrency=32`                                 |
 
-When multiple rates are specified, they are sorted in ascending order. If a failure constraint (such as over-saturation or excessive errors) triggers at a given rate, all remaining higher rates are skipped.
+When multiple rates are specified and a constraint with `stopping_scope="all"` is configured (e.g., over-saturation or error rate limits), rates must be in ascending order. If such a constraint triggers at a given rate, remaining rates are skipped.
 
 Use `--seed kind=static,value=42` for reproducible Poisson scheduling.
 

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -178,7 +178,7 @@ guidellm run --profile kind=poisson,rate=16 --seed kind=static,value=42
 | `rate`            | Target rate(s) in requests per second   | `--profile kind=poisson,rate=10` or `--profile '{"kind":"poisson","rate":[10,20]}'` |
 | `max_concurrency` | Maximum concurrent requests to schedule | `--profile kind=poisson,rate=10,max_concurrency=32`                                 |
 
-When multiple rates are specified and a constraint with `stopping_scope="all"` is configured (e.g., over-saturation or error rate limits), rates must be in ascending order. If such a constraint triggers at a given rate, remaining rates are skipped.
+When multiple rates are specified and a constraint with `stopping_scope="all"` is configured (e.g., over-saturation or error rate limits), triggering that constraint will skip all remaining rates in the list. For best results, specify rates in ascending order so that only higher (harder) rates are skipped. With non-ascending order, easier rates that follow a failed rate will also be skipped.
 
 Use `--seed kind=static,value=42` for reproducible Poisson scheduling.
 

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -190,7 +190,7 @@ The sweep profile applies a sequence of benchmark strategies to find the optimal
 
 1. It runs a `synchronous` strategy to measure the baseline rate,
 2. then runs a `throughput` strategy to determine peak throughput,
-3. and finally runs a series of asynchronous strategies with rates interpolated between the baseline and maximum throughput. (The number of interpolated strategies is `sweep_size` minus 2.) The asynchronous strategy type is determined by the `strategy_type` profile parameter. The default strategy type is `constant`. During the async phase, if a failure constraint triggers at a given rate, all remaining higher rates are skipped.
+3. and finally runs a series of asynchronous strategies with rates interpolated between the baseline and maximum throughput. (The number of interpolated strategies is `sweep_size` minus 2.) The asynchronous strategy type is determined by the `strategy_type` profile parameter. The default strategy type is `constant`. During the async phase, if a constraint with `stopping_scope="all"` triggers at a given rate, remaining rates are skipped.
 
 For example, to run a sweep with 10 strategies, 10 seconds of rampup, and a strategy type of `poisson`:
 

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -178,6 +178,8 @@ guidellm run --profile kind=poisson,rate=16 --seed kind=static,value=42
 | `rate`            | Target rate(s) in requests per second   | `--profile kind=poisson,rate=10` or `--profile '{"kind":"poisson","rate":[10,20]}'` |
 | `max_concurrency` | Maximum concurrent requests to schedule | `--profile kind=poisson,rate=10,max_concurrency=32`                                 |
 
+When multiple rates are specified, they are sorted in ascending order. If a failure constraint (such as over-saturation or excessive errors) triggers at a given rate, all remaining higher rates are skipped.
+
 Use `--seed kind=static,value=42` for reproducible Poisson scheduling.
 
 You can use the `--override` option to specify a list of rate values, to run a set of Poisson "strategies" (sub-benchmarks) with different rate values. For example, `--profile kind=poisson --override profile.rate 10,20,30` will run a Poisson strategy with 10 requests per second, a Poisson strategy with 20 requests per second, and a Poisson strategy with 30 requests per second.
@@ -188,7 +190,7 @@ The sweep profile applies a sequence of benchmark strategies to find the optimal
 
 1. It runs a `synchronous` strategy to measure the baseline rate,
 2. then runs a `throughput` strategy to determine peak throughput,
-3. and finally runs a series of asynchronous strategies with rates interpolated between the baseline and maximum throughput. (The number of interpolated strategies is `sweep_size` minus 2.) The asynchronous strategy type is determined by the `strategy_type` profile parameter. The default strategy type is `constant`.
+3. and finally runs a series of asynchronous strategies with rates interpolated between the baseline and maximum throughput. (The number of interpolated strategies is `sweep_size` minus 2.) The asynchronous strategy type is determined by the `strategy_type` profile parameter. The default strategy type is `constant`. During the async phase, if a failure constraint triggers at a given rate, all remaining higher rates are skipped.
 
 For example, to run a sweep with 10 strategies, 10 seconds of rampup, and a strategy type of `poisson`:
 

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import Field, PositiveFloat, PositiveInt, field_validator
 
 from guidellm.benchmark.schemas import ProfileArgs
+from guidellm.logger import logger
 from guidellm.scheduler import (
     AsyncConstantStrategy,
     AsyncPoissonStrategy,
@@ -56,7 +57,12 @@ class AsyncProfileArgs(ProfileArgs):
         if not value:
             raise ValueError("rate requires at least one value")
         if isinstance(value, list | tuple):
-            return value
+            sorted_rates = sorted(value)
+            if list(sorted_rates) != list(value):
+                logger.warning(
+                    f"Rates reordered from {list(value)} to {sorted_rates} (ascending)"
+                )
+            return sorted_rates
         if isinstance(value, int | float):
             return [value]
         raise ValueError(
@@ -107,15 +113,22 @@ class AsyncProfile(Profile):
         """
         Generate async strategy for next configured rate.
 
-        :param prev_strategy: Previously completed strategy (unused)
-        :param prev_benchmark: Benchmark results from previous execution (unused)
+        Rates are sorted ascending, so if a previous rate was terminated by a
+        failure constraint (over-saturation, errors, etc.), all remaining higher
+        rates are skipped.
+
+        :param prev_strategy: Previously completed strategy
+        :param prev_benchmark: Benchmark results from previous execution
         :return: AsyncConstantStrategy or AsyncPoissonStrategy for next rate,
-            or None if all rates completed
+            or None if all rates completed or failure detected
         :raises ValueError: If strategy_type is neither 'constant' nor 'poisson'
         """
-        _ = (prev_strategy, prev_benchmark)  # unused
+        _ = prev_strategy
 
         if len(self.completed_strategies) >= len(self.args.rate):
+            return None
+
+        if prev_benchmark is not None and self._should_stop_escalating(prev_benchmark):
             return None
 
         current_rate = self.args.rate[len(self.completed_strategies)]

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import Field, PositiveFloat, PositiveInt, field_validator
 
 from guidellm.benchmark.schemas import ProfileArgs
-from guidellm.logger import logger
 from guidellm.scheduler import (
     AsyncConstantStrategy,
     AsyncPoissonStrategy,
@@ -57,12 +56,7 @@ class AsyncProfileArgs(ProfileArgs):
         if not value:
             raise ValueError("rate requires at least one value")
         if isinstance(value, list | tuple):
-            sorted_rates = sorted(value)
-            if list(sorted_rates) != list(value):
-                logger.warning(
-                    f"Rates reordered from {list(value)} to {sorted_rates} (ascending)"
-                )
-            return sorted_rates
+            return value
         if isinstance(value, int | float):
             return [value]
         raise ValueError(
@@ -98,6 +92,16 @@ class AsyncProfile(Profile):
         else:
             raise ValueError(f"Invalid profile kind: {args.kind}")
 
+        if (
+            len(args.rate) > 1
+            and self._has_escalation_stopping()
+            and list(args.rate) != sorted(args.rate)
+        ):
+            raise ValueError(
+                "Early-exit (stopping_scope='all') requires rates in ascending "
+                f"order, got {list(args.rate)}"
+            )
+
     @property
     def strategy_types(self) -> list[str]:
         """
@@ -113,14 +117,13 @@ class AsyncProfile(Profile):
         """
         Generate async strategy for next configured rate.
 
-        Rates are sorted ascending, so if a previous rate was terminated by a
-        failure constraint (over-saturation, errors, etc.), all remaining higher
-        rates are skipped.
+        If a previous rate was terminated by a constraint with
+        stopping_scope='all', remaining rates are skipped.
 
         :param prev_strategy: Previously completed strategy
         :param prev_benchmark: Benchmark results from previous execution
         :return: AsyncConstantStrategy or AsyncPoissonStrategy for next rate,
-            or None if all rates completed or failure detected
+            or None if all rates completed or escalation halted
         :raises ValueError: If strategy_type is neither 'constant' nor 'poisson'
         """
         _ = prev_strategy

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -92,16 +92,6 @@ class AsyncProfile(Profile):
         else:
             raise ValueError(f"Invalid profile kind: {args.kind}")
 
-        if (
-            len(args.rate) > 1
-            and self._has_escalation_stopping()
-            and list(args.rate) != sorted(args.rate)
-        ):
-            raise ValueError(
-                "Early-exit (stopping_scope='all') requires rates in ascending "
-                f"order, got {list(args.rate)}"
-            )
-
     @property
     def strategy_types(self) -> list[str]:
         """

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -78,16 +78,6 @@ class ConcurrentProfile(Profile):
         super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
-        if (
-            len(args.streams) > 1
-            and self._has_escalation_stopping()
-            and list(args.streams) != sorted(args.streams)
-        ):
-            raise ValueError(
-                "Early-exit (stopping_scope='all') requires streams in ascending "
-                f"order, got {list(args.streams)}"
-            )
-
     @property
     def strategy_types(self) -> list[str]:
         """

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import Field, PositiveInt, field_validator
 
 from guidellm.benchmark.schemas import ProfileArgs
+from guidellm.logger import logger
 from guidellm.scheduler import (
     ConcurrentStrategy,
     ConstraintInitializer,
@@ -48,7 +49,13 @@ class ConcurrentProfileArgs(ProfileArgs):
         if not value:
             raise ValueError("streams requires at least one value")
         if isinstance(value, list | tuple):
-            return [int(stream) for stream in value]
+            streams = [int(stream) for stream in value]
+            sorted_streams = sorted(streams)
+            if sorted_streams != streams:
+                logger.warning(
+                    f"Streams reordered from {streams} to {sorted_streams} (ascending)"
+                )
+            return sorted_streams
         if isinstance(value, int | float):
             return [int(value)]
         raise ValueError(
@@ -93,13 +100,21 @@ class ConcurrentProfile(Profile):
         """
         Generate concurrent strategy for next stream count.
 
-        :param prev_strategy: Previously completed strategy (unused)
-        :param prev_benchmark: Benchmark results from previous execution (unused)
+        Stream counts are sorted ascending, so if a previous stream count was
+        terminated by a failure constraint (over-saturation, errors, etc.), all
+        remaining higher stream counts are skipped.
+
+        :param prev_strategy: Previously completed strategy
+        :param prev_benchmark: Benchmark results from previous execution
         :return: ConcurrentStrategy with next stream count, or None if complete
+            or failure detected
         """
-        _ = (prev_strategy, prev_benchmark)  # unused
+        _ = prev_strategy
 
         if len(self.completed_strategies) >= len(self.args.streams):
+            return None
+
+        if prev_benchmark is not None and self._should_stop_escalating(prev_benchmark):
             return None
 
         return ConcurrentStrategy(

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import Field, PositiveInt, field_validator
 
 from guidellm.benchmark.schemas import ProfileArgs
-from guidellm.logger import logger
 from guidellm.scheduler import (
     ConcurrentStrategy,
     ConstraintInitializer,
@@ -49,13 +48,7 @@ class ConcurrentProfileArgs(ProfileArgs):
         if not value:
             raise ValueError("streams requires at least one value")
         if isinstance(value, list | tuple):
-            streams = [int(stream) for stream in value]
-            sorted_streams = sorted(streams)
-            if sorted_streams != streams:
-                logger.warning(
-                    f"Streams reordered from {streams} to {sorted_streams} (ascending)"
-                )
-            return sorted_streams
+            return [int(stream) for stream in value]
         if isinstance(value, int | float):
             return [int(value)]
         raise ValueError(
@@ -85,6 +78,16 @@ class ConcurrentProfile(Profile):
         super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
+        if (
+            len(args.streams) > 1
+            and self._has_escalation_stopping()
+            and list(args.streams) != sorted(args.streams)
+        ):
+            raise ValueError(
+                "Early-exit (stopping_scope='all') requires streams in ascending "
+                f"order, got {list(args.streams)}"
+            )
+
     @property
     def strategy_types(self) -> list[str]:
         """
@@ -100,14 +103,13 @@ class ConcurrentProfile(Profile):
         """
         Generate concurrent strategy for next stream count.
 
-        Stream counts are sorted ascending, so if a previous stream count was
-        terminated by a failure constraint (over-saturation, errors, etc.), all
-        remaining higher stream counts are skipped.
+        If a previous stream count was terminated by a constraint with
+        stopping_scope='all', remaining stream counts are skipped.
 
         :param prev_strategy: Previously completed strategy
         :param prev_benchmark: Benchmark results from previous execution
         :return: ConcurrentStrategy with next stream count, or None if complete
-            or failure detected
+            or escalation halted
         """
         _ = prev_strategy
 

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -102,14 +102,6 @@ class Profile(ABC):
         self.constraints = dict(constraints or {})
         self.completed_strategies: list[SchedulingStrategy] = []
 
-    def _has_escalation_stopping(self) -> bool:
-        """Check if any constraint is configured with stopping_scope='all'."""
-        for initializer in self.constraints.values():
-            args = getattr(initializer, "args", None)
-            if args is not None and getattr(args, "stopping_scope", "current") == "all":
-                return True
-        return False
-
     @property
     def info(self) -> dict[str, Any]:
         """
@@ -142,9 +134,10 @@ class Profile(ABC):
 
         for name, action in scheduler_state.end_queuing_constraints.items():
             if action.stopping_scope == "all":
-                logger.info(
-                    f"Stopping rate escalation: constraint '{name}' "
-                    f"triggered (stopping_scope=all)"
+                logger.debug(
+                    "Stopping rate escalation: constraint '{}' "
+                    "triggered (stopping_scope=all)",
+                    name,
                 )
                 return True
         return False

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -102,6 +102,14 @@ class Profile(ABC):
         self.constraints = dict(constraints or {})
         self.completed_strategies: list[SchedulingStrategy] = []
 
+    def _has_escalation_stopping(self) -> bool:
+        """Check if any constraint is configured with stopping_scope='all'."""
+        for initializer in self.constraints.values():
+            args = getattr(initializer, "args", None)
+            if args is not None and getattr(args, "stopping_scope", "current") == "all":
+                return True
+        return False
+
     @property
     def info(self) -> dict[str, Any]:
         """
@@ -119,26 +127,24 @@ class Profile(ABC):
     @staticmethod
     def _should_stop_escalating(prev_benchmark: Benchmark) -> bool:
         """
-        Check if a benchmark was terminated by a failure constraint.
+        Check if a benchmark was terminated by a constraint with stopping_scope="all".
 
         Inspects the scheduler state's end_queuing_constraints for any constraint
-        that used "stop_all" for request processing, which indicates the system
-        could not handle the load (over-saturation, excessive errors, etc.).
-        Constraints that use "stop_local" (max duration, max requests) are normal
-        completions and do not trigger escalation stops.
+        whose stopping_scope is "all", indicating the system could not handle the
+        load and escalation to subsequent rates/streams should halt.
 
         :param prev_benchmark: Benchmark instance
-        :return: True if a failure constraint was triggered, False otherwise
+        :return: True if escalation should stop, False otherwise
         """
         scheduler_state = getattr(prev_benchmark, "scheduler_state", None)
         if scheduler_state is None:
             return False
 
         for name, action in scheduler_state.end_queuing_constraints.items():
-            if action.request_processing == "stop_all":
+            if action.stopping_scope == "all":
                 logger.info(
                     f"Stopping rate escalation: constraint '{name}' "
-                    f"triggered (request_processing=stop_all)"
+                    f"triggered (stopping_scope=all)"
                 )
                 return True
         return False

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -9,6 +9,7 @@ from collections.abc import Generator, MutableMapping
 from typing import Any
 
 from guidellm.benchmark.schemas import Benchmark, ProfileArgs
+from guidellm.logger import logger
 from guidellm.scheduler import (
     Constraint,
     ConstraintInitializer,
@@ -114,6 +115,33 @@ class Profile(ABC):
         :return: Strategy types executed or to be executed in this profile
         """
         return [strat.type_ for strat in self.completed_strategies]
+
+    @staticmethod
+    def _should_stop_escalating(prev_benchmark: Benchmark) -> bool:
+        """
+        Check if a benchmark was terminated by a failure constraint.
+
+        Inspects the scheduler state's end_queuing_constraints for any constraint
+        that used "stop_all" for request processing, which indicates the system
+        could not handle the load (over-saturation, excessive errors, etc.).
+        Constraints that use "stop_local" (max duration, max requests) are normal
+        completions and do not trigger escalation stops.
+
+        :param prev_benchmark: Benchmark instance with a scheduler_state attribute
+        :return: True if a failure constraint was triggered, False otherwise
+        """
+        scheduler_state = getattr(prev_benchmark, "scheduler_state", None)
+        if scheduler_state is None:
+            return False
+
+        for name, action in scheduler_state.end_queuing_constraints.items():
+            if action.request_processing == "stop_all":
+                logger.info(
+                    f"Stopping rate escalation: constraint '{name}' "
+                    f"triggered (request_processing=stop_all)"
+                )
+                return True
+        return False
 
     def strategies_generator(
         self,

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -127,7 +127,7 @@ class Profile(ABC):
         Constraints that use "stop_local" (max duration, max requests) are normal
         completions and do not trigger escalation stops.
 
-        :param prev_benchmark: Benchmark instance with a scheduler_state attribute
+        :param prev_benchmark: Benchmark instance
         :return: True if a failure constraint was triggered, False otherwise
         """
         scheduler_state = getattr(prev_benchmark, "scheduler_state", None)

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -97,7 +97,9 @@ class SweepProfile(Profile):
         Generate next strategy in adaptive sweep sequence.
 
         Executes synchronous and throughput strategies first to measure baseline
-        rates, then generates interpolated rates for async strategies.
+        rates, then generates interpolated rates for async strategies. If a
+        failure constraint is triggered during the async phase, all remaining
+        higher rates are skipped.
 
         :param prev_strategy: Previously completed strategy instance
         :param prev_benchmark: Benchmark results from previous strategy execution
@@ -129,6 +131,18 @@ class SweepProfile(Profile):
                     self.args.sweep_size - 1,
                 )
             )[1:]  # don't rerun synchronous
+            # After throughput, fall through to async rate logic below.
+            # Don't check escalation since throughput is designed to push
+            # beyond sustainable load (over-saturation is expected).
+
+        # Stop escalation if a failure constraint was triggered.
+        # The throughput guard above skips this via the != "throughput" check.
+        # Synchronous never reaches here (returns ThroughputStrategy above).
+        if (
+            prev_strategy.type_ != "throughput"
+            and self._should_stop_escalating(prev_benchmark)  # type: ignore[arg-type]
+        ):
+            return None
 
         next_index = (
             len(self.completed_strategies) - 1 - 1

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -132,10 +132,9 @@ class SweepProfile(Profile):
                 )
             )[1:]  # don't rerun synchronous
 
-        # Stop escalation if a failure constraint was triggered during the
-        # async phase. Throughput is excluded (type_ != "throughput") because
-        # it intentionally pushes beyond sustainable load. Synchronous never
-        # reaches here — it returns a ThroughputStrategy above.
+        # Stop escalation if a constraint with stopping_scope='all' triggered
+        # during the async phase. Throughput is excluded because it intentionally
+        # pushes beyond sustainable load. Synchronous never reaches here.
         if (
             prev_strategy.type_ != "throughput"
             and self._should_stop_escalating(prev_benchmark)  # type: ignore[arg-type]

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -131,13 +131,11 @@ class SweepProfile(Profile):
                     self.args.sweep_size - 1,
                 )
             )[1:]  # don't rerun synchronous
-            # After throughput, fall through to async rate logic below.
-            # Don't check escalation since throughput is designed to push
-            # beyond sustainable load (over-saturation is expected).
 
-        # Stop escalation if a failure constraint was triggered.
-        # The throughput guard above skips this via the != "throughput" check.
-        # Synchronous never reaches here (returns ThroughputStrategy above).
+        # Stop escalation if a failure constraint was triggered during the
+        # async phase. Throughput is excluded (type_ != "throughput") because
+        # it intentionally pushes beyond sustainable load. Synchronous never
+        # reaches here — it returns a ThroughputStrategy above.
         if (
             prev_strategy.type_ != "throughput"
             and self._should_stop_escalating(prev_benchmark)  # type: ignore[arg-type]

--- a/src/guidellm/scheduler/constraints/args.py
+++ b/src/guidellm/scheduler/constraints/args.py
@@ -4,7 +4,7 @@ Kind-discriminated constraint argument schemas for benchmark configuration.
 
 from __future__ import annotations
 
-from typing import Annotated, ClassVar
+from typing import Annotated, ClassVar, Literal
 
 from annotated_types import Gt, Lt
 from pydantic import BeforeValidator, ConfigDict, Field
@@ -72,6 +72,15 @@ class ConstraintArgs(PydanticClassRegistryMixin["ConstraintArgs"]):
 
     kind: str = Field(
         description="Constraint type discriminator for polymorphic serialization",
+    )
+
+    stopping_scope: Literal["current", "all"] = Field(
+        default="current",
+        description=(
+            "Whether triggering this constraint should stop only the current "
+            "benchmark ('current') or also halt escalation to subsequent "
+            "rates/streams ('all')."
+        ),
     )
 
     @property

--- a/src/guidellm/scheduler/constraints/error.py
+++ b/src/guidellm/scheduler/constraints/error.py
@@ -159,6 +159,7 @@ class MaxErrorsConstraint(PydanticConstraintInitializer):
         return SchedulerUpdateAction(
             request_queuing="stop" if errors_exceeded else "continue",
             request_processing="stop_all" if errors_exceeded else "continue",
+            stopping_scope=self.args.stopping_scope,
             metadata={
                 "max_errors": max_errors,
                 "errors_exceeded": errors_exceeded,
@@ -238,6 +239,7 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
         return SchedulerUpdateAction(
             request_queuing="stop" if exceeded else "continue",
             request_processing="stop_all" if exceeded else "continue",
+            stopping_scope=self.args.stopping_scope,
             metadata={
                 "max_error_rate": max_error_rate,
                 "window_size": self.args.window,
@@ -316,6 +318,7 @@ class MaxGlobalErrorRateConstraint(PydanticConstraintInitializer):
         return SchedulerUpdateAction(
             request_queuing="stop" if exceeded else "continue",
             request_processing="stop_all" if exceeded else "continue",
+            stopping_scope=self.args.stopping_scope,
             metadata={
                 "max_error_rate": max_error_rate,
                 "min_processed": self.args.minimum,

--- a/src/guidellm/scheduler/constraints/request.py
+++ b/src/guidellm/scheduler/constraints/request.py
@@ -134,6 +134,7 @@ class MaxNumberConstraint(PydanticConstraintInitializer):
         return SchedulerUpdateAction(
             request_queuing="stop" if create_exceeded else "continue",
             request_processing="stop_local" if processed_exceeded else "continue",
+            stopping_scope=self.args.stopping_scope,
             metadata={
                 "max_requests": max_num,
                 "create_exceeded": create_exceeded,
@@ -206,6 +207,7 @@ class MaxDurationConstraint(PydanticConstraintInitializer):
         return SchedulerUpdateAction(
             request_queuing="stop" if duration_exceeded else "continue",
             request_processing="stop_local" if duration_exceeded else "continue",
+            stopping_scope=self.args.stopping_scope,
             metadata={
                 "max_duration": max_duration,
                 "elapsed_time": elapsed,

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -362,6 +362,7 @@ class OverSaturationConstraint(Constraint):
         confidence: float = 0.95,
         eps: float = 1e-12,
         mode: Literal["enforce", "monitor"] = "enforce",
+        stopping_scope: Literal["current", "all"] = "current",
     ) -> None:  # noqa: PLR0913
         """
         Initialize the over-saturation constraint.
@@ -400,6 +401,7 @@ class OverSaturationConstraint(Constraint):
         self.confidence = confidence
         self.eps = eps
         self.mode = mode
+        self.stopping_scope = stopping_scope
         self.reset()
 
     @property
@@ -617,6 +619,7 @@ class OverSaturationConstraint(Constraint):
         return SchedulerUpdateAction(
             request_queuing="stop" if should_stop else "continue",
             request_processing="stop_all" if should_stop else "continue",
+            stopping_scope=self.stopping_scope,
             metadata={
                 "ttft_slope": ttft_slope,
                 "ttft_slope_moe": ttft_slope_moe,
@@ -670,4 +673,5 @@ class OverSaturationConstraintInitializer(PydanticConstraintInitializer):
             minimum_window_size=self.args.minimum_window_size,
             confidence=self.args.confidence,
             mode=self.args.mode,
+            stopping_scope=self.args.stopping_scope,
         )

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -393,7 +393,7 @@ class OverSaturationConstraint(Constraint):
             (default: "enforce")
         :param stopping_scope: Whether to halt only the current benchmark or also prevent escalation to subsequent rates/streams.
             (default: "current")
-       """
+        """
         self.minimum_duration = minimum_duration
         self.minimum_ttft = minimum_ttft
         self.maximum_window_seconds = maximum_window_seconds

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -391,7 +391,9 @@ class OverSaturationConstraint(Constraint):
             (default: 1e-12)
         :param mode: Whether to stop when over-saturation is detected, or only monitor
             (default: "enforce")
-        """
+        :param stopping_scope: Whether to halt only the current benchmark or also prevent escalation to subsequent rates/streams.
+            (default: "current")
+       """
         self.minimum_duration = minimum_duration
         self.minimum_ttft = minimum_ttft
         self.maximum_window_seconds = maximum_window_seconds

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -391,7 +391,8 @@ class OverSaturationConstraint(Constraint):
             (default: 1e-12)
         :param mode: Whether to stop when over-saturation is detected, or only monitor
             (default: "enforce")
-        :param stopping_scope: Whether to halt only the current benchmark or also prevent escalation to subsequent rates/streams.
+        :param stopping_scope: Whether to halt only the current benchmark
+            or also prevent escalation to subsequent rates/streams.
             (default: "current")
         """
         self.minimum_duration = minimum_duration

--- a/src/guidellm/scheduler/schemas.py
+++ b/src/guidellm/scheduler/schemas.py
@@ -288,6 +288,14 @@ class SchedulerUpdateAction(StandardBaseModel):
         default="continue",
         description="Action to take for request processing operations",
     )
+    stopping_scope: Literal["current", "all"] = Field(
+        default="current",
+        description=(
+            "Whether this constraint's stop signal should halt only the current "
+            "benchmark ('current') or also prevent escalation to subsequent "
+            "rates/streams ('all')."
+        ),
+    )
     metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional context and data for the scheduler action",

--- a/tests/unit/benchmark/test_profiles.py
+++ b/tests/unit/benchmark/test_profiles.py
@@ -33,6 +33,8 @@ from guidellm.scheduler import (
     SchedulerUpdateAction,
     SynchronousStrategy,
 )
+from guidellm.scheduler.constraints import MaxErrorsConstraintArgs
+from guidellm.scheduler.constraints.factory import ConstraintsInitializerFactory
 
 MULTI_PROFILE_FACTORIES = (
     "_make_async_profile",
@@ -234,13 +236,6 @@ class TestRateOrdering:
 
     def test_async_ascending_validation_with_escalation_stopping(self):
         """Non-ascending rates with stopping_scope='all' constraint should raise."""
-        from guidellm.scheduler.constraints import (
-            MaxErrorsConstraintArgs,
-        )
-        from guidellm.scheduler.constraints.factory import (
-            ConstraintsInitializerFactory,
-        )
-
         constraint_args = MaxErrorsConstraintArgs(
             kind="max_errors", count=5, stopping_scope="all"
         )
@@ -248,19 +243,10 @@ class TestRateOrdering:
         args = AsyncProfileArgs(kind="constant", rate=[10.0, 5.0, 1.0])
 
         with pytest.raises(ValueError, match="ascending"):
-            AsyncProfile(
-                args, random_seed=42, constraints={"max_errors": initializer}
-            )
+            AsyncProfile(args, random_seed=42, constraints={"max_errors": initializer})
 
     def test_concurrent_ascending_validation_with_escalation_stopping(self):
         """Non-ascending streams with stopping_scope='all' constraint should raise."""
-        from guidellm.scheduler.constraints import (
-            MaxErrorsConstraintArgs,
-        )
-        from guidellm.scheduler.constraints.factory import (
-            ConstraintsInitializerFactory,
-        )
-
         constraint_args = MaxErrorsConstraintArgs(
             kind="max_errors", count=5, stopping_scope="all"
         )

--- a/tests/unit/benchmark/test_profiles.py
+++ b/tests/unit/benchmark/test_profiles.py
@@ -33,8 +33,6 @@ from guidellm.scheduler import (
     SchedulerUpdateAction,
     SynchronousStrategy,
 )
-from guidellm.scheduler.constraints import MaxErrorsConstraintArgs
-from guidellm.scheduler.constraints.factory import ConstraintsInitializerFactory
 
 MULTI_PROFILE_FACTORIES = (
     "_make_async_profile",
@@ -233,42 +231,6 @@ class TestRateOrdering:
         """Streams should NOT be sorted — user order is preserved."""
         args = ConcurrentProfileArgs(kind="concurrent", streams=[16, 4, 1, 8])
         assert args.streams == [16, 4, 1, 8]
-
-    def test_async_ascending_validation_with_escalation_stopping(self):
-        """Non-ascending rates with stopping_scope='all' constraint should raise."""
-        constraint_args = MaxErrorsConstraintArgs(
-            kind="max_errors", count=5, stopping_scope="all"
-        )
-        initializer = ConstraintsInitializerFactory.create(constraint_args)
-        args = AsyncProfileArgs(kind="constant", rate=[10.0, 5.0, 1.0])
-
-        with pytest.raises(ValueError, match="ascending"):
-            AsyncProfile(args, random_seed=42, constraints={"max_errors": initializer})
-
-    def test_concurrent_ascending_validation_with_escalation_stopping(self):
-        """Non-ascending streams with stopping_scope='all' constraint should raise."""
-        constraint_args = MaxErrorsConstraintArgs(
-            kind="max_errors", count=5, stopping_scope="all"
-        )
-        initializer = ConstraintsInitializerFactory.create(constraint_args)
-        args = ConcurrentProfileArgs(kind="concurrent", streams=[8, 4, 2])
-
-        with pytest.raises(ValueError, match="ascending"):
-            ConcurrentProfile(
-                args, random_seed=42, constraints={"max_errors": initializer}
-            )
-
-    def test_async_unsorted_ok_without_escalation_stopping(self):
-        """Non-ascending rates are fine without stopping_scope='all'."""
-        args = AsyncProfileArgs(kind="constant", rate=[10.0, 5.0, 1.0])
-        profile = AsyncProfile(args, random_seed=42, constraints=None)
-        assert profile.args.rate == [10.0, 5.0, 1.0]
-
-    def test_concurrent_unsorted_ok_without_escalation_stopping(self):
-        """Non-ascending streams are fine without stopping_scope='all'."""
-        args = ConcurrentProfileArgs(kind="concurrent", streams=[8, 4, 2])
-        profile = ConcurrentProfile(args, random_seed=42, constraints=None)
-        assert profile.args.streams == [8, 4, 2]
 
 
 # ============================================================================

--- a/tests/unit/benchmark/test_profiles.py
+++ b/tests/unit/benchmark/test_profiles.py
@@ -1,0 +1,454 @@
+"""
+Tests for cross-rate early exit behavior in AsyncProfile, ConcurrentProfile,
+and SweepProfile.
+
+## WRITTEN BY AI ##
+
+Validates that:
+- AsyncProfile and ConcurrentProfile sort rates/streams ascending
+- Failure constraints (stop_all) stop rate escalation
+- Normal completions (stop_local) do not stop rate escalation
+- SweepProfile stops escalation during the async phase but not during throughput
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from guidellm.benchmark.profiles import (
+    AsyncProfile,
+    AsyncProfileArgs,
+    ConcurrentProfile,
+    ConcurrentProfileArgs,
+    Profile,
+    SweepProfile,
+    SweepProfileArgs,
+)
+from guidellm.scheduler import (
+    AsyncConstantStrategy,
+    AsyncPoissonStrategy,
+    ConcurrentStrategy,
+    SchedulerState,
+    SchedulerUpdateAction,
+    SynchronousStrategy,
+)
+
+MULTI_PROFILE_FACTORIES = (
+    "_make_async_profile",
+    "_make_concurrent_profile",
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_mock_benchmark(
+    end_queuing_constraints: dict[str, SchedulerUpdateAction] | None = None,
+    request_throughput_mean: float = 10.0,
+):
+    """
+    Create a lightweight mock benchmark with a scheduler_state.
+
+    Uses SimpleNamespace to avoid constructing a full GenerativeBenchmark,
+    which requires many nested fields.
+    """
+    state = SchedulerState()
+    if end_queuing_constraints:
+        state.end_queuing_constraints = end_queuing_constraints
+
+    throughput = SimpleNamespace(
+        successful=SimpleNamespace(mean=request_throughput_mean),
+    )
+
+    return SimpleNamespace(
+        scheduler_state=state,
+        request_throughput=throughput,
+    )
+
+
+def _make_failure_action(name: str = "test_constraint") -> SchedulerUpdateAction:
+    """Create a SchedulerUpdateAction with stop_all (failure)."""
+    return SchedulerUpdateAction(
+        request_queuing="stop",
+        request_processing="stop_all",
+        metadata={f"{name}_triggered": True},
+    )
+
+
+def _make_normal_completion_action() -> SchedulerUpdateAction:
+    """Create a SchedulerUpdateAction with stop_local (normal completion)."""
+    return SchedulerUpdateAction(
+        request_queuing="stop",
+        request_processing="stop_local",
+        metadata={"duration_exceeded": True},
+    )
+
+
+def _make_failure_benchmark(constraint_name: str = "over_saturation"):
+    """Create a mock benchmark terminated by a stop_all constraint."""
+    return _make_mock_benchmark(
+        end_queuing_constraints={
+            constraint_name: _make_failure_action(constraint_name),
+        }
+    )
+
+
+def _make_normal_benchmark():
+    """Create a mock benchmark that completed normally (stop_local)."""
+    return _make_mock_benchmark(
+        end_queuing_constraints={
+            "max_duration": _make_normal_completion_action(),
+        }
+    )
+
+
+def _make_async_profile(**overrides):
+    """Create an AsyncProfile with the new Args-based API."""
+    defaults = {"kind": "constant", "rate": [1.0, 5.0, 10.0]}
+    defaults.update(overrides)
+    args = AsyncProfileArgs(**defaults)
+    return AsyncProfile(args, random_seed=42, constraints=None)
+
+
+def _make_concurrent_profile(**overrides):
+    """Create a ConcurrentProfile with the new Args-based API."""
+    defaults = {"kind": "concurrent", "streams": [2, 4, 8]}
+    defaults.update(overrides)
+    args = ConcurrentProfileArgs(**defaults)
+    return ConcurrentProfile(args, random_seed=42, constraints=None)
+
+
+def _make_sweep_profile(sweep_size: int = 5, strategy_type: str = "constant"):
+    """Create a SweepProfile with the new Args-based API."""
+    args = SweepProfileArgs(
+        kind="sweep", sweep_size=sweep_size, strategy_type=strategy_type
+    )
+    return SweepProfile(args, random_seed=42, constraints=None)
+
+
+def _advance_sweep_to_async_phase(profile: SweepProfile, sync_rate=2.0, tp_rate=10.0):
+    """
+    Advance a SweepProfile through sync and throughput phases, returning
+    the first async strategy. Mutates profile.completed_strategies.
+
+    Follows the same protocol as strategies_generator: each strategy is
+    appended to completed_strategies before the next next_strategy call.
+    """
+    # Phase 1: synchronous
+    sync_strat = SynchronousStrategy()
+    sync_benchmark = _make_mock_benchmark(request_throughput_mean=sync_rate)
+    throughput_strat = profile.next_strategy(sync_strat, sync_benchmark)
+    profile.completed_strategies.append(sync_strat)
+
+    # Phase 2: throughput
+    throughput_benchmark = _make_mock_benchmark(request_throughput_mean=tp_rate)
+    profile.completed_strategies.append(throughput_strat)
+    first_async_strat = profile.next_strategy(throughput_strat, throughput_benchmark)
+
+    return first_async_strat, throughput_strat
+
+
+# ============================================================================
+# Profile._should_stop_escalating tests
+# ============================================================================
+
+
+class TestShouldStopEscalating:
+    """Tests for the shared Profile._should_stop_escalating static method."""
+
+    def test_stop_all_triggers_escalation_stop(self):
+        """A constraint with request_processing=stop_all should trigger stop."""
+        benchmark = _make_failure_benchmark("over_saturation")
+        assert Profile._should_stop_escalating(benchmark) is True
+
+    def test_stop_local_does_not_trigger(self):
+        """A constraint with request_processing=stop_local should not trigger."""
+        benchmark = _make_normal_benchmark()
+        assert Profile._should_stop_escalating(benchmark) is False
+
+    def test_no_constraints(self):
+        """No constraints triggered means no stop."""
+        benchmark = _make_mock_benchmark(end_queuing_constraints={})
+        assert Profile._should_stop_escalating(benchmark) is False
+
+    def test_no_scheduler_state(self):
+        """Benchmark without scheduler_state should not stop."""
+        benchmark = SimpleNamespace()
+        assert Profile._should_stop_escalating(benchmark) is False
+
+    def test_mixed_constraints_with_one_stop_all(self):
+        """If multiple constraints present and one is stop_all, should stop."""
+        benchmark = _make_mock_benchmark(
+            end_queuing_constraints={
+                "max_duration": _make_normal_completion_action(),
+                "over_saturation": _make_failure_action("over_saturation"),
+            }
+        )
+        assert Profile._should_stop_escalating(benchmark) is True
+
+    def test_multiple_stop_local_does_not_trigger(self):
+        """Multiple stop_local constraints should not trigger stop."""
+        benchmark = _make_mock_benchmark(
+            end_queuing_constraints={
+                "max_duration": _make_normal_completion_action(),
+                "max_requests": _make_normal_completion_action(),
+            }
+        )
+        assert Profile._should_stop_escalating(benchmark) is False
+
+
+# ============================================================================
+# Rate/stream sorting tests
+# ============================================================================
+
+
+class TestRateSorting:
+    """Rates and streams should be sorted ascending by Pydantic validators."""
+
+    @pytest.mark.parametrize(
+        ("unsorted_input", "sorted_output"),
+        [
+            ([50.0, 10.0, 1.0, 25.0], [1.0, 10.0, 25.0, 50.0]),
+            ([1.0, 5.0, 10.0], [1.0, 5.0, 10.0]),
+            ([5.0], [5.0]),
+        ],
+        ids=["unsorted", "sorted", "single"],
+    )
+    def test_async_rate_sorting(self, unsorted_input, sorted_output):
+        args = AsyncProfileArgs(kind="constant", rate=unsorted_input)
+        assert args.rate == sorted_output
+
+    @pytest.mark.parametrize(
+        ("unsorted_input", "sorted_output"),
+        [
+            ([16, 4, 1, 8], [1, 4, 8, 16]),
+            ([2, 4, 8], [2, 4, 8]),
+            ([4], [4]),
+        ],
+        ids=["unsorted", "sorted", "single"],
+    )
+    def test_concurrent_stream_sorting(self, unsorted_input, sorted_output):
+        args = ConcurrentProfileArgs(kind="concurrent", streams=unsorted_input)
+        assert args.streams == sorted_output
+
+
+# ============================================================================
+# Cross-rate early exit tests (parametrized across AsyncProfile & ConcurrentProfile)
+# ============================================================================
+
+
+class TestMultiRateProfileEarlyExit:
+    """
+    Tests for next_strategy() cross-rate early exit, parametrized across
+    AsyncProfile and ConcurrentProfile which share the same behavior.
+    """
+
+    @staticmethod
+    def _make_async_profile():
+        profile = _make_async_profile(rate=[1.0, 5.0, 10.0])
+        first = AsyncConstantStrategy(rate=1.0)
+        return profile, first
+
+    @staticmethod
+    def _make_concurrent_profile():
+        profile = _make_concurrent_profile(streams=[2, 4, 8])
+        first = ConcurrentStrategy(streams=2)
+        return profile, first
+
+    @pytest.mark.parametrize("make_profile", MULTI_PROFILE_FACTORIES)
+    def test_normal_completion_continues(self, make_profile):
+        """After normal completion (stop_local), should advance to next rate."""
+        profile, first_strategy = getattr(self, make_profile)()
+        profile.completed_strategies.append(first_strategy)
+
+        next_strat = profile.next_strategy(first_strategy, _make_normal_benchmark())
+
+        assert next_strat is not None
+
+    @pytest.mark.parametrize("make_profile", MULTI_PROFILE_FACTORIES)
+    def test_failure_stops(self, make_profile):
+        """After failure (stop_all), should return None."""
+        profile, first_strategy = getattr(self, make_profile)()
+        profile.completed_strategies.append(first_strategy)
+
+        next_strat = profile.next_strategy(first_strategy, _make_failure_benchmark())
+
+        assert next_strat is None
+
+    @pytest.mark.parametrize("make_profile", MULTI_PROFILE_FACTORIES)
+    def test_first_rate_always_runs(self, make_profile):
+        """First rate should always run (no previous benchmark)."""
+        profile, _ = getattr(self, make_profile)()
+
+        next_strat = profile.next_strategy(None, None)
+
+        assert next_strat is not None
+
+    @pytest.mark.parametrize("make_profile", MULTI_PROFILE_FACTORIES)
+    def test_all_rates_completed_returns_none(self, make_profile):
+        """When all rates are done, should return None regardless."""
+        profile, first_strategy = getattr(self, make_profile)()
+        num_rates = len(
+            profile.args.rate if hasattr(profile.args, "rate") else profile.args.streams
+        )
+        for _ in range(num_rates):
+            profile.completed_strategies.append(first_strategy)
+
+        next_strat = profile.next_strategy(first_strategy, _make_mock_benchmark())
+
+        assert next_strat is None
+
+    def test_middle_rate_failure_skips_remaining(self):
+        """Rate 1 succeeds, rate 2 succeeds, rate 3 fails, rate 4 is skipped.
+
+        This is the core use case: the system handles low rates fine but
+        fails at a mid-range rate, and higher rates are not attempted.
+        """
+        profile = _make_async_profile(rate=[1.0, 5.0, 10.0, 50.0])
+
+        # Rate 1 (1.0 RPS): succeeds
+        strat_1 = profile.next_strategy(None, None)
+        assert strat_1 is not None
+        assert strat_1.rate == 1.0
+        profile.completed_strategies.append(strat_1)
+
+        # Rate 2 (5.0 RPS): succeeds
+        strat_2 = profile.next_strategy(strat_1, _make_normal_benchmark())
+        assert strat_2 is not None
+        assert strat_2.rate == 5.0
+        profile.completed_strategies.append(strat_2)
+
+        # Rate 3 (10.0 RPS): runs
+        strat_3 = profile.next_strategy(strat_2, _make_normal_benchmark())
+        assert strat_3 is not None
+        assert strat_3.rate == 10.0
+        profile.completed_strategies.append(strat_3)
+
+        # Rate 4 (50.0 RPS): should be skipped because rate 3 failed
+        strat_4 = profile.next_strategy(strat_3, _make_failure_benchmark())
+        assert strat_4 is None
+
+    def test_poisson_strategy_early_exit(self):
+        """Poisson strategy type should work through the same early-exit path."""
+        profile = _make_async_profile(kind="poisson", rate=[1.0, 5.0, 10.0])
+
+        strat_1 = profile.next_strategy(None, None)
+        assert strat_1 is not None
+        assert isinstance(strat_1, AsyncPoissonStrategy)
+        assert strat_1.rate == 1.0
+        profile.completed_strategies.append(strat_1)
+
+        # First rate fails -> second rate skipped
+        strat_2 = profile.next_strategy(strat_1, _make_failure_benchmark())
+        assert strat_2 is None
+
+
+# ============================================================================
+# SweepProfile cross-rate early exit tests
+# ============================================================================
+
+
+class TestSweepProfileEarlyExit:
+    """Tests for SweepProfile.next_strategy() cross-rate early exit."""
+
+    def test_sync_and_throughput_always_run(self):
+        """Synchronous and throughput phases should always run."""
+        profile = _make_sweep_profile()
+
+        strat = profile.next_strategy(None, None)
+        assert strat is not None
+        assert strat.type_ == "synchronous"
+
+    def test_throughput_runs_after_sync_with_failure(self):
+        """Throughput always runs after sync (sync returns early before check)."""
+        profile = _make_sweep_profile()
+
+        sync_strategy = SynchronousStrategy()
+        sync_benchmark = _make_mock_benchmark(
+            request_throughput_mean=5.0,
+            end_queuing_constraints={
+                "over_saturation": _make_failure_action("over_saturation"),
+            },
+        )
+
+        strat = profile.next_strategy(sync_strategy, sync_benchmark)
+        assert strat is not None
+        assert strat.type_ == "throughput"
+
+    def test_throughput_failure_does_not_stop(self):
+        """No failure during throughput should stop the sweep.
+
+        Throughput pushes the system to its limit by design, so all failure
+        checks are skipped after the throughput phase.
+        """
+        profile = _make_sweep_profile(sweep_size=5)
+
+        sync_strat = SynchronousStrategy()
+        sync_benchmark = _make_mock_benchmark(request_throughput_mean=2.0)
+        throughput_strat = profile.next_strategy(sync_strat, sync_benchmark)
+        profile.completed_strategies.append(sync_strat)
+
+        throughput_benchmark = _make_mock_benchmark(
+            request_throughput_mean=10.0,
+            end_queuing_constraints={
+                "over_saturation": _make_failure_action("over_saturation"),
+            },
+        )
+        profile.completed_strategies.append(throughput_strat)
+        first_async_strat = profile.next_strategy(
+            throughput_strat, throughput_benchmark
+        )
+
+        assert first_async_strat is not None
+
+    def test_async_phase_stops_on_failure(self):
+        """During async phase, stop_all constraint should stop remaining rates."""
+        profile = _make_sweep_profile(sweep_size=5)
+        first_async_strat, _ = _advance_sweep_to_async_phase(profile)
+        assert first_async_strat is not None
+
+        profile.completed_strategies.append(first_async_strat)
+        next_strat = profile.next_strategy(first_async_strat, _make_failure_benchmark())
+
+        assert next_strat is None
+
+    def test_async_phase_continues_on_normal_completion(self):
+        """During async phase, stop_local should advance to next rate."""
+        profile = _make_sweep_profile(sweep_size=5)
+        first_async_strat, _ = _advance_sweep_to_async_phase(profile)
+        assert first_async_strat is not None
+
+        profile.completed_strategies.append(first_async_strat)
+        next_strat = profile.next_strategy(first_async_strat, _make_normal_benchmark())
+
+        assert next_strat is not None
+
+    def test_sweep_size_2_no_async_phase(self):
+        """With sweep_size=2, only sync + throughput run; no async phase.
+
+        Verifies the escalation check is never reached and the profile
+        completes cleanly without generating any async rates.
+        """
+        profile = _make_sweep_profile(sweep_size=2)
+
+        # Phase 1: synchronous
+        sync_strat = profile.next_strategy(None, None)
+        assert sync_strat is not None
+        assert sync_strat.type_ == "synchronous"
+        profile.completed_strategies.append(sync_strat)
+
+        # Phase 2: throughput
+        sync_benchmark = _make_mock_benchmark(request_throughput_mean=5.0)
+        throughput_strat = profile.next_strategy(sync_strat, sync_benchmark)
+        assert throughput_strat is not None
+        assert throughput_strat.type_ == "throughput"
+        profile.completed_strategies.append(throughput_strat)
+
+        # Phase 3: should be None — no async rates generated
+        throughput_benchmark = _make_mock_benchmark(request_throughput_mean=10.0)
+        next_strat = profile.next_strategy(throughput_strat, throughput_benchmark)
+
+        assert profile.measured_rates == []
+        assert next_strat is None

--- a/tests/unit/benchmark/test_profiles.py
+++ b/tests/unit/benchmark/test_profiles.py
@@ -5,10 +5,11 @@ and SweepProfile.
 ## WRITTEN BY AI ##
 
 Validates that:
-- AsyncProfile and ConcurrentProfile sort rates/streams ascending
-- Failure constraints (stop_all) stop rate escalation
+- AsyncProfile and ConcurrentProfile preserve user-specified rate/stream ordering
+- Constraints with stopping_scope='all' stop rate escalation
 - Normal completions (stop_local) do not stop rate escalation
 - SweepProfile stops escalation during the async phase but not during throughput
+- Ascending order is validated when early-exit constraints are configured
 """
 
 from types import SimpleNamespace
@@ -69,10 +70,11 @@ def _make_mock_benchmark(
 
 
 def _make_failure_action(name: str = "test_constraint") -> SchedulerUpdateAction:
-    """Create a SchedulerUpdateAction with stop_all (failure)."""
+    """Create a SchedulerUpdateAction with stopping_scope='all' (escalation stop)."""
     return SchedulerUpdateAction(
         request_queuing="stop",
         request_processing="stop_all",
+        stopping_scope="all",
         metadata={f"{name}_triggered": True},
     )
 
@@ -87,7 +89,7 @@ def _make_normal_completion_action() -> SchedulerUpdateAction:
 
 
 def _make_failure_benchmark(constraint_name: str = "over_saturation"):
-    """Create a mock benchmark terminated by a stop_all constraint."""
+    """Create a mock benchmark terminated by a stopping_scope='all' constraint."""
     return _make_mock_benchmark(
         end_queuing_constraints={
             constraint_name: _make_failure_action(constraint_name),
@@ -158,14 +160,27 @@ def _advance_sweep_to_async_phase(profile: SweepProfile, sync_rate=2.0, tp_rate=
 class TestShouldStopEscalating:
     """Tests for the shared Profile._should_stop_escalating static method."""
 
-    def test_stop_all_triggers_escalation_stop(self):
-        """A constraint with request_processing=stop_all should trigger stop."""
+    def test_stopping_scope_all_triggers_escalation_stop(self):
+        """A constraint with stopping_scope='all' should trigger stop."""
         benchmark = _make_failure_benchmark("over_saturation")
         assert Profile._should_stop_escalating(benchmark) is True
 
     def test_stop_local_does_not_trigger(self):
         """A constraint with request_processing=stop_local should not trigger."""
         benchmark = _make_normal_benchmark()
+        assert Profile._should_stop_escalating(benchmark) is False
+
+    def test_stop_all_without_stopping_scope_does_not_trigger(self):
+        """stop_all alone (stopping_scope='current') should NOT trigger stop."""
+        action = SchedulerUpdateAction(
+            request_queuing="stop",
+            request_processing="stop_all",
+            stopping_scope="current",
+            metadata={"test": True},
+        )
+        benchmark = _make_mock_benchmark(
+            end_queuing_constraints={"test_constraint": action}
+        )
         assert Profile._should_stop_escalating(benchmark) is False
 
     def test_no_constraints(self):
@@ -178,8 +193,8 @@ class TestShouldStopEscalating:
         benchmark = SimpleNamespace()
         assert Profile._should_stop_escalating(benchmark) is False
 
-    def test_mixed_constraints_with_one_stop_all(self):
-        """If multiple constraints present and one is stop_all, should stop."""
+    def test_mixed_constraints_with_one_stopping_scope_all(self):
+        """With one stopping_scope='all' among multiple constraints, should stop."""
         benchmark = _make_mock_benchmark(
             end_queuing_constraints={
                 "max_duration": _make_normal_completion_action(),
@@ -200,38 +215,74 @@ class TestShouldStopEscalating:
 
 
 # ============================================================================
-# Rate/stream sorting tests
+# Rate/stream ordering tests
 # ============================================================================
 
 
-class TestRateSorting:
-    """Rates and streams should be sorted ascending by Pydantic validators."""
+class TestRateOrdering:
+    """Rates and streams should preserve user-specified order."""
 
-    @pytest.mark.parametrize(
-        ("unsorted_input", "sorted_output"),
-        [
-            ([50.0, 10.0, 1.0, 25.0], [1.0, 10.0, 25.0, 50.0]),
-            ([1.0, 5.0, 10.0], [1.0, 5.0, 10.0]),
-            ([5.0], [5.0]),
-        ],
-        ids=["unsorted", "sorted", "single"],
-    )
-    def test_async_rate_sorting(self, unsorted_input, sorted_output):
-        args = AsyncProfileArgs(kind="constant", rate=unsorted_input)
-        assert args.rate == sorted_output
+    def test_async_rates_preserved(self):
+        """Rates should NOT be sorted — user order is preserved."""
+        args = AsyncProfileArgs(kind="constant", rate=[50.0, 10.0, 1.0, 25.0])
+        assert args.rate == [50.0, 10.0, 1.0, 25.0]
 
-    @pytest.mark.parametrize(
-        ("unsorted_input", "sorted_output"),
-        [
-            ([16, 4, 1, 8], [1, 4, 8, 16]),
-            ([2, 4, 8], [2, 4, 8]),
-            ([4], [4]),
-        ],
-        ids=["unsorted", "sorted", "single"],
-    )
-    def test_concurrent_stream_sorting(self, unsorted_input, sorted_output):
-        args = ConcurrentProfileArgs(kind="concurrent", streams=unsorted_input)
-        assert args.streams == sorted_output
+    def test_concurrent_streams_preserved(self):
+        """Streams should NOT be sorted — user order is preserved."""
+        args = ConcurrentProfileArgs(kind="concurrent", streams=[16, 4, 1, 8])
+        assert args.streams == [16, 4, 1, 8]
+
+    def test_async_ascending_validation_with_escalation_stopping(self):
+        """Non-ascending rates with stopping_scope='all' constraint should raise."""
+        from guidellm.scheduler.constraints import (
+            MaxErrorsConstraintArgs,
+        )
+        from guidellm.scheduler.constraints.factory import (
+            ConstraintsInitializerFactory,
+        )
+
+        constraint_args = MaxErrorsConstraintArgs(
+            kind="max_errors", count=5, stopping_scope="all"
+        )
+        initializer = ConstraintsInitializerFactory.create(constraint_args)
+        args = AsyncProfileArgs(kind="constant", rate=[10.0, 5.0, 1.0])
+
+        with pytest.raises(ValueError, match="ascending"):
+            AsyncProfile(
+                args, random_seed=42, constraints={"max_errors": initializer}
+            )
+
+    def test_concurrent_ascending_validation_with_escalation_stopping(self):
+        """Non-ascending streams with stopping_scope='all' constraint should raise."""
+        from guidellm.scheduler.constraints import (
+            MaxErrorsConstraintArgs,
+        )
+        from guidellm.scheduler.constraints.factory import (
+            ConstraintsInitializerFactory,
+        )
+
+        constraint_args = MaxErrorsConstraintArgs(
+            kind="max_errors", count=5, stopping_scope="all"
+        )
+        initializer = ConstraintsInitializerFactory.create(constraint_args)
+        args = ConcurrentProfileArgs(kind="concurrent", streams=[8, 4, 2])
+
+        with pytest.raises(ValueError, match="ascending"):
+            ConcurrentProfile(
+                args, random_seed=42, constraints={"max_errors": initializer}
+            )
+
+    def test_async_unsorted_ok_without_escalation_stopping(self):
+        """Non-ascending rates are fine without stopping_scope='all'."""
+        args = AsyncProfileArgs(kind="constant", rate=[10.0, 5.0, 1.0])
+        profile = AsyncProfile(args, random_seed=42, constraints=None)
+        assert profile.args.rate == [10.0, 5.0, 1.0]
+
+    def test_concurrent_unsorted_ok_without_escalation_stopping(self):
+        """Non-ascending streams are fine without stopping_scope='all'."""
+        args = ConcurrentProfileArgs(kind="concurrent", streams=[8, 4, 2])
+        profile = ConcurrentProfile(args, random_seed=42, constraints=None)
+        assert profile.args.streams == [8, 4, 2]
 
 
 # ============================================================================
@@ -269,7 +320,7 @@ class TestMultiRateProfileEarlyExit:
 
     @pytest.mark.parametrize("make_profile", MULTI_PROFILE_FACTORIES)
     def test_failure_stops(self, make_profile):
-        """After failure (stop_all), should return None."""
+        """After stopping_scope='all' trigger, should return None."""
         profile, first_strategy = getattr(self, make_profile)()
         profile.completed_strategies.append(first_strategy)
 
@@ -404,7 +455,7 @@ class TestSweepProfileEarlyExit:
         assert first_async_strat is not None
 
     def test_async_phase_stops_on_failure(self):
-        """During async phase, stop_all constraint should stop remaining rates."""
+        """During async phase, stopping_scope='all' should stop remaining rates."""
         profile = _make_sweep_profile(sweep_size=5)
         first_async_strat, _ = _advance_sweep_to_async_phase(profile)
         assert first_async_strat is not None


### PR DESCRIPTION
## Summary

This PR adds cross-rate early-exit behavior for multi-rate benchmark profiles so benchmarks stop escalating once a terminal failure condition is hit at a lower rate/stream. It also makes rate/stream ordering deterministic (ascending) and updates user-facing docs/help text to reflect multi-rate semantics and skip behavior.

## Details

- Added shared failure-check logic in profile flow to detect terminal scheduler constraints (`request_processing=stop_all`) from the previous benchmark state.
- Updated `AsyncProfile.next_strategy()` to stop scheduling higher rates after a terminal failure; continue normally on `stop_local`.
- Updated `ConcurrentProfile.next_strategy()` with the same early-exit behavior for stream escalation.
- Updated `SweepProfile.next_strategy()` so `synchronous` and `throughput` always run, with early-exit applied only during async-rate continuation.
- Sorted multi-value rates/streams ascending in argument resolution for deterministic progression; added warning logs when input order is changed.
- Updated CLI help and README to document per-profile `--rate` semantics, multi-value behavior, and failure-triggered skipping.
- Added unit tests covering:
  - sorting behavior
  - continuation on normal completion (`stop_local`)
  - early exit on terminal failures (`stop_all`)
  - sweep-specific phase behavior and edge cases

## Test Plan

- Run unit tests for benchmark profiles:
  - `pytest tests/unit/benchmark/test_profiles.py`
- Sanity-check existing benchmark profile tests still pass:
  - `pytest tests/unit/benchmark -k profile`
- Run a multi-rate benchmark and verify higher rates are skipped after a terminal failure:
  - `guidellm benchmark ... --profile constant --rate 1 --rate 5 --rate 10`

## Related Issues

- Resolves https://github.com/vllm-project/guidellm/issues/604

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)

<!-- begin:squash-data -->

---

# git log

commit 577e1b9aaedada851bce96931aef4aaa6896f999
Author: Uri Shaket <ushaket@redhat.com>
Date:   Sun Feb 15 13:56:30 2026 +0200

    Add cross-rate early exit for multi-rate benchmark profiles
    
    When running multiple rates (constant, poisson, concurrent profiles) or
    sweeping, stop escalating to higher rates if a failure constraint
    (over-saturation, max errors, error rate) triggers at a lower rate.
    
    - Sort rates/streams ascending in AsyncProfile and ConcurrentProfile
    - Add _should_stop_escalating() on base Profile class using stop_all
      as the failure signal (vs stop_local for normal completions)
    - Skip failure check after throughput phase in SweepProfile since
      over-saturation is expected at maximum load
    - Log warning when rate order is changed by sorting
    - Update CLI help and README with multi-rate documentation
    - Add comprehensive unit tests for all profile types
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>

commit db623461e0ca2a90037828eb8a9cf8672d452720
Author: Uri Shaket <ushaket@redhat.com>
Date:   Mon Jun 29 16:40:30 2026 +0300

    Address review feedback: fix docs, comments, and docstring
    
    - Simplify _should_stop_escalating param docstring (not a precondition)
    - Consolidate sweep.py early-exit comments into one clear block
    - Revert README multi-rate sentence, move docs to getting-started/benchmark.md
    - Add early-exit behavior notes to Concurrent, Constant, Poisson, Sweep sections
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>

commit 37895189fc92fa440a134d67957810d347ae0d80
Author: Uri Shaket <ushaket@redhat.com>
Date:   Wed Jul 8 12:46:36 2026 +0300

    CR
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit 95b52fd5d707f80915005061dfd93f3ec0877bdc
Author: Uri Shaket <ushaket@redhat.com>
Date:   Wed Jul 8 13:34:14 2026 +0300

    fix tests
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit d98ba5d99615f7671ffdce180bf899457cee999b
Author: Uri Shaket <ushaket@redhat.com>
Date:   Thu Jul 9 20:49:15 2026 +0300

    CR
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit 1e429538e22d77b2ac94d1a86d40982a9987edf5
Author: Uri Shaket <ushaket@redhat.com>
Date:   Sun Jul 12 10:37:56 2026 +0300

    CR
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit 3a3a8479785a4ebdb92257c4dc5fd73dcb71d340
Author: Uri Shaket <ushaket@redhat.com>
Date:   Tue Jul 14 20:40:28 2026 +0300

    Update src/guidellm/scheduler/constraints/saturation.py
    
    Co-authored-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit d058ff2d324dddc0c33a13d0aefdd2c12539d888
Author: Uri Shaket <ushaket@redhat.com>
Date:   Tue Jul 14 21:00:02 2026 +0300

    fix lint
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit ce09cdad9864cb4b71141fbd813435f42443a6f2
Author: Uri Shaket <ushaket@redhat.com>
Date:   Tue Jul 14 21:03:52 2026 +0300

    fix lint
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

---------

Co-authored-by: Cursor <cursoragent@cursor.com>
Co-authored-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Signed-off-by: Uri Shaket <ushaket@redhat.com>
