### PR TITLE
Fix HTML on main and disable by default

### DIFF
--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -291,7 +291,7 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
     random_seed: int = Field(default=42, description="Random seed for reproducibility")
     # Output configuration
     outputs: list[str] | tuple[str] = Field(
-        default_factory=lambda: ["json", "csv", "html"],
+        default_factory=lambda: ["json", "csv"],
         description=(
             "The aliases of the output types to create with their default filenames "
             "the file names and extensions of the output types to create"

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -31,8 +31,8 @@ class Environment(str, Enum):
 
 
 ENV_REPORT_MAPPING = {
-    Environment.PROD: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/v0.6.0/index.html",
-    Environment.STAGING: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/v0.6.0/index.html",
+    Environment.PROD: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/v0.5.4/index.html",
+    Environment.STAGING: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/v0.4.0/index.html",
     Environment.DEV: "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev/index.html",
     Environment.LOCAL: "http://localhost:3000/index.html",
 }


### PR DESCRIPTION
## Summary

Something I failed to notice during the scramble to get v0.5.4 out is that the HTML CI only generates the new version template on release, so tagging it with the current dev version will not work. Also just remove it from the defaults in preparation for phasing it out entirely.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
