### PR TITLE
Add helper to defer ImportError on extras and support lazy loading

### DIFF
--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -22,6 +22,8 @@ from pydantic import ConfigDict, Field, field_validator
 
 from guidellm.backends.backend import Backend, BackendArgs
 from guidellm.backends.vllm_python.vllm_response import VLLMResponseHandler
+from guidellm.extras.audio import HAS_AUDIO, _decode_audio
+from guidellm.extras.vision import HAS_VISION, image_dict_to_pil
 from guidellm.extras.vllm import (
     HAS_VLLM,
     AsyncEngineArgs,
@@ -36,22 +38,6 @@ from guidellm.schemas import (
     RequestInfo,
     StandardBaseModel,
 )
-
-try:
-    from guidellm.extras.audio import _decode_audio
-
-    HAS_AUDIO = True
-except ImportError:
-    _decode_audio = None  # type: ignore[assignment]
-    HAS_AUDIO = False
-
-try:
-    from guidellm.extras.vision import image_dict_to_pil
-
-    HAS_VISION = True
-except ImportError:
-    image_dict_to_pil = None  # type: ignore[assignment]
-    HAS_VISION = False
 
 # Sentinel for "chat template not yet resolved" cache.
 _CHAT_TEMPLATE_UNSET: object = object()

--- a/src/guidellm/extras/audio.py
+++ b/src/guidellm/extras/audio.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 import numpy as np
 import torch
 
-try:
+if TYPE_CHECKING:
     from torchcodec import AudioSamples
     from torchcodec.decoders import AudioDecoder
     from torchcodec.encoders import AudioEncoder
-except ImportError as e:
-    raise ImportError("Please install guidellm[audio] to use audio features") from e
+
+    HAS_AUDIO = True
+else:
+    from guidellm.utils import ExtrasImporter
+
+    _audio_importer = ExtrasImporter(
+        {
+            "AudioSamples": "torchcodec.AudioSamples",
+            "AudioDecoder": "torchcodec.decoders.AudioDecoder",
+            "AudioEncoder": "torchcodec.encoders.AudioEncoder",
+        },
+        extras_group="audio",
+    )
+
+    # Make imports available at module level for runtime use
+    AudioSamples = _audio_importer.AudioSamples
+    AudioDecoder = _audio_importer.AudioDecoder
+    AudioEncoder = _audio_importer.AudioEncoder
+    HAS_AUDIO = _audio_importer.is_available
 
 __all__ = [
+    "HAS_AUDIO",
     "encode_audio",
     "is_url",
 ]

--- a/src/guidellm/extras/vision.py
+++ b/src/guidellm/extras/vision.py
@@ -3,19 +3,31 @@ from __future__ import annotations
 import base64
 import io
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 import numpy as np
 
-try:
+if TYPE_CHECKING:
     from PIL import Image as PILImage
-except ImportError as e:
-    raise ImportError(
-        "Please install guidellm[vision] to use image/video features"
-    ) from e
+
+    HAS_VISION = True
+else:
+    from guidellm.utils import ExtrasImporter
+
+    _vision_importer = ExtrasImporter(
+        {
+            "PILImage": "PIL.Image",
+        },
+        extras_group="vision",
+    )
+
+    # Make imports available at module level for runtime use
+    PILImage = _vision_importer.PILImage
+    HAS_VISION = _vision_importer.is_available
 
 __all__ = [
+    "HAS_VISION",
     "encode_image",
     "encode_video",
     "get_file_format",

--- a/src/guidellm/extras/vllm.py
+++ b/src/guidellm/extras/vllm.py
@@ -23,12 +23,15 @@ else:
         eager=False,
     )
 
-    # Make imports available at module level for runtime use
-    SamplingParams = _vllm_importer.SamplingParams
-    AsyncEngineArgs = _vllm_importer.AsyncEngineArgs
-    AsyncLLMEngine = _vllm_importer.AsyncLLMEngine
-    RequestOutput = _vllm_importer.RequestOutput
+    # Create lazy proxies - these don't trigger imports until used
+    SamplingParams = _vllm_importer.get_proxy("SamplingParams")
+    AsyncEngineArgs = _vllm_importer.get_proxy("AsyncEngineArgs")
+    AsyncLLMEngine = _vllm_importer.get_proxy("AsyncLLMEngine")
+    RequestOutput = _vllm_importer.get_proxy("RequestOutput")
+
+    # HAS_VLLM can be set directly - is_available uses find_spec, doesn't import
     HAS_VLLM = _vllm_importer.is_available
+
 
 __all__ = [
     "HAS_VLLM",

--- a/src/guidellm/extras/vllm.py
+++ b/src/guidellm/extras/vllm.py
@@ -23,15 +23,12 @@ else:
         eager=False,
     )
 
-    # Create lazy proxies - these don't trigger imports until used
-    SamplingParams = _vllm_importer.get_proxy("SamplingParams")
-    AsyncEngineArgs = _vllm_importer.get_proxy("AsyncEngineArgs")
-    AsyncLLMEngine = _vllm_importer.get_proxy("AsyncLLMEngine")
-    RequestOutput = _vllm_importer.get_proxy("RequestOutput")
-
-    # HAS_VLLM can be set directly - is_available uses find_spec, doesn't import
+    # Make imports available at module level for runtime use
+    SamplingParams = _vllm_importer.SamplingParams
+    AsyncEngineArgs = _vllm_importer.AsyncEngineArgs
+    AsyncLLMEngine = _vllm_importer.AsyncLLMEngine
+    RequestOutput = _vllm_importer.RequestOutput
     HAS_VLLM = _vllm_importer.is_available
-
 
 __all__ = [
     "HAS_VLLM",

--- a/src/guidellm/extras/vllm.py
+++ b/src/guidellm/extras/vllm.py
@@ -1,13 +1,39 @@
-try:
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from vllm import SamplingParams
     from vllm.engine.arg_utils import AsyncEngineArgs
     from vllm.engine.async_llm_engine import AsyncLLMEngine
     from vllm.outputs import RequestOutput
 
     HAS_VLLM = True
-except ImportError:
-    AsyncLLMEngine = None  # type: ignore[assignment, misc]
-    AsyncEngineArgs = None  # type: ignore[assignment, misc]
-    SamplingParams = None  # type: ignore[assignment, misc]
-    RequestOutput = None  # type: ignore[assignment, misc]
-    HAS_VLLM = False
+else:
+    from guidellm.utils import ExtrasImporter
+
+    _vllm_importer = ExtrasImporter(
+        {
+            "SamplingParams": "vllm.SamplingParams",
+            "AsyncEngineArgs": "vllm.engine.arg_utils.AsyncEngineArgs",
+            "AsyncLLMEngine": "vllm.engine.async_llm_engine.AsyncLLMEngine",
+            "RequestOutput": "vllm.outputs.RequestOutput",
+        },
+        extras_group="vllm",
+        eager=False,
+    )
+
+    # Make imports available at module level for runtime use
+    SamplingParams = _vllm_importer.SamplingParams
+    AsyncEngineArgs = _vllm_importer.AsyncEngineArgs
+    AsyncLLMEngine = _vllm_importer.AsyncLLMEngine
+    RequestOutput = _vllm_importer.RequestOutput
+    HAS_VLLM = _vllm_importer.is_available
+
+__all__ = [
+    "HAS_VLLM",
+    "AsyncEngineArgs",
+    "AsyncLLMEngine",
+    "RequestOutput",
+    "SamplingParams",
+]

--- a/src/guidellm/utils/__init__.py
+++ b/src/guidellm/utils/__init__.py
@@ -9,6 +9,7 @@ from .encoding import (
     SerializationTypesAlias,
     Serializer,
 )
+from .extras_importer import ExtrasImporter
 from .functions import (
     all_defined,
     safe_add,
@@ -60,6 +61,7 @@ __all__ = [
     "Encoder",
     "EncodingTypesAlias",
     "EndlessTextCreator",
+    "ExtrasImporter",
     "InfoMixin",
     "IntegerRangeSampler",
     "InterProcessMessaging",

--- a/src/guidellm/utils/extras_importer.py
+++ b/src/guidellm/utils/extras_importer.py
@@ -1,0 +1,229 @@
+"""
+Lazy-loading utilities for optional dependencies.
+
+This module provides ExtrasImporter, a class for managing optional dependencies
+with graceful fallback when dependencies are unavailable. It supports both eager
+and lazy import strategies and creates helpful import stubs for missing packages.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import threading
+from typing import Any
+
+
+class _ImportStub:
+    """
+    Placeholder object that raises ImportError when called or accessed.
+
+    Allows isinstance checks and None comparisons without raising errors,
+    but blocks instantiation, method calls, and attribute access.
+
+    This enables imports to succeed even when dependencies are unavailable,
+    with errors only occurring when the stub is actually used.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        import_path: str,
+        extras_group: str | list[str],
+    ) -> None:
+        """
+        Initialize an import stub.
+
+        Args:
+            name: The attribute name being imported (e.g., "SamplingParams")
+            import_path: The full import path (e.g., "vllm.SamplingParams")
+            extras_group: Name(s) of extras group for error messages
+        """
+        self._stub_name = name
+        self._stub_import_path = import_path
+        self._stub_extras_group = extras_group
+
+    def _raise_import_error(self) -> None:
+        """Raise helpful ImportError with installation instructions."""
+        if isinstance(self._stub_extras_group, list):
+            extras = " or ".join(f"guidellm[{g}]" for g in self._stub_extras_group)
+        else:
+            extras = f"guidellm[{self._stub_extras_group}]"
+
+        raise ImportError(
+            f"'{self._stub_name}' from '{self._stub_import_path}' requires "
+            f"optional dependencies. Install with: pip install {extras}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+        """Raise error when stub is called."""
+        self._raise_import_error()
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        Raise AttributeError for attribute access.
+
+        This allows hasattr() checks to work properly (they catch AttributeError).
+        The stub itself will raise ImportError when called.
+        """
+        raise AttributeError(
+            f"'{self._stub_name}.{name}' is not available. "
+            f"Install guidellm[{self._stub_extras_group}] to use this feature."
+        )
+
+    def __bool__(self) -> bool:
+        """Return False to support truthiness checks."""
+        return False
+
+    def __repr__(self) -> str:
+        """Return a helpful representation."""
+        return f"<ImportStub for '{self._stub_name}' from '{self._stub_import_path}'>"
+
+
+class ExtrasImporter:
+    """
+    Lazy-loading manager for optional dependencies with graceful fallback.
+
+    Handles optional dependency imports by creating import stubs when
+    dependencies are unavailable. Supports both eager loading (import all
+    at initialization) and lazy loading (import on first access).
+
+    Example:
+        vllm_extras = ExtrasImporter(
+            {
+                "SamplingParams": "vllm.SamplingParams",
+                "AsyncEngineArgs": "vllm.engine.arg_utils.AsyncEngineArgs",
+                "AsyncLLMEngine": "vllm.engine.async_llm_engine.AsyncLLMEngine",
+                "RequestOutput": "vllm.outputs.RequestOutput",
+            },
+            extras_group="vllm",
+        )
+
+        # Access attributes (triggers lazy import)
+        params = vllm_extras.SamplingParams(temperature=0.7)
+
+        # Check availability
+        if vllm_extras.is_available:
+            # Use vllm features
+    """
+
+    def __init__(
+        self,
+        imports: dict[str, str],
+        *,
+        extras_group: str | list[str],
+        eager: bool = True,
+    ) -> None:
+        """
+        Initialize the extras importer.
+
+        Args:
+            imports: Mapping of attribute names to import paths.
+                Examples:
+                - "SamplingParams": "vllm.SamplingParams" (object import)
+                - "vllm": "vllm" (module import)
+            extras_group: Name(s) of extras group for error messages.
+                Used to generate helpful pip install commands.
+            eager: If True, attempt all imports immediately (default: True).
+                If False, imports happen on first attribute access (lazy).
+        """
+        self._imports = imports
+        self._extras_group = extras_group
+        self._import_cache: dict[str, Any] = {}
+        self._stub_cache: dict[str, _ImportStub] = {}
+        self._lock = threading.Lock()
+
+        if eager:
+            self._import_all()
+
+    def _import_all(self) -> None:
+        """Eagerly import all registered imports."""
+        for name in self._imports:
+            self._import_or_stub(name)
+
+    def _import_or_stub(self, name: str) -> Any:
+        """
+        Import the named attribute or create a stub.
+
+        Args:
+            name: The attribute name to import
+
+        Returns:
+            The imported object or an import stub
+        """
+        with self._lock:
+            # Check cache first
+            if name in self._import_cache:
+                return self._import_cache[name]
+            if name in self._stub_cache:
+                return self._stub_cache[name]
+
+            # Try to import
+            import_path = self._imports[name]
+            module_path, attr_name = self._parse_import_path(import_path)
+
+            try:
+                module = importlib.import_module(module_path)
+                obj = getattr(module, attr_name) if attr_name else module
+                self._import_cache[name] = obj
+                return obj
+            except (ImportError, AttributeError):
+                stub = _ImportStub(name, import_path, self._extras_group)
+                self._stub_cache[name] = stub
+                return stub
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        Lazy load imports on first access.
+
+        Args:
+            name: The attribute name to access
+
+        Returns:
+            The imported object or an import stub
+
+        Raises:
+            AttributeError: If the attribute is not registered or is private
+        """
+        if name.startswith("_"):
+            raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")
+
+        if name not in self._imports:
+            raise AttributeError(f"No import registered for '{name}'")
+
+        return self._import_or_stub(name)
+
+    @property
+    def is_available(self) -> bool:
+        """
+        Check if all registered imports are available without importing them.
+
+        Uses importlib.util.find_spec to check module availability.
+        Compatible with HAS_* flag pattern.
+
+        Returns:
+            True if all imports are available, False otherwise
+        """
+        for import_path in self._imports.values():
+            module_path, _ = self._parse_import_path(import_path)
+            if importlib.util.find_spec(module_path) is None:
+                return False
+        return True
+
+    def _parse_import_path(self, import_path: str) -> tuple[str, str | None]:
+        """
+        Parse import path to distinguish module vs object import.
+
+        Args:
+            import_path: The import path to parse
+
+        Returns:
+            Tuple of (module_path, attribute_name)
+            - attribute_name is None for module imports
+            - attribute_name is set for object imports
+        """
+        if "." not in import_path:
+            return import_path, None
+
+        parts = import_path.rsplit(".", 1)
+        return parts[0], parts[1]

--- a/src/guidellm/utils/extras_importer.py
+++ b/src/guidellm/utils/extras_importer.py
@@ -14,6 +14,71 @@ import threading
 from typing import Any
 
 
+class _LazyImportProxy:
+    """
+    Lazy import proxy that defers the actual import until the object is used.
+
+    This allows module-level assignments without triggering imports immediately.
+    The real import only happens when the proxy is called or has attributes accessed.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        import_path: str,
+        extras_group: str | list[str],
+    ) -> None:
+        """Initialize lazy import proxy."""
+        self._proxy_name = name
+        self._proxy_import_path = import_path
+        self._proxy_extras_group = extras_group
+        self._proxy_target: Any = None
+        self._proxy_lock = threading.Lock()
+
+    def _ensure_imported(self) -> Any:
+        """Import the target object if not already imported."""
+        if self._proxy_target is None:
+            with self._proxy_lock:
+                if self._proxy_target is None:
+                    module_path, attr_name = self._parse_import_path()
+                    try:
+                        module = importlib.import_module(module_path)
+                        self._proxy_target = (
+                            getattr(module, attr_name) if attr_name else module
+                        )
+                    except (ImportError, AttributeError):
+                        # Create stub on import failure
+                        self._proxy_target = _ImportStub(
+                            self._proxy_name,
+                            self._proxy_import_path,
+                            self._proxy_extras_group,
+                        )
+        return self._proxy_target
+
+    def _parse_import_path(self) -> tuple[str, str | None]:
+        """Parse import path into module and optional attribute."""
+        if "." not in self._proxy_import_path:
+            return self._proxy_import_path, None
+        parts = self._proxy_import_path.rsplit(".", 1)
+        return parts[0], parts[1]
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+        """Forward calls to the imported object."""
+        return self._ensure_imported()(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward attribute access to the imported object."""
+        if name.startswith("_proxy_"):
+            raise AttributeError(name)
+        return getattr(self._ensure_imported(), name)
+
+    def __repr__(self) -> str:
+        """Return representation."""
+        if self._proxy_target is None:
+            return f"<LazyImportProxy for '{self._proxy_name}' (not yet imported)>"
+        return repr(self._proxy_target)
+
+
 class _ImportStub:
     """
     Placeholder object that raises ImportError when called or accessed.
@@ -209,6 +274,25 @@ class ExtrasImporter:
             if importlib.util.find_spec(module_path) is None:
                 return False
         return True
+
+    def get_proxy(self, name: str) -> Any:
+        """
+        Get a lazy import proxy for the named attribute.
+
+        The proxy defers the actual import until the object is used,
+        allowing module-level assignments without eager importing.
+
+        Args:
+            name: The attribute name to get a proxy for
+
+        Returns:
+            A lazy import proxy that will import on first use
+        """
+        if name not in self._imports:
+            raise AttributeError(f"No import registered for '{name}'")
+
+        import_path = self._imports[name]
+        return _LazyImportProxy(name, import_path, self._extras_group)
 
     def _parse_import_path(self, import_path: str) -> tuple[str, str | None]:
         """

--- a/src/guidellm/utils/extras_importer.py
+++ b/src/guidellm/utils/extras_importer.py
@@ -14,80 +14,15 @@ import threading
 from typing import Any
 
 
-class _LazyImportProxy:
-    """
-    Lazy import proxy that defers the actual import until the object is used.
-
-    This allows module-level assignments without triggering imports immediately.
-    The real import only happens when the proxy is called or has attributes accessed.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        import_path: str,
-        extras_group: str | list[str],
-    ) -> None:
-        """Initialize lazy import proxy."""
-        self._proxy_name = name
-        self._proxy_import_path = import_path
-        self._proxy_extras_group = extras_group
-        self._proxy_target: Any = None
-        self._proxy_lock = threading.Lock()
-
-    def _ensure_imported(self) -> Any:
-        """Import the target object if not already imported."""
-        if self._proxy_target is None:
-            with self._proxy_lock:
-                if self._proxy_target is None:
-                    module_path, attr_name = self._parse_import_path()
-                    try:
-                        module = importlib.import_module(module_path)
-                        self._proxy_target = (
-                            getattr(module, attr_name) if attr_name else module
-                        )
-                    except (ImportError, AttributeError):
-                        # Create stub on import failure
-                        self._proxy_target = _ImportStub(
-                            self._proxy_name,
-                            self._proxy_import_path,
-                            self._proxy_extras_group,
-                        )
-        return self._proxy_target
-
-    def _parse_import_path(self) -> tuple[str, str | None]:
-        """Parse import path into module and optional attribute."""
-        if "." not in self._proxy_import_path:
-            return self._proxy_import_path, None
-        parts = self._proxy_import_path.rsplit(".", 1)
-        return parts[0], parts[1]
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
-        """Forward calls to the imported object."""
-        return self._ensure_imported()(*args, **kwargs)
-
-    def __getattr__(self, name: str) -> Any:
-        """Forward attribute access to the imported object."""
-        if name.startswith("_proxy_"):
-            raise AttributeError(name)
-        return getattr(self._ensure_imported(), name)
-
-    def __repr__(self) -> str:
-        """Return representation."""
-        if self._proxy_target is None:
-            return f"<LazyImportProxy for '{self._proxy_name}' (not yet imported)>"
-        return repr(self._proxy_target)
-
-
 class _ImportStub:
     """
-    Placeholder object that raises ImportError when called or accessed.
+    Import stub that lazily loads dependencies or raises helpful errors.
 
-    Allows isinstance checks and None comparisons without raising errors,
-    but blocks instantiation, method calls, and attribute access.
+    This class handles both eager and lazy import scenarios:
+    - In eager mode, the import is attempted immediately on creation
+    - In lazy mode, the import is deferred until first use
 
-    This enables imports to succeed even when dependencies are unavailable,
-    with errors only occurring when the stub is actually used.
+    If the import fails, the stub raises helpful errors when used.
     """
 
     def __init__(
@@ -95,6 +30,7 @@ class _ImportStub:
         name: str,
         import_path: str,
         extras_group: str | list[str],
+        eager: bool = False,
     ) -> None:
         """
         Initialize an import stub.
@@ -103,10 +39,53 @@ class _ImportStub:
             name: The attribute name being imported (e.g., "SamplingParams")
             import_path: The full import path (e.g., "vllm.SamplingParams")
             extras_group: Name(s) of extras group for error messages
+            eager: If True, attempt import immediately
         """
         self._stub_name = name
         self._stub_import_path = import_path
         self._stub_extras_group = extras_group
+        self._stub_target: Any = None
+        self._stub_failed = False
+        self._stub_lock = threading.Lock()
+
+        if eager:
+            # Attempt import but don't raise on failure
+            self._ensure_imported(raise_on_failure=False)
+
+    def _parse_import_path(self) -> tuple[str, str | None]:
+        """Parse import path into module and optional attribute."""
+        if "." not in self._stub_import_path:
+            return self._stub_import_path, None
+        parts = self._stub_import_path.rsplit(".", 1)
+        return parts[0], parts[1]
+
+    def _ensure_imported(self, raise_on_failure: bool = True) -> Any:
+        """
+        Import the target object if not already imported.
+
+        Args:
+            raise_on_failure: If True, raise ImportError on failure.
+                If False, return None.
+
+        Returns:
+            The imported object, or None if import failed
+        """
+        if self._stub_target is None and not self._stub_failed:
+            with self._stub_lock:
+                if self._stub_target is None and not self._stub_failed:
+                    module_path, attr_name = self._parse_import_path()
+                    try:
+                        module = importlib.import_module(module_path)
+                        self._stub_target = (
+                            getattr(module, attr_name) if attr_name else module
+                        )
+                    except (ImportError, AttributeError):
+                        self._stub_failed = True
+
+        if self._stub_failed and raise_on_failure:
+            self._raise_import_error()
+
+        return self._stub_target
 
     def _raise_import_error(self) -> None:
         """Raise helpful ImportError with installation instructions."""
@@ -121,28 +100,32 @@ class _ImportStub:
         )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
-        """Raise error when stub is called."""
-        self._raise_import_error()
+        """Forward calls to the imported object."""
+        return self._ensure_imported()(*args, **kwargs)
 
     def __getattr__(self, name: str) -> Any:
-        """
-        Raise AttributeError for attribute access.
-
-        This allows hasattr() checks to work properly (they catch AttributeError).
-        The stub itself will raise ImportError when called.
-        """
-        raise AttributeError(
-            f"'{self._stub_name}.{name}' is not available. "
-            f"Install guidellm[{self._stub_extras_group}] to use this feature."
-        )
+        """Forward attribute access to the imported object."""
+        if name.startswith("_stub_"):
+            raise AttributeError(name)
+        return getattr(self._ensure_imported(), name)
 
     def __bool__(self) -> bool:
-        """Return False to support truthiness checks."""
-        return False
+        """Return truthiness of the imported object, or False if import failed."""
+        if self._stub_failed:
+            return False
+        try:
+            target = self._ensure_imported()
+            return bool(target)
+        except ImportError:
+            return False
 
     def __repr__(self) -> str:
-        """Return a helpful representation."""
-        return f"<ImportStub for '{self._stub_name}' from '{self._stub_import_path}'>"
+        """Return representation."""
+        if self._stub_target is not None:
+            return repr(self._stub_target)
+        if self._stub_failed:
+            return f"<ImportStub (failed) for '{self._stub_name}'>"
+        return f"<ImportStub (not imported) for '{self._stub_name}'>"
 
 
 class ExtrasImporter:
@@ -194,58 +177,46 @@ class ExtrasImporter:
         """
         self._imports = imports
         self._extras_group = extras_group
-        self._import_cache: dict[str, Any] = {}
+        self._eager = eager
         self._stub_cache: dict[str, _ImportStub] = {}
         self._lock = threading.Lock()
 
+        # Pre-create stubs if eager mode
         if eager:
-            self._import_all()
+            for name in imports:
+                self._get_or_create_stub(name)
 
-    def _import_all(self) -> None:
-        """Eagerly import all registered imports."""
-        for name in self._imports:
-            self._import_or_stub(name)
-
-    def _import_or_stub(self, name: str) -> Any:
+    def _get_or_create_stub(self, name: str) -> _ImportStub:
         """
-        Import the named attribute or create a stub.
+        Get or create a stub for the named import.
 
         Args:
-            name: The attribute name to import
+            name: The attribute name to get a stub for
 
         Returns:
-            The imported object or an import stub
+            An import stub (eager or lazy based on configuration)
         """
         with self._lock:
-            # Check cache first
-            if name in self._import_cache:
-                return self._import_cache[name]
             if name in self._stub_cache:
                 return self._stub_cache[name]
 
-            # Try to import
-            import_path = self._imports[name]
-            module_path, attr_name = self._parse_import_path(import_path)
+            if name not in self._imports:
+                raise AttributeError(f"No import registered for '{name}'")
 
-            try:
-                module = importlib.import_module(module_path)
-                obj = getattr(module, attr_name) if attr_name else module
-                self._import_cache[name] = obj
-                return obj
-            except (ImportError, AttributeError):
-                stub = _ImportStub(name, import_path, self._extras_group)
-                self._stub_cache[name] = stub
-                return stub
+            import_path = self._imports[name]
+            stub = _ImportStub(name, import_path, self._extras_group, eager=self._eager)
+            self._stub_cache[name] = stub
+            return stub
 
     def __getattr__(self, name: str) -> Any:
         """
-        Lazy load imports on first access.
+        Get a stub for the named import.
 
         Args:
             name: The attribute name to access
 
         Returns:
-            The imported object or an import stub
+            An import stub
 
         Raises:
             AttributeError: If the attribute is not registered or is private
@@ -253,10 +224,7 @@ class ExtrasImporter:
         if name.startswith("_"):
             raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")
 
-        if name not in self._imports:
-            raise AttributeError(f"No import registered for '{name}'")
-
-        return self._import_or_stub(name)
+        return self._get_or_create_stub(name)
 
     @property
     def is_available(self) -> bool:
@@ -270,44 +238,21 @@ class ExtrasImporter:
             True if all imports are available, False otherwise
         """
         for import_path in self._imports.values():
-            module_path, _ = self._parse_import_path(import_path)
+            module_path = self._parse_module_path(import_path)
             if importlib.util.find_spec(module_path) is None:
                 return False
         return True
 
-    def get_proxy(self, name: str) -> Any:
+    def _parse_module_path(self, import_path: str) -> str:
         """
-        Get a lazy import proxy for the named attribute.
-
-        The proxy defers the actual import until the object is used,
-        allowing module-level assignments without eager importing.
+        Extract the module path from an import path.
 
         Args:
-            name: The attribute name to get a proxy for
+            import_path: The import path (e.g., "vllm.SamplingParams")
 
         Returns:
-            A lazy import proxy that will import on first use
-        """
-        if name not in self._imports:
-            raise AttributeError(f"No import registered for '{name}'")
-
-        import_path = self._imports[name]
-        return _LazyImportProxy(name, import_path, self._extras_group)
-
-    def _parse_import_path(self, import_path: str) -> tuple[str, str | None]:
-        """
-        Parse import path to distinguish module vs object import.
-
-        Args:
-            import_path: The import path to parse
-
-        Returns:
-            Tuple of (module_path, attribute_name)
-            - attribute_name is None for module imports
-            - attribute_name is set for object imports
+            The module path (e.g., "vllm")
         """
         if "." not in import_path:
-            return import_path, None
-
-        parts = import_path.rsplit(".", 1)
-        return parts[0], parts[1]
+            return import_path
+        return import_path.rsplit(".", 1)[0]

--- a/tests/unit/utils/test_extras_importer.py
+++ b/tests/unit/utils/test_extras_importer.py
@@ -45,16 +45,16 @@ class TestImportStub:
 
     def test_stub_attribute_access_raises_error(self):
         """
-        Test that accessing stub attributes raises AttributeError.
-
-        This allows hasattr() checks to work properly.
+        Test that accessing stub attributes raises ImportError when import fails.
 
         ### WRITTEN BY AI ###
         """
-        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        stub = _ImportStub(
+            "TestClass", "test.module.TestClass", "test-extra", eager=True
+        )
         with pytest.raises(
-            AttributeError,
-            match=r"'TestClass\.some_attribute' is not available",
+            ImportError,
+            match=r"'TestClass' from 'test\.module\.TestClass' requires optional",
         ):
             _ = stub.some_attribute
 
@@ -87,8 +87,16 @@ class TestImportStub:
 
         ### WRITTEN BY AI ###
         """
-        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
-        assert repr(stub) == "<ImportStub for 'TestClass' from 'test.module.TestClass'>"
+        stub = _ImportStub(
+            "TestClass", "test.module.TestClass", "test-extra", eager=False
+        )
+        assert repr(stub) == "<ImportStub (not imported) for 'TestClass'>"
+
+        # After failed import attempt
+        stub_eager = _ImportStub(
+            "TestClass", "test.module.TestClass", "test-extra", eager=True
+        )
+        assert repr(stub_eager) == "<ImportStub (failed) for 'TestClass'>"
 
 
 class TestExtrasImporter:
@@ -106,9 +114,16 @@ class TestExtrasImporter:
             eager=True,
         )
 
-        # Should be imported immediately
-        assert importer.os is sys.modules["os"]
-        assert importer.path is sys.modules["os"].path
+        # Stubs are created immediately and import eagerly
+        # Accessing the attribute returns the stub, which forwards to the real object
+        assert importer._stub_cache["os"]._stub_target is sys.modules["os"]
+        assert importer._stub_cache["path"]._stub_target is sys.modules["os"].path
+
+        # Direct access should return the real objects through stub forwarding
+        os_module = importer.os
+        path_module = importer.path
+        assert os_module.__name__ == "os"
+        assert path_module.__name__ in {"posixpath", "ntpath"}
 
     def test_eager_loading_missing_creates_stub(self):
         """
@@ -122,9 +137,13 @@ class TestExtrasImporter:
             eager=True,
         )
 
-        # Should create stub, not raise
-        stub = importer.NonExistent
-        assert isinstance(stub, _ImportStub)
+        # Stub is created and import is attempted immediately (and fails)
+        assert "NonExistent" in importer._stub_cache
+        assert importer._stub_cache["NonExistent"]._stub_failed is True
+
+        # Accessing it should raise ImportError
+        with pytest.raises(ImportError, match="requires optional dependencies"):
+            importer.NonExistent()
 
     def test_lazy_loading_success(self):
         """
@@ -138,13 +157,21 @@ class TestExtrasImporter:
             eager=False,
         )
 
