### PR TITLE
Fix worker status for unusable terminal backend responses

### DIFF
--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -483,6 +483,7 @@ class OpenAIHTTPBackend(Backend):
         response.raise_for_status()
         data = response.json()
         gen_response = request_handler.compile_non_streaming(request, arguments, data)
+        request_handler.post_validation(gen_response)
         yield gen_response, request_info
         self._check_tool_call_expectations(request, gen_response)
 
@@ -553,6 +554,7 @@ class OpenAIHTTPBackend(Backend):
 
             request_info.timings.request_end = time.time()
             gen_response = request_handler.compile_streaming(request, arguments)
+            request_handler.post_validation(gen_response)
             self._check_tool_call_expectations(request, gen_response)
             yield gen_response, request_info
         except asyncio.CancelledError as err:

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -341,6 +341,24 @@ def _apply_tool_call_metrics(
         output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
 
+def _validate_text_response(response: GenerationResponse) -> None:
+    """Reject a compiled response that has no usable output.
+
+    A response is considered usable if it has non-empty text, tool calls,
+    or output tokens. Used by text/chat completions and responses handlers.
+
+    :param response: The compiled generation response to validate.
+    :raises ValueError: If the response contains no usable output.
+    """
+    has_text = bool(response.text and response.text.strip())
+    has_tool_calls = bool(response.tool_calls)
+    output_tokens = response.output_metrics.total_tokens or 0
+    if not has_text and not has_tool_calls and output_tokens <= 0:
+        raise ValueError(
+            "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty response payload"
+        )
+
+
 _DEFAULT_REASONING_TEMPLATE = "<think>{reasoning}</think>"
 
 
@@ -596,14 +614,8 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         )
 
     def post_validation(self, response: GenerationResponse) -> None:
-        has_text = bool(response.text and response.text.strip())
-        has_tool_calls = bool(response.tool_calls)
-        output_tokens = response.output_metrics.total_tokens or 0
-        if not has_text and not has_tool_calls and output_tokens <= 0:
-            raise ValueError(
-                "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty "
-                "response payload"
-            )
+        """Reject responses with no text, tool calls, or output tokens."""
+        _validate_text_response(response)
 
     def extract_line_data(self, line: str) -> dict[str, Any] | None:
         """
@@ -1883,14 +1895,8 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         )
 
     def post_validation(self, response: GenerationResponse) -> None:
-        has_text = bool(response.text and response.text.strip())
-        has_tool_calls = bool(response.tool_calls)
-        output_tokens = response.output_metrics.total_tokens or 0
-        if not has_text and not has_tool_calls and output_tokens <= 0:
-            raise ValueError(
-                "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty "
-                "response payload"
-            )
+        """Reject responses with no text, tool calls, or output tokens."""
+        _validate_text_response(response)
 
     def extract_line_data(self, line: str) -> dict[str, Any] | None:
         """Parse a Responses API SSE line.
@@ -2192,7 +2198,7 @@ class PoolingRequestHandler(ChatCompletionsRequestHandler):
     """
 
     def post_validation(self, response: GenerationResponse) -> None:  # noqa: ARG002
-        pass
+        """Pooling responses produce non-text output; skip validation."""
 
     def format(
         self,

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -581,8 +581,8 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         output_tokens = response.output_metrics.total_tokens or 0
         if not has_text and output_tokens <= 0:
             raise ValueError(
-                "[UNUSABLE_BACKEND_RESPONSE] backend resolved without a usable "
-                "terminal response payload"
+                "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty "
+                "response payload"
             )
 
     def extract_line_data(self, line: str) -> dict[str, Any] | None:

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -512,7 +512,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         text = choice.get("text", "")
         input_metrics, output_metrics = self.extract_metrics(usage, text)
 
-        return GenerationResponse(
+        compiled = GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),  # use vLLM ID if available
@@ -520,6 +520,8 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
+        self._validate_compiled_response(compiled)
+        return compiled
 
     def add_streaming_line(self, line: str) -> int | None:
         """
