### PR TITLE
Fix CSV column misalignment across multiple benchmarks

### DIFF
--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -117,8 +117,9 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
 
         with output_path.open("w", newline="") as file:
             writer = csv.writer(file)
-            headers: list[list[str]] = []
-            rows: list[list[str | int | float]] = []
+
+            row_maps: list[dict[tuple[str, ...], str | int | float]] = []
+            ordered_headers: dict[tuple[str, ...], None] = {}
 
             for benchmark in report.benchmarks:
                 benchmark_headers: list[list[str]] = []
@@ -144,12 +145,30 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
                 self._add_scheduler_info(benchmark, benchmark_headers, benchmark_values)
                 self._add_runtime_info(report, benchmark_headers, benchmark_values)
 
-                if not headers:
-                    headers = benchmark_headers
-                rows.append(benchmark_values)
+                row_map: dict[tuple[str, ...], str | int | float] = {}
+                for header_parts, value in zip(
+                    benchmark_headers, benchmark_values, strict=False
+                ):
+                    header_key = tuple(header_parts)
+                    row_map[header_key] = value
+
+                    if header_key not in ordered_headers:
+                        ordered_headers[header_key] = None
+
+                row_maps.append(row_map)
+
+            header_keys = list(ordered_headers.keys())
+            headers = [list(header_key) for header_key in header_keys]
+
+            data_rows: list[list[str | int | float]] = []
+            for row_map in row_maps:
+                aligned_row_values = [
+                    row_map.get(header_key, "") for header_key in header_keys
+                ]
+                data_rows.append(aligned_row_values)
 
             self._write_multirow_header(writer, headers)
-            for row in rows:
+            for row in data_rows:
                 writer.writerow(row)
 
         return output_path

--- a/tests/unit/benchmark/test_csv_output.py
+++ b/tests/unit/benchmark/test_csv_output.py
@@ -1,8 +1,8 @@
-## WRITTEN BY AI ##
-import asyncio
 import csv
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from guidellm.benchmark.outputs.csv import GenerativeBenchmarkerCSV
 
@@ -14,11 +14,6 @@ def _make_report(benchmarks):
         metadata=SimpleNamespace(model_dump_json=lambda: "{}"),
         args=SimpleNamespace(model_dump_json=lambda: "{}"),
     )
-
-
-def _finalize_sync(out, report):
-    """Run the async CSV finalizer in a synchronous test context."""
-    return asyncio.run(out.finalize(report))
 
 
 def _make_csv_output(tmp_path: Path, benchmarks):
@@ -48,8 +43,14 @@ def _make_csv_output(tmp_path: Path, benchmarks):
     return out, report
 
 
-def test_headers_merge_and_order(tmp_path: Path):
-    """Ensure headers from multiple benchmarks are merged in first-seen order."""
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_headers_merge_and_order(tmp_path: Path):
+    """
+    Ensure headers from multiple benchmarks are merged in first-seen order.
+
+    ### WRITTEN BY AI ###
+    """
     bench1 = SimpleNamespace(
         _test_fields=[
             (("GroupA", "Field1", ""), "v1"),
@@ -65,7 +66,7 @@ def test_headers_merge_and_order(tmp_path: Path):
     )
 
     out, report = _make_csv_output(tmp_path, [bench1, bench2])
-    path = _finalize_sync(out, report)
+    path = await out.finalize(report)
 
     rows = list(csv.reader(path.open()))
     header_rows = rows[:3]
@@ -81,17 +82,52 @@ def test_headers_merge_and_order(tmp_path: Path):
     ]
 
 
-def test_values_alignment(tmp_path: Path):
-    """Ensure missing columns are written as blanks for each aligned row."""
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_values_alignment(tmp_path: Path):
+    """
+    Ensure missing columns are written as blanks for each aligned row.
+
+    ### WRITTEN BY AI ###
+    """
     bench1 = SimpleNamespace(
         _test_fields=[(("G", "A", ""), "a"), (("G", "B", ""), "b")]
     )
     bench2 = SimpleNamespace(_test_fields=[(("G", "A", ""), "a2")])
 
     out, report = _make_csv_output(tmp_path, [bench1, bench2])
-    path = _finalize_sync(out, report)
+    path = await out.finalize(report)
     rows = list(csv.reader(path.open()))
     data_rows = rows[3:]
 
     assert data_rows[0] == ["a", "b"]
     assert data_rows[1] == ["a2", ""]
+
+
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_first_benchmark_missing_columns(tmp_path: Path):
+    """
+    When the first benchmark lacks columns that the second has, those columns
+    should still appear in the output and the first row gets blank values.
+
+    ### WRITTEN BY AI ###
+    """
+    bench1 = SimpleNamespace(_test_fields=[(("G", "A", ""), "a1")])
+    bench2 = SimpleNamespace(
+        _test_fields=[(("G", "A", ""), "a2"), (("G", "B", ""), "b2")]
+    )
+
+    out, report = _make_csv_output(tmp_path, [bench1, bench2])
+    path = await out.finalize(report)
+    rows = list(csv.reader(path.open()))
+    header_rows = rows[:3]
+    data_rows = rows[3:]
+
+    reconstructed = [
+        tuple(col[i] for col in header_rows) for i in range(len(header_rows[0]))
+    ]
+
+    assert reconstructed == [("G", "A", ""), ("G", "B", "")]
+    assert data_rows[0] == ["a1", ""]
+    assert data_rows[1] == ["a2", "b2"]