-        # Should not be imported yet
-        assert "os" not in importer._import_cache
+        # Stub should not exist yet
+        assert "os" not in importer._stub_cache
 
-        # Access should trigger import
-        result = importer.os
-        assert result is sys.modules["os"]
-        assert "os" in importer._import_cache
+        # Access should create stub and trigger import on first use
+        stub = importer.os
+        assert isinstance(stub, _ImportStub)
+        assert "os" in importer._stub_cache
+
+        # Stub should not have imported yet (lazy)
+        assert stub._stub_target is None
+
+        # Using the stub should trigger import
+        result = stub.__name__  # Access an attribute
+        assert result == "os"
+        assert stub._stub_target is sys.modules["os"]
 
     def test_lazy_loading_missing_creates_stub(self):
         """
@@ -158,13 +185,19 @@ class TestExtrasImporter:
             eager=False,
         )
 
-        # Access should create stub
+        # Access should create stub (not imported yet)
         stub = importer.NonExistent
         assert isinstance(stub, _ImportStub)
+        assert stub._stub_target is None
+        assert not stub._stub_failed
+
+        # Using the stub should trigger import attempt and fail
+        with pytest.raises(ImportError, match="requires optional dependencies"):
+            stub()
 
     def test_import_caching(self):
         """
-        Test that successful imports are cached.
+        Test that stubs are cached and imports are cached within stubs.
 
         ### WRITTEN BY AI ###
         """
@@ -174,13 +207,19 @@ class TestExtrasImporter:
             eager=False,
         )
 
-        # First access
-        first_result = importer.os
-        # Second access should return cached value
-        second_result = importer.os
+        # First access creates stub
+        first_stub = importer.os
+        # Second access should return same stub
+        second_stub = importer.os
 
-        assert first_result is second_result
-        assert first_result is sys.modules["os"]
+        assert first_stub is second_stub
+        assert isinstance(first_stub, _ImportStub)
+
+        # Force import by accessing the stub
+        _ = first_stub.__name__
+
+        # Import should be cached in the stub
+        assert first_stub._stub_target is sys.modules["os"]
 
     def test_stub_caching(self):
         """