@@ -562,7 +564,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         text = "".join(self.streaming_texts)
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
 
-        return GenerationResponse(
+        compiled = GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=self.streaming_response_id,  # use vLLM ID if available
@@ -570,6 +572,18 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
+        self._validate_compiled_response(compiled)
+        return compiled
+
+    def _validate_compiled_response(self, response: GenerationResponse) -> None:
+        """Raise when endpoint produced a terminal payload with no usable output."""
+        has_text = bool(response.text and response.text.strip())
+        output_tokens = response.output_metrics.total_tokens or 0
+        if not has_text and output_tokens <= 0:
+            raise ValueError(
+                "[UNUSABLE_BACKEND_RESPONSE] backend resolved without a usable "
+                "terminal response payload"
+            )
 
     def extract_line_data(self, line: str) -> dict[str, Any] | None:
         """
@@ -1074,7 +1088,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             output_metrics, len(tool_calls) if tool_calls else 0, text
         )
 
-        return GenerationResponse(
+        compiled = GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),  # use vLLM ID if available
@@ -1084,6 +1098,8 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
+        self._validate_compiled_response(compiled)
+        return compiled
 
     def add_streaming_line(self, line: str) -> int | None:
         """
@@ -1175,7 +1191,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         :param request: Original generation request
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
-        return _compile_streaming_response(
+        compiled = _compile_streaming_response(
             request,
             arguments,
             self.streaming_texts,
@@ -1185,6 +1201,8 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.extract_metrics,
             streaming_reasoning_texts=self.streaming_reasoning_texts,
         )
+        self._validate_compiled_response(compiled)
+        return compiled
 
 
 @OpenAIRequestHandlerFactory.register(

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -126,6 +126,18 @@ class OpenAIRequestHandler(Protocol):
         """
         ...
 
+    def post_validation(self, response: GenerationResponse) -> None:
+        """Validate a compiled response before returning it.
+
+        Default implementation is permissive (no-op). Handlers override
+        this to reject responses that lack usable output for their
+        endpoint type.
+
+        :param response: The compiled generation response to validate.
+        :raises ValueError: If the response is unusable.
+        """
+        ...
+
 
 class OpenAIRequestHandlerFactory(RegistryMixin[type[OpenAIRequestHandler]]):
     """
@@ -269,6 +281,18 @@ class OpenAIWSRequestHandler(Protocol):
         :param request: Original generation request
         :param arguments: Request arguments from format()
         :return: Standardized GenerationResponse with extracted metrics
+        """
+        ...
+
+    def post_validation(self, response: GenerationResponse) -> None:
+        """Validate a compiled response before returning it.
+
+        Default implementation is permissive (no-op). Handlers override
+        this to reject responses that lack usable output for their
+        endpoint type.
+
+        :param response: The compiled generation response to validate.
+        :raises ValueError: If the response is unusable.
         """
         ...
 
@@ -512,7 +536,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         text = choice.get("text", "")
         input_metrics, output_metrics = self.extract_metrics(usage, text)
 
-        compiled = GenerationResponse(
+        return GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),  # use vLLM ID if available
@@ -520,8 +544,6 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
-        self._validate_compiled_response(compiled)
-        return compiled
 
     def add_streaming_line(self, line: str) -> int | None:
         """
@@ -564,7 +586,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         text = "".join(self.streaming_texts)
         input_metrics, output_metrics = self.extract_metrics(self.streaming_usage, text)
 
-        compiled = GenerationResponse(
+        return GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=self.streaming_response_id,  # use vLLM ID if available
@@ -572,14 +594,12 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
-        self._validate_compiled_response(compiled)
-        return compiled
 
-    def _validate_compiled_response(self, response: GenerationResponse) -> None:
-        """Raise when endpoint produced a terminal payload with no usable output."""
+    def post_validation(self, response: GenerationResponse) -> None:
         has_text = bool(response.text and response.text.strip())
+        has_tool_calls = bool(response.tool_calls)
         output_tokens = response.output_metrics.total_tokens or 0
-        if not has_text and output_tokens <= 0:
+        if not has_text and not has_tool_calls and output_tokens <= 0:
             raise ValueError(
                 "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty "
                 "response payload"
@@ -1088,7 +1108,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             output_metrics, len(tool_calls) if tool_calls else 0, text
         )
 
-        compiled = GenerationResponse(
+        return GenerationResponse(
             request_id=request.request_id,
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),  # use vLLM ID if available
@@ -1098,8 +1118,6 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             input_metrics=input_metrics,
             output_metrics=output_metrics,
         )
-        self._validate_compiled_response(compiled)
-        return compiled
 
     def add_streaming_line(self, line: str) -> int | None:
         """
@@ -1191,7 +1209,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         :param request: Original generation request
         :return: Standardized GenerationResponse with concatenated content and metrics
         """
-        compiled = _compile_streaming_response(
+        return _compile_streaming_response(
             request,
             arguments,
             self.streaming_texts,
@@ -1201,8 +1219,6 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.extract_metrics,
             streaming_reasoning_texts=self.streaming_reasoning_texts,
         )
-        self._validate_compiled_response(compiled)
-        return compiled
 
 
 @OpenAIRequestHandlerFactory.register(
@@ -1866,6 +1882,16 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             streaming_reasoning_texts=self.streaming_reasoning_texts,
         )
 
+    def post_validation(self, response: GenerationResponse) -> None:
+        has_text = bool(response.text and response.text.strip())
+        has_tool_calls = bool(response.tool_calls)
+        output_tokens = response.output_metrics.total_tokens or 0
+        if not has_text and not has_tool_calls and output_tokens <= 0:
+            raise ValueError(
+                "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty "
+                "response payload"
+            )
+
     def extract_line_data(self, line: str) -> dict[str, Any] | None:
         """Parse a Responses API SSE line.
 
@@ -2164,6 +2190,9 @@ class PoolingRequestHandler(ChatCompletionsRequestHandler):
     Inherits from ChatCompletionsRequestHandler and overrides format() to handle
     pooling-specific request structure with nested data fields.
     """
+
+    def post_validation(self, response: GenerationResponse) -> None:  # noqa: ARG002
+        pass
 
     def format(
         self,

--- a/src/guidellm/backends/openai/websocket.py
+++ b/src/guidellm/backends/openai/websocket.py
@@ -506,7 +506,9 @@ class OpenAIWebSocketBackend(Backend):
                                 f"(last type={event.get('type')!r})."
                             )
 
-                yield handler.compile_streaming(request, arguments), request_info
+                compiled = handler.compile_streaming(request, arguments)
+                handler.post_validation(compiled)
+                yield compiled, request_info
 
         except asyncio.CancelledError as err:
             yield handler.compile_streaming(request, arguments), request_info

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -407,17 +407,10 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             async for resp, info in self.backend.resolve(  # type: ignore[attr-defined]
                 request, request_info, history or None
             ):
+                response = resp
                 request_info = info
                 if request_info is None:
                     raise RuntimeError("Received invalid request info from backend")
-
-                if (
-                    resp is None
-                    and request_info.timings.first_token_iteration is not None
-                ):
-                    self._send_update("first_token", None, request, request_info)
-
-                response = resp
 
             # Complete the request
             request_info.timings.resolve_end = time.time()

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -407,10 +407,17 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             async for resp, info in self.backend.resolve(  # type: ignore[attr-defined]
                 request, request_info, history or None
             ):
-                response = resp
                 request_info = info
                 if request_info is None:
                     raise RuntimeError("Received invalid request info from backend")
+
+                if (
+                    resp is None
+                    and request_info.timings.first_token_iteration is not None
+                ):
+                    self._send_update("first_token", None, request, request_info)
+
+                response = resp
 
             # Complete the request
             request_info.timings.resolve_end = time.time()

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -449,7 +449,11 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_resolve_with_history(self, httpx_mock: HTTPXMock):
         """Test resolve method handles conversation history."""
-        backend = _make_backend(target="http://test", request_format="/v1/completions")
+        backend = _make_backend(
+            target="http://test",
+            request_format="/v1/completions",
+            stream=False,
+        )
 
         # Mock the models endpoint
         httpx_mock.add_response(

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -575,9 +575,6 @@ class TestTextCompletionsRequestHandler:
                 10,
                 5,
             ),
-            ({"choices": [{"text": ""}], "usage": {}}, "", None, None),
-            ({"choices": [], "usage": {}}, "", None, None),
-            ({}, "", None, None),
         ],
     )
     def test_non_streaming(
@@ -638,7 +635,6 @@ class TestTextCompletionsRequestHandler:
                 None,
                 None,
             ),
-            (["", "data: [DONE]"], "", None, None),
         ],
     )
     def test_streaming(
@@ -671,6 +667,47 @@ class TestTextCompletionsRequestHandler:
         assert response.output_metrics.text_tokens == expected_output_tokens
         assert response.output_metrics.text_words == len(expected_text.split())
         assert response.output_metrics.text_characters == len(expected_text)
+
+    @pytest.mark.regression
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"choices": [{"text": ""}], "usage": {}},
+            {"choices": [], "usage": {}},
+            {},
+        ],
+    )
+    def test_non_streaming_raises_for_unusable_terminal_payload(
+        self, valid_instances, generation_request, response
+    ):
+        """Test unusable non-streaming text response raises.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            instance.compile_non_streaming(generation_request, arguments, response)
+
+    @pytest.mark.regression
+    def test_streaming_raises_for_unusable_terminal_payload(
+        self, valid_instances, generation_request
+    ):
+        """Test unusable streaming text response raises.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        for line in ["", "data: [DONE]"]:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            instance.compile_streaming(generation_request, arguments)
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(
@@ -1112,18 +1149,6 @@ class TestChatCompletionsRequestHandler:
                 10,
                 5,
             ),