--- a/tests/unit/benchmark/test_csv_output.py
+++ b/tests/unit/benchmark/test_csv_output.py
@@ -1,0 +1,97 @@
+## WRITTEN BY AI ##
+import asyncio
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+
+from guidellm.benchmark.outputs.csv import GenerativeBenchmarkerCSV
+
+
+def _make_report(benchmarks):
+    """Build a minimal benchmark report for CSV output tests."""
+    return SimpleNamespace(
+        benchmarks=benchmarks,
+        metadata=SimpleNamespace(model_dump_json=lambda: "{}"),
+        args=SimpleNamespace(model_dump_json=lambda: "{}"),
+    )
+
+
+def _finalize_sync(out, report):
+    """Run the async CSV finalizer in a synchronous test context."""
+    return asyncio.run(out.finalize(report))
+
+
+def _make_csv_output(tmp_path: Path, benchmarks):
+    """Create a CSV output instance with only the fields this test needs."""
+    report = _make_report(benchmarks)
+    out = GenerativeBenchmarkerCSV(output_path=tmp_path)
+
+    # Disable unrelated metric emitters so the test controls the output shape.
+    for name in [
+        "_add_benchmark_info",
+        "_add_timing_info",
+        "_add_request_counts",
+        "_add_request_latency_metrics",
+        "_add_server_throughput_metrics",
+        "_add_modality_metrics",
+        "_add_scheduler_info",
+        "_add_runtime_info",
+    ]:
+        setattr(out, name, lambda *a, **k: None)
+
+    def _add_run_info(self, benchmark, headers, values):
+        for key, val in benchmark._test_fields:
+            headers.append(list(key))
+            values.append(val)
+
+    out._add_run_info = _add_run_info.__get__(out, out.__class__)
+    return out, report
+
+
+def test_headers_merge_and_order(tmp_path: Path):
+    """Ensure headers from multiple benchmarks are merged in first-seen order."""
+    bench1 = SimpleNamespace(
+        _test_fields=[
+            (("GroupA", "Field1", ""), "v1"),
+            (("GroupB", "Field2", ""), "v2"),
+        ]
+    )
+
+    bench2 = SimpleNamespace(
+        _test_fields=[
+            (("GroupA", "Field1", ""), "v1_b2"),
+            (("GroupC", "Field3", ""), "v3"),
+        ]
+    )
+
+    out, report = _make_csv_output(tmp_path, [bench1, bench2])
+    path = _finalize_sync(out, report)
+
+    rows = list(csv.reader(path.open()))
+    header_rows = rows[:3]
+
+    reconstructed = [
+        tuple(col[i] for col in header_rows) for i in range(len(header_rows[0]))
+    ]
+
+    assert reconstructed == [
+        ("GroupA", "Field1", ""),
+        ("GroupB", "Field2", ""),
+        ("GroupC", "Field3", ""),
+    ]
+
+
+def test_values_alignment(tmp_path: Path):
+    """Ensure missing columns are written as blanks for each aligned row."""
+    bench1 = SimpleNamespace(
+        _test_fields=[(("G", "A", ""), "a"), (("G", "B", ""), "b")]
+    )
+    bench2 = SimpleNamespace(_test_fields=[(("G", "A", ""), "a2")])
+
+    out, report = _make_csv_output(tmp_path, [bench1, bench2])
+    path = _finalize_sync(out, report)
+    rows = list(csv.reader(path.open()))
+    data_rows = rows[3:]
+
+    assert data_rows[0] == ["a", "b"]
+    assert data_rows[1] == ["a2", ""]


### PR DESCRIPTION
## Summary:
Improve the CSV output formatter to dynamically construct a unified master header when running multiple benchmark profiles sequentially, preventing column misalignment by safely padding missing metrics.

## Details:

Currently, the CSV output formatter (`GenerativeBenchmarkerCSV`) locks the header structure of the entire result to the first executed benchmark when multiple benchmark profiles are run sequentially (sweep profile). 
As a result, if subsequent benchmarks measure new metrics or different modalities, it causes the data columns to misalign or break against the headers. 
To resolve this, the logic was improved to dynamically construct a superset (master header) of all benchmark result headers and safely pad any missing metrics with empty strings.

## Test Plan:
```
guidellm benchmark \
  --target "http://localhost:8000" \
  --profile sweep \
  --max-seconds 30 \
  --data "prompt_tokens=256,output_tokens=128"
```

### Before
<img width="937" height="275" alt="image" src="https://github.com/user-attachments/assets/ef3d83f6-0014-4556-8458-6cf81004e2b8" />

### After
<img width="948" height="265" alt="image" src="https://github.com/user-attachments/assets/9e7af465-1821-426b-bf33-4ebac1f18187" />


## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)