### PR TITLE
Adapt multi-turn documentation to new format

### DIFF
--- a/docs/guides/multiturn.md
+++ b/docs/guides/multiturn.md
@@ -349,9 +349,9 @@ guidellm benchmark run \
   --profile concurrent \
   --rate 10 \
   --max-requests 150 \
-  --data "prefix_tokens=512,prompt_tokens=128,output_tokens=256" \      # Turn 1
-  --data "prompt_tokens=256,prompt_token_stdev=32,output_tokens=128" \  # Turn 2
-  --data "prompt_tokens=64,output_tokens=128,output_tokens_stdev=16" \  # Turn 3
+  --data '{"prefix_tokens":512,"prompt_tokens":128,"output_tokens":256}' \      # Turn 1
+  --data '{"prompt_tokens":256,"prompt_token_stdev":32,"output_tokens":128}' \  # Turn 2
+  --data '{"prompt_tokens":64,"output_tokens":128,"output_token_stdev":16}' \   # Turn 3
   --data-preprocessors "turn_pivot"
 ```
 

--- a/docs/guides/multiturn.md
+++ b/docs/guides/multiturn.md
@@ -350,8 +350,8 @@ guidellm benchmark run \
   --rate 10 \
   --max-requests 150 \
   --data '{"prefix_tokens":512,"prompt_tokens":128,"output_tokens":256}' \      # Turn 1
-  --data '{"prompt_tokens":256,"prompt_token_stdev":32,"output_tokens":128}' \  # Turn 2
-  --data '{"prompt_tokens":64,"output_tokens":128,"output_token_stdev":16}' \   # Turn 3
+  --data '{"prompt_tokens":256,"prompt_tokens_stdev":32,"output_tokens":128}' \  # Turn 2
+  --data '{"prompt_tokens":64,"output_tokens":128,"output_tokens_stdev":16}' \   # Turn 3
   --data-preprocessors "turn_pivot"
 ```
 


### PR DESCRIPTION
## Summary

The script in the documentation for running a multi-turn benchmark using TurnPivot had some issues

## Details

- Fixed a typo
- Remove comments from script as they prevented it from running properly in bash

## Test Plan

N/A

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