-            (
-                {"choices": [{"message": {"content": ""}}], "usage": {}},
-                "",
-                None,
-                None,
-            ),
-            (
-                {"choices": [], "usage": {}},
-                "",
-                None,
-                None,
-            ),
         ],
     )
     def test_non_streaming(
@@ -1177,12 +1202,6 @@ class TestChatCompletionsRequestHandler:
                 None,
                 None,
             ),
-            (
-                ["", "data: [DONE]"],
-                "",
-                None,
-                None,
-            ),
         ],
     )
     def test_streaming(
@@ -1214,6 +1233,46 @@ class TestChatCompletionsRequestHandler:
         assert response.input_metrics.text_tokens == expected_input_tokens
         assert response.output_metrics.text_tokens == expected_output_tokens
 
+    @pytest.mark.regression
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"choices": [{"message": {"content": ""}}], "usage": {}},
+            {"choices": [], "usage": {}},
+        ],
+    )
+    def test_non_streaming_raises_for_unusable_terminal_payload(
+        self, valid_instances, generation_request, response
+    ):
+        """Test unusable non-streaming chat response raises.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            instance.compile_non_streaming(generation_request, arguments, response)
+
+    @pytest.mark.regression
+    def test_streaming_raises_for_unusable_terminal_payload(
+        self, valid_instances, generation_request
+    ):
+        """Test unusable streaming chat response raises.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        for line in ["", "data: [DONE]"]:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            instance.compile_streaming(generation_request, arguments)
+
     @pytest.mark.sanity
     def test_streaming_reasoning_tokens(self, valid_instances, generation_request):
         """Test that reasoning tokens are properly detected for TTFT measurement.
@@ -1228,15 +1287,12 @@ class TestChatCompletionsRequestHandler:
         arguments = instance.format(generation_request)
 
         lines = [
-            # First chunk has reasoning token
             (
                 'data: {"id": "chatcmpl-123", "choices": '
                 '[{"index": 0, "delta": {"reasoning": "Okay"}}], "usage": {}}'
             ),
-            # More reasoning tokens
             'data: {"choices": [{"delta": {"reasoning": ", let me"}}], "usage": {}}',
             'data: {"choices": [{"delta": {"reasoning": " think..."}}], "usage": {}}',
-            # Finally content tokens
             'data: {"choices": [{"delta": {"content": "Hello"}}], "usage": {}}',
             (
                 'data: {"choices": [{"delta": {"content": " world!"}}], '
@@ -1256,17 +1312,13 @@ class TestChatCompletionsRequestHandler:
             elif result is None:
                 break
 
-        # Verify that the first update happened on the first reasoning token (line 0)
         assert first_update_on_line == 0, (
             f"Expected first token detection on line 0 (reasoning token), "
             f"but got {first_update_on_line}"
         )
-
-        # Verify all chunks with content were counted (5 lines with tokens)
         assert updated_count == 5
 
         response = instance.compile_streaming(generation_request, arguments)
-        # Reasoning tokens should NOT appear in response.text; only content does
         assert "Okay" not in response.text
         assert "let me think..." not in response.text
         assert response.text == "Hello world!"
@@ -1289,7 +1341,6 @@ class TestChatCompletionsRequestHandler:
         arguments = instance.format(generation_request)
 
         lines = [
-            # Chunk with both reasoning and content (edge case)
             (
                 'data: {"choices": [{"delta": '
                 '{"reasoning": "Let me think...", "content": "Answer: "}}], '
@@ -1307,12 +1358,9 @@ class TestChatCompletionsRequestHandler:
             if result > 0:
                 updated_count += 1
 
-        # First chunk has both reasoning and content (counts as 1 iteration)
-        # Second chunk has content only (counts as 1 iteration)
         assert updated_count == 2
 
         response = instance.compile_streaming(generation_request, arguments)
-        # Reasoning text should NOT appear; only content is captured
         assert "Let me think..." not in response.text
         assert response.text == "Answer: 42"
 
@@ -2065,8 +2113,6 @@ class TestChatCompletionsRequestHandler:
 
         assert "tool_choice" not in result.body
         assert "tools" not in result.body
-
-
 class TestAudioRequestHandler:
     """Test cases for AudioRequestHandler.
 

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2113,6 +2113,8 @@ class TestChatCompletionsRequestHandler:
 
         assert "tool_choice" not in result.body
         assert "tools" not in result.body
