### PR TITLE
openai_http: document extras in BackendArgs and CLI help for backend_…

### DIFF
--- a/src/guidellm/__main__.py
+++ b/src/guidellm/__main__.py
@@ -175,7 +175,8 @@ def benchmark():
     default=BenchmarkGenerativeTextArgs.get_default("backend_kwargs"),
     help=(
         "JSON string of arguments to pass to the backend. E.g., "
-        '\'{"api_key": "apikey-*", "verify": false}\''
+        '\'{"api_key": "apikey-*", "verify": false}\' or '
+        '\'{"extras": {"body": {"temperature": 0.6, "top_p": 0.95}}}\' for sampling params.'
     ),
 )
 @click.option(

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -74,6 +74,13 @@ class OpenAIHttpBackendArgs(BackendArgs):
             )
         },
     )
+    extras: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional request arguments to merge into each request (e.g. body fields). "
+            'Use {"body": {"temperature": 0.6, "top_p": 0.95}} to set sampling params.'
+        ),
+    )
 
     @field_validator("request_format")
     @classmethod


### PR DESCRIPTION
…kwargs

- Add optional extras field to OpenAIHttpBackendArgs with description for merging request body fields (e.g. temperature, top_p) via backend_kwargs.
- Update --backend-kwargs help to mention extras.body example for sampling params.
- Backend already supported extras; this improves discoverability and schema docs.

Made-with: Cursor

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