@@ -194,12 +233,13 @@ class TestExtrasImporter:
             eager=False,
         )
 
-        # First access
+        # First access creates stub
         first_stub = importer.NonExistent
-        # Second access should return same stub
+        # Second access should return same cached stub
         second_stub = importer.NonExistent
 
         assert first_stub is second_stub
+        assert isinstance(first_stub, _ImportStub)
 
     def test_is_available_all_present(self):
         """
@@ -249,10 +289,15 @@ class TestExtrasImporter:
         importer = ExtrasImporter(
             {"os": "os"},
             extras_group="test",
+            eager=True,
         )
 
-        result = importer.os
-        assert result is sys.modules["os"]
+        stub = importer.os
+        assert isinstance(stub, _ImportStub)
+        assert stub._stub_target is sys.modules["os"]
+
+        # Stub should forward attribute access to the module
+        assert stub.__name__ == "os"
 
     def test_object_import(self):
         """
@@ -263,38 +308,55 @@ class TestExtrasImporter:
         importer = ExtrasImporter(
             {"path": "os.path"},
             extras_group="test",
+            eager=True,
         )
 
-        result = importer.path
-        assert result is sys.modules["os"].path
+        stub = importer.path
+        assert isinstance(stub, _ImportStub)
+        assert stub._stub_target is sys.modules["os"].path
+
+        # Stub should forward attribute access
+        assert hasattr(stub, "join")
 
     def test_object_import_missing_module(self):
         """
-        Test importing object from missing module creates stub.
+        Test importing object from missing module creates failed stub.
 
         ### WRITTEN BY AI ###
         """
         importer = ExtrasImporter(
             {"TestClass": "non_existent_module.TestClass"},
             extras_group="test",
+            eager=True,
         )
 