+
+
 class TestAudioRequestHandler:
     """Test cases for AudioRequestHandler.
 

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -686,9 +686,12 @@ class TestTextCompletionsRequestHandler:
         """
         instance = valid_instances
         arguments = instance.format(generation_request)
+        compiled = instance.compile_non_streaming(
+            generation_request, arguments, response
+        )
 
         with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
-            instance.compile_non_streaming(generation_request, arguments, response)
+            instance.post_validation(compiled)
 
     @pytest.mark.regression
     def test_streaming_raises_for_unusable_terminal_payload(
@@ -706,8 +709,10 @@ class TestTextCompletionsRequestHandler:
             if result is None:
                 break
 
+        compiled = instance.compile_streaming(generation_request, arguments)
+
         with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
-            instance.compile_streaming(generation_request, arguments)
+            instance.post_validation(compiled)
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(
@@ -1250,9 +1255,12 @@ class TestChatCompletionsRequestHandler:
         """
         instance = valid_instances
         arguments = instance.format(generation_request)
+        compiled = instance.compile_non_streaming(
+            generation_request, arguments, response
+        )
 
         with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
-            instance.compile_non_streaming(generation_request, arguments, response)
+            instance.post_validation(compiled)
 
     @pytest.mark.regression
     def test_streaming_raises_for_unusable_terminal_payload(
@@ -1270,8 +1278,45 @@ class TestChatCompletionsRequestHandler:
             if result is None:
                 break
 
+        compiled = instance.compile_streaming(generation_request, arguments)
+
         with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
-            instance.compile_streaming(generation_request, arguments)
+            instance.post_validation(compiled)
+
+    @pytest.mark.regression
+    def test_non_streaming_tool_call_only_passes_validation(
+        self, valid_instances, generation_request
+    ):
+        """Tool-call-only response (no text) is valid and must not raise.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"NYC"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+        instance.post_validation(result)
+        assert result.tool_calls is not None
+        assert len(result.tool_calls) == 1
 
     @pytest.mark.sanity
     def test_streaming_reasoning_tokens(self, valid_instances, generation_request):
@@ -3050,18 +3095,6 @@ class TestResponsesRequestHandler:
                 10,
                 8,
             ),
-            (
-                {"id": "resp_789", "output": [], "usage": {}},
-                "",
-                None,
-                None,
-            ),
-            (
-                {"output": []},
-                "",
-                None,
-                None,
-            ),
         ],
     )
     def test_non_streaming(
@@ -3152,29 +3185,6 @@ class TestResponsesRequestHandler:
                     "data: [DONE]",
                 ],
                 "Test",
