### PR TITLE
Rename tox envs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/run-tox
         with:
           python-version: ${{ inputs.python }}
-          tox-env: types
+          tox-env: type-check
 
   precommit-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/actions/run-tox
         with:
           python-version: ${{ inputs.python }}
-          tox-env: quality
+          tox-env: lint-check
 
   type-checks:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ We follow strict coding standards to ensure code quality and maintainability. Pl
 To check code quality locally, use the following Tox environment:
 
 ```bash
-tox -e quality
+tox -e lint-check
 ```
 
 To automatically fix style issues, use:
 
 ```bash
-tox -e style
+tox -e lint-fix
 ```
 
 To run type checks, use:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ tox -e lint-fix
 To run type checks, use:
 
 ```bash
-tox -e types
+tox -e type-check
 ```
 
 ## Submitting Changes

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -78,7 +78,7 @@ tox -e lint-fix
 To ensure type safety using Mypy:
 
 ```bash
-tox -e types
+tox -e type-check
 ```
 
 ### Link Checking
@@ -86,7 +86,7 @@ tox -e types
 To ensure valid links added to the documentation / Markdown files:
 
 ```bash
-tox -e links
+tox -e link-check
 ```
 
 ### Automating Quality Checks with Pre-Commit Hooks (Optional)

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -64,13 +64,13 @@ Additionally, to ensure consistency and quality of the codebase, we use [ruff](h
 To check code quality, including linting and formatting:
 
 ```bash
-tox -e quality
+tox -e lint-check
 ```
 
 To automatically fix style issues:
 
 ```bash
-tox -e style
+tox -e lint-fix
 ```
 
 ### Type Checking

--- a/tox.ini
+++ b/tox.ini
@@ -49,14 +49,14 @@ commands =
     python -m mdformat README.md DEVELOPING.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/ src/ tests/
 
 
-[testenv:types]
+[testenv:type-check]
 description = Run type checks
 base = tests
 commands =
     mypy --check-untyped-defs {posargs}
 
 
-[testenv:links]
+[testenv:link-check]
 description = Run link checks for root and docs markdown files
 base = tests
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
     python -m pytest tests/e2e {posargs}
 
 
-[testenv:check]
+[testenv:lint-check]
 description = Run all quality checks
 base = tests
 commands =
@@ -39,17 +39,15 @@ commands =
     ruff check
     python -m mdformat --check README.md DEVELOPING.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/ src/ tests/
 
-# Legacy alias
-[testenv:quality]
-base = check
 
-[testenv:style]
+[testenv:lint-fix]
 description = Run style checks and fixes
 base = tests
 commands =
     ruff format
     ruff check --fix
     python -m mdformat README.md DEVELOPING.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/ src/ tests/
+
 
 [testenv:types]
 description = Run type checks


### PR DESCRIPTION
## Summary

Rename various `tox` environments to be more consistent and descriptive.

## Details

Renames:

* `quality` -> `lint-check`
* `style` -> `lint-fix`
* `types` -> `type-check`
* `links` -> `link-check`

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