-        result = importer.TestClass
-        assert isinstance(result, _ImportStub)
+        stub = importer.TestClass
+        assert isinstance(stub, _ImportStub)
+        assert stub._stub_failed is True
+
+        # Using it should raise ImportError
+        with pytest.raises(ImportError, match="requires optional dependencies"):
+            stub()
 
     def test_object_import_missing_attribute(self):
         """
-        Test importing missing attribute from existing module creates stub.
+        Test importing missing attribute from existing module creates failed stub.
 
         ### WRITTEN BY AI ###
         """
         importer = ExtrasImporter(
             {"NonExistentAttr": "os.non_existent_attribute"},
             extras_group="test",
+            eager=True,
         )
 
-        result = importer.NonExistentAttr
-        assert isinstance(result, _ImportStub)
+        stub = importer.NonExistentAttr
+        assert isinstance(stub, _ImportStub)
+        assert stub._stub_failed is True
+
+        # Using it should raise ImportError
+        with pytest.raises(ImportError, match="requires optional dependencies"):
+            stub()
 
     def test_unregistered_attribute_raises_error(self):
         """
@@ -345,8 +407,13 @@ class TestExtrasImporter:
 
         def access_imports():
             try:
-                results.append(importer.os)
-                results.append(importer.path)
+                # Get stubs
+                os_stub = importer.os
+                path_stub = importer.path
+                # Force import
+                os_name = os_stub.__name__
+                path_name = path_stub.join
+                results.append((os_stub, path_stub, os_name, path_name))
             except (ImportError, AttributeError) as e:
                 errors.append(e)
 
@@ -359,16 +426,18 @@ class TestExtrasImporter:
         # Should have no errors
         assert len(errors) == 0
 
-        # All results should be the same cached objects
-        os_results = results[::2]  # Every other starting from 0
-        path_results = results[1::2]  # Every other starting from 1
+        # All results should use the same stubs
+        assert len(results) == 10
+        first_os_stub, first_path_stub, _, _ = results[0]
+        for os_stub, path_stub, os_name, path_name in results:
+            assert os_stub is first_os_stub
+            assert path_stub is first_path_stub
+            assert os_name == "os"
+            assert callable(path_name)
 
-        assert all(r is sys.modules["os"] for r in os_results)
-        assert all(r is sys.modules["os"].path for r in path_results)
-
-    def test_parse_import_path_module(self):
+    def test_parse_module_path_simple(self):
         """