-                None,
-                None,
-            ),
-            (
-                [
-                    "event: response.created",
-                    (
-                        "data: {"
-                        '"type":"response.created",'
-                        '"response":{"id":"resp_3"},'
-                        '"sequence_number":0}'
-                    ),
-                    "",
-                    "event: response.completed",
-                    (
-                        "data: {"
-                        '"type":"response.completed",'
-                        '"response":{"id":"resp_3","usage":{}},'
-                        '"sequence_number":2}'
-                    ),
-                    "data: [DONE]",
-                ],
-                "",
                 None,
                 None,
             ),
@@ -3337,20 +3347,6 @@ class TestResponsesRequestHandler:
                 10,
                 2,
             ),
-            (
-                [
-                    "event: response.failed",
-                    (
-                        "data: {"
-                        '"type":"response.failed",'
-                        '"response":{"id":"resp_fail_no_usage"},'
-                        '"sequence_number":1}'
-                    ),
-                ],
-                "",
-                None,
-                None,
-            ),
         ],
     )
     def test_streaming_terminal_events(
@@ -3379,6 +3375,57 @@ class TestResponsesRequestHandler:
         assert response.text == expected_text
         assert response.input_metrics.text_tokens == expected_input_tokens
         assert response.output_metrics.text_tokens == expected_output_tokens
+
+    @pytest.mark.regression
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"output": [], "usage": {}},
+            {"output": [{"type": "message", "content": []}], "usage": {}},
+        ],
+    )
+    def test_non_streaming_raises_for_unusable_terminal_payload(
+        self, valid_instances, generation_request, response
+    ):
+        """Responses API empty output raises UNUSABLE_BACKEND_RESPONSE.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        compiled = instance.compile_non_streaming(
+            generation_request, arguments, response
+        )
+
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            instance.post_validation(compiled)
+
+    @pytest.mark.regression
+    def test_non_streaming_tool_call_only_passes_validation(
+        self, valid_instances, generation_request
+    ):
+        """Tool-call-only Responses API output is valid and must not raise.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+        response = {
+            "output": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city":"NYC"}',
+                }
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        result = instance.compile_non_streaming(generation_request, arguments, response)
+        instance.post_validation(result)
+        assert result.tool_calls is not None
+        assert len(result.tool_calls) == 1
 
     @pytest.mark.sanity
     def test_streaming_reasoning_triggers_ttft_not_content(


### PR DESCRIPTION
## Summary

This PR fixes a scheduler correctness bug where requests could be marked as `completed` even when the backend resolved without a usable terminal response. It adds explicit terminal-response validation in the worker so malformed/empty terminal results are surfaced as `errored` with a clear diagnostic instead of being counted as successful requests.

## Details

- [x] Added terminal response validation in `WorkerProcess` to guard final status transitions.
- [x] Updated request finalization logic so unusable terminal responses set:
  - status: `errored`
  - error message: `[UNUSABLE_BACKEND_RESPONSE] backend resolved without a usable terminal response payload`
- [x] Implemented `GenerationResponse`-aware usability criteria:
  - usable if non-empty `text` **or** `output_metrics.total_tokens > 0`
  - `None` terminal response is always unusable
  - non-`GenerationResponse` fallback remains `bool(response)` for generic/test compatibility
- [x] Added regression tests in `tests/unit/scheduler/test_worker.py` for:
  - no terminal response object -> `errored`
  - empty `GenerationResponse` -> `errored`
  - token-bearing `GenerationResponse` with empty text -> `completed`
- [x] Preserved existing cancellation/error flow behavior outside terminal-response validation.

## Test Plan

- Run targeted worker regression tests:
  - `uv run pytest -q tests/unit/scheduler/test_worker.py -k "terminal_response or empty_generation_response or generation_response_with_tokens or invalid_initialization"`
- Verify expected outcomes:
  - missing terminal response is not marked `completed`
  - empty `GenerationResponse` is not marked `completed`
  - non-empty signal (`output_tokens > 0`) is accepted as `completed`
- Confirm no lint issues on touched files.

## Related Issues

- Resolves #613

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)

<!-- begin:squash-data -->

---

# git log

commit ffedece7bc093dcd18e4259c0d753f3cf03d7b27
Author: Uri Shaket <ushaket@redhat.com>
Date:   Mon Mar 2 23:55:49 2026 +0200

    mvoe validation logic to RequestHandlers
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit 03cdec7a6954e3dcaa610a9c5b382966a8212098
Author: Uri Shaket <ushaket@redhat.com>
Date:   Mon Mar 2 23:57:34 2026 +0200

    revert worker changes
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit e5fda3292f86e3f7892171a4106fb415504b66df
Author: Uri Shaket <ushaket@redhat.com>
Date:   Wed Jul 15 11:25:12 2026 +0300

    fix tests
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit d459b2ef7eeda1bf1b0b8f0cf3655173163a2520
Author: Uri Shaket <ushaket@redhat.com>
Date:   Wed Jul 15 13:23:05 2026 +0300

    self CR
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>

commit 36036d0b0b7f67c111337f628e64173dfd5e69fc
Author: Uri Shaket <ushaket@redhat.com>
Date:   Thu Jul 16 17:28:58 2026 +0300

    Clarify unusable backend response error message
    
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>

commit 1789158ca2cedcf63d8ef55927ee77e77358c03a
Author: Uri Shaket <ushaket@redhat.com>
Date:   Tue Jul 21 20:39:29 2026 +0300

    refactor: centralize post_validation hook for response validation
    
    Add post_validation to OpenAIRequestHandler and OpenAIWSRequestHandler
    protocols with a permissive no-op default. TextCompletionsRequestHandler
    and ResponsesRequestHandler override with a check for text, tool_calls,
    or output_tokens. PoolingRequestHandler and EmbeddingsRequestHandler
    keep the default no-op since they produce non-text output.
    
    Validation is called from the backend resolve methods (http.py,
    websocket.py) after compile, not inside each handler's compile methods.
    Cancellation paths skip validation for partial responses.
    
    Fixes tool-call-only false negative: responses with tool_calls but no
    text are now correctly treated as valid output.
    
    Assisted-by: Claude
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>

commit 6de940a469e2bd55cbcacf96cef81d7a23c7047e
Author: Uri Shaket <ushaket@redhat.com>
Date:   Thu Jul 23 09:44:58 2026 +0300

    refactor: deduplicate post_validation and add docstrings
    
    Extract _validate_text_response helper shared by
    TextCompletionsRequestHandler and ResponsesRequestHandler.
    Add docstrings to all post_validation overrides.
    
    Assisted-by: Claude
    Signed-off-by: Uri Shaket <ushaket@redhat.com>
    Co-authored-by: Cursor <cursoragent@cursor.com>

---------

Assisted-by: Claude
Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Uri Shaket <ushaket@redhat.com>