-        Test _parse_import_path for module imports.
+        Test _parse_module_path for simple module imports.
 
         ### WRITTEN BY AI ###
         """
@@ -377,13 +446,12 @@ class TestExtrasImporter:
             extras_group="test",
         )
 
-        module_path, attr_name = importer._parse_import_path("os")
+        module_path = importer._parse_module_path("os")
         assert module_path == "os"
-        assert attr_name is None
 
-    def test_parse_import_path_object(self):
+    def test_parse_module_path_object(self):
         """
-        Test _parse_import_path for object imports.
+        Test _parse_module_path for object imports.
 
         ### WRITTEN BY AI ###
         """
@@ -392,13 +460,12 @@ class TestExtrasImporter:
             extras_group="test",
         )
 
-        module_path, attr_name = importer._parse_import_path("os.path")
+        module_path = importer._parse_module_path("os.path")
         assert module_path == "os"
-        assert attr_name == "path"
 
-    def test_parse_import_path_nested_object(self):
+    def test_parse_module_path_nested_object(self):
         """
-        Test _parse_import_path for nested object imports.
+        Test _parse_module_path for nested object imports.
 
         ### WRITTEN BY AI ###
         """
@@ -407,9 +474,8 @@ class TestExtrasImporter:
             extras_group="test",
         )
 
-        module_path, attr_name = importer._parse_import_path("os.path.join")
+        module_path = importer._parse_module_path("os.path.join")
         assert module_path == "os.path"
-        assert attr_name == "join"
 
 
 @pytest.mark.integration
@@ -431,21 +497,24 @@ class TestExtrasImporterIntegration:
                 "RequestOutput": "vllm.outputs.RequestOutput",
             },
             extras_group="vllm",
+            eager=False,  # vllm uses lazy loading
         )
 
         # Should have is_available property
         has_vllm = importer.is_available
         assert isinstance(has_vllm, bool)
 
-        # Access should not raise (creates stub if not available)
+        # Access should return stub (not raise)
         sampling_params = importer.SamplingParams
+        assert isinstance(sampling_params, _ImportStub)
+
         if has_vllm:
-            # If vllm is installed, should be the real class
-            assert not isinstance(sampling_params, _ImportStub)
+            # If vllm is installed, using the stub should work
+            # Access an attribute to trigger import
+            assert hasattr(sampling_params, "__name__")
+            assert sampling_params._stub_target is not None
         else:
-            # If vllm is not installed, should be a stub
-            assert isinstance(sampling_params, _ImportStub)
-            # Calling stub should raise with helpful message
+            # If vllm is not installed, using stub should raise with helpful message
             with pytest.raises(ImportError, match="pip install guidellm\\[vllm\\]"):
                 sampling_params()
 
@@ -462,16 +531,22 @@ class TestExtrasImporterIntegration:
                 "AudioEncoder": "torchcodec.encoders.AudioEncoder",
             },
             extras_group="audio",
+            eager=True,  # audio uses eager loading
         )
 
         has_audio = importer.is_available
         assert isinstance(has_audio, bool)
 
         audio_decoder = importer.AudioDecoder
+        assert isinstance(audio_decoder, _ImportStub)
+
         if has_audio:
-            assert not isinstance(audio_decoder, _ImportStub)
+            # Import should have succeeded
+            assert audio_decoder._stub_target is not None
+            assert not audio_decoder._stub_failed
         else:
-            assert isinstance(audio_decoder, _ImportStub)
+            # Import should have failed
+            assert audio_decoder._stub_failed
             with pytest.raises(ImportError, match="pip install guidellm\\[audio\\]"):
                 audio_decoder()
 
@@ -486,15 +561,21 @@ class TestExtrasImporterIntegration:
                 "PILImage": "PIL.Image",
             },
             extras_group="vision",
+            eager=True,  # vision uses eager loading
         )
 
         has_vision = importer.is_available
         assert isinstance(has_vision, bool)
 
         pil_image = importer.PILImage
+        assert isinstance(pil_image, _ImportStub)
+
         if has_vision:
-            assert not isinstance(pil_image, _ImportStub)
+            # Import should have succeeded
+            assert pil_image._stub_target is not None
+            assert not pil_image._stub_failed
         else:
-            assert isinstance(pil_image, _ImportStub)
+            # Import should have failed
+            assert pil_image._stub_failed
             with pytest.raises(ImportError, match="pip install guidellm\\[vision\\]"):
                 pil_image.open("test.jpg")

--- a/tests/unit/utils/test_extras_importer.py
+++ b/tests/unit/utils/test_extras_importer.py
@@ -1,0 +1,500 @@
+"""
+Tests for ExtrasImporter lazy-loading utilities.
+
+### WRITTEN BY AI ###
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from typing import Any
+
+import pytest
+
+from guidellm.utils.extras_importer import ExtrasImporter, _ImportStub
+
+
+class TestImportStub:
+    """Test the _ImportStub class."""
+
+    def test_stub_creation(self):
+        """
+        Test that stubs can be created with proper attributes.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        assert stub._stub_name == "TestClass"
+        assert stub._stub_import_path == "test.module.TestClass"
+        assert stub._stub_extras_group == "test-extra"
+
+    def test_stub_call_raises_error(self):
+        """
+        Test that calling a stub raises ImportError with helpful message.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        with pytest.raises(
+            ImportError,
+            match=r"'TestClass' from 'test\.module\.TestClass' requires optional "
+            r"dependencies\. Install with: pip install guidellm\[test-extra\]",
+        ):
+            stub()
+
+    def test_stub_attribute_access_raises_error(self):
+        """
+        Test that accessing stub attributes raises AttributeError.
+
+        This allows hasattr() checks to work properly.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        with pytest.raises(
+            AttributeError,
+            match=r"'TestClass\.some_attribute' is not available",
+        ):
+            _ = stub.some_attribute
+
+    def test_stub_bool_returns_false(self):
+        """
+        Test that stubs are falsy for truthiness checks.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        assert not stub
+        assert bool(stub) is False
+
+    def test_stub_multiple_extras_groups(self):
+        """
+        Test error message with multiple extras groups.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", ["extra1", "extra2"])
+        with pytest.raises(
+            ImportError,
+            match=r"Install with: pip install guidellm\[extra1\] or guidellm\[extra2\]",
+        ):
+            stub()
+
+    def test_stub_repr(self):
+        """
+        Test that stub has a helpful representation.
+
+        ### WRITTEN BY AI ###
+        """
+        stub = _ImportStub("TestClass", "test.module.TestClass", "test-extra")
+        assert repr(stub) == "<ImportStub for 'TestClass' from 'test.module.TestClass'>"
+
+
+class TestExtrasImporter:
+    """Test the ExtrasImporter class."""
+
+    def test_eager_loading_success(self):
+        """
+        Test successful eager import of available modules.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os", "path": "os.path"},
+            extras_group="test",
+            eager=True,
+        )
+
+        # Should be imported immediately
+        assert importer.os is sys.modules["os"]
+        assert importer.path is sys.modules["os"].path
+
+    def test_eager_loading_missing_creates_stub(self):
+        """
+        Test that eager loading creates stubs for missing imports.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"NonExistent": "non_existent_module_xyz.NonExistent"},
+            extras_group="test",
+            eager=True,
+        )
+
+        # Should create stub, not raise
+        stub = importer.NonExistent
+        assert isinstance(stub, _ImportStub)
+
+    def test_lazy_loading_success(self):
+        """
+        Test successful lazy import on first access.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+            eager=False,
+        )
+
+        # Should not be imported yet
+        assert "os" not in importer._import_cache
+
+        # Access should trigger import
+        result = importer.os
+        assert result is sys.modules["os"]
+        assert "os" in importer._import_cache
+
+    def test_lazy_loading_missing_creates_stub(self):
+        """
+        Test that lazy loading creates stubs for missing imports.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"NonExistent": "non_existent_module_xyz.NonExistent"},
+            extras_group="test",
+            eager=False,
+        )
+
+        # Access should create stub
+        stub = importer.NonExistent
+        assert isinstance(stub, _ImportStub)
+
+    def test_import_caching(self):
+        """
+        Test that successful imports are cached.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+            eager=False,
+        )
+
+        # First access
+        first_result = importer.os
+        # Second access should return cached value
+        second_result = importer.os
+
+        assert first_result is second_result
+        assert first_result is sys.modules["os"]
+
+    def test_stub_caching(self):
+        """
+        Test that stubs are cached.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"NonExistent": "non_existent_module_xyz.NonExistent"},
+            extras_group="test",
+            eager=False,
+        )
+
+        # First access
+        first_stub = importer.NonExistent
+        # Second access should return same stub
+        second_stub = importer.NonExistent
+
+        assert first_stub is second_stub
+
+    def test_is_available_all_present(self):
+        """
+        Test is_available returns True when all imports available.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os", "path": "os.path"},
+            extras_group="test",
+        )
+
+        assert importer.is_available is True
+
+    def test_is_available_some_missing(self):
+        """
+        Test is_available returns False when some imports missing.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os", "NonExistent": "non_existent_module_xyz.NonExistent"},
+            extras_group="test",
+        )
+
+        assert importer.is_available is False
+
+    def test_is_available_all_missing(self):
+        """
+        Test is_available returns False when all imports missing.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"NonExistent": "non_existent_module_xyz.NonExistent"},
+            extras_group="test",
+        )
+
+        assert importer.is_available is False
+
+    def test_module_import(self):
+        """
+        Test importing entire module (no attribute).
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+        )
+
+        result = importer.os
+        assert result is sys.modules["os"]
+
+    def test_object_import(self):
+        """
+        Test importing object from module.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"path": "os.path"},
+            extras_group="test",
+        )
+
+        result = importer.path
+        assert result is sys.modules["os"].path
+
+    def test_object_import_missing_module(self):
+        """
+        Test importing object from missing module creates stub.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"TestClass": "non_existent_module.TestClass"},
+            extras_group="test",
+        )
+
+        result = importer.TestClass
+        assert isinstance(result, _ImportStub)
+
+    def test_object_import_missing_attribute(self):
+        """
+        Test importing missing attribute from existing module creates stub.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"NonExistentAttr": "os.non_existent_attribute"},
+            extras_group="test",
+        )
+
+        result = importer.NonExistentAttr
+        assert isinstance(result, _ImportStub)
+
+    def test_unregistered_attribute_raises_error(self):
+        """
+        Test that accessing unregistered attribute raises AttributeError.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+        )
+
+        with pytest.raises(
+            AttributeError, match="No import registered for 'unregistered'"
+        ):
+            _ = importer.unregistered
+
+    def test_private_attribute_raises_error(self):
+        """
+        Test that accessing private attributes raises AttributeError.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+        )
+
+        with pytest.raises(
+            AttributeError, match="'ExtrasImporter' has no attribute '_private'"
+        ):
+            _ = importer._private
+
+    def test_thread_safety(self):
+        """
+        Test that concurrent access doesn't cause race conditions.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os", "path": "os.path"},
+            extras_group="test",
+            eager=False,  # Start with nothing cached
+        )
+
+        results: list[Any] = []
+        errors: list[Exception] = []
+
+        def access_imports():
+            try:
+                results.append(importer.os)
+                results.append(importer.path)
+            except (ImportError, AttributeError) as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=access_imports) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # Should have no errors
+        assert len(errors) == 0
+
+        # All results should be the same cached objects
+        os_results = results[::2]  # Every other starting from 0
+        path_results = results[1::2]  # Every other starting from 1
+
+        assert all(r is sys.modules["os"] for r in os_results)
+        assert all(r is sys.modules["os"].path for r in path_results)
+
+    def test_parse_import_path_module(self):
+        """
+        Test _parse_import_path for module imports.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"os": "os"},
+            extras_group="test",
+        )
+
+        module_path, attr_name = importer._parse_import_path("os")
+        assert module_path == "os"
+        assert attr_name is None
+
+    def test_parse_import_path_object(self):
+        """
+        Test _parse_import_path for object imports.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"path": "os.path"},
+            extras_group="test",
+        )
+
+        module_path, attr_name = importer._parse_import_path("os.path")
+        assert module_path == "os"
+        assert attr_name == "path"
+
+    def test_parse_import_path_nested_object(self):
+        """
+        Test _parse_import_path for nested object imports.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {"join": "os.path.join"},
+            extras_group="test",
+        )
+
+        module_path, attr_name = importer._parse_import_path("os.path.join")
+        assert module_path == "os.path"
+        assert attr_name == "join"
+
+
+@pytest.mark.integration
+class TestExtrasImporterIntegration:
+    """Integration tests for ExtrasImporter."""
+
+    def test_vllm_pattern(self):
+        """
+        Test the pattern used for vllm extras.
+
+        ### WRITTEN BY AI ###
+        """
+        # This mimics the vllm.py usage pattern
+        importer = ExtrasImporter(
+            {
+                "SamplingParams": "vllm.SamplingParams",
+                "AsyncEngineArgs": "vllm.engine.arg_utils.AsyncEngineArgs",
+                "AsyncLLMEngine": "vllm.engine.async_llm_engine.AsyncLLMEngine",
+                "RequestOutput": "vllm.outputs.RequestOutput",
+            },
+            extras_group="vllm",
+        )
+
+        # Should have is_available property
+        has_vllm = importer.is_available
+        assert isinstance(has_vllm, bool)
+
+        # Access should not raise (creates stub if not available)
+        sampling_params = importer.SamplingParams
+        if has_vllm:
+            # If vllm is installed, should be the real class
+            assert not isinstance(sampling_params, _ImportStub)
+        else:
+            # If vllm is not installed, should be a stub
+            assert isinstance(sampling_params, _ImportStub)
+            # Calling stub should raise with helpful message
+            with pytest.raises(ImportError, match="pip install guidellm\\[vllm\\]"):
+                sampling_params()
+
+    def test_audio_pattern(self):
+        """
+        Test the pattern used for audio extras.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {
+                "AudioSamples": "torchcodec.AudioSamples",
+                "AudioDecoder": "torchcodec.decoders.AudioDecoder",
+                "AudioEncoder": "torchcodec.encoders.AudioEncoder",
+            },
+            extras_group="audio",
+        )
+
+        has_audio = importer.is_available
+        assert isinstance(has_audio, bool)
+
+        audio_decoder = importer.AudioDecoder
+        if has_audio:
+            assert not isinstance(audio_decoder, _ImportStub)
+        else:
+            assert isinstance(audio_decoder, _ImportStub)
+            with pytest.raises(ImportError, match="pip install guidellm\\[audio\\]"):
+                audio_decoder()
+
+    def test_vision_pattern(self):
+        """
+        Test the pattern used for vision extras.
+
+        ### WRITTEN BY AI ###
+        """
+        importer = ExtrasImporter(
+            {
+                "PILImage": "PIL.Image",
+            },
+            extras_group="vision",
+        )
+
+        has_vision = importer.is_available
+        assert isinstance(has_vision, bool)
+
+        pil_image = importer.PILImage
+        if has_vision:
+            assert not isinstance(pil_image, _ImportStub)
+        else:
+            assert isinstance(pil_image, _ImportStub)
+            with pytest.raises(ImportError, match="pip install guidellm\\[vision\\]"):
+                pil_image.open("test.jpg")


### PR DESCRIPTION
## Summary

Adds a helper to replace optional imports with stubs if unavailable. Still a WIP

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
