### PR TITLE
Checks for no valid requests in processed dataset

### DIFF
--- a/src/guidellm/data/loaders.py
+++ b/src/guidellm/data/loaders.py
@@ -85,8 +85,6 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
     def set_epoch(self, epoch: int):
         self.epoch = epoch
 
-    _CONSECUTIVE_ERROR_WARN_THRESHOLD = 50
-
     def generator(  # noqa: C901
         self,
         max_items: int | None = None,
@@ -97,7 +95,6 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         gen_count = 0
         yield_count = 0
         error_count = 0
-        consecutive_errors = 0
 
         with contextlib.suppress(StopIteration):
             dataset_iters = []
@@ -127,27 +124,25 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
                         row = preprocessor(row)
 
                     result = self.finalizer(row)
+                    # Filter empty results (e.g. column mapper matched
+                    # no columns, so finalizer returned an empty list)
+                    if not result:
+                        continue
                     yield result
                     yield_count += 1
-                    consecutive_errors = 0
                 except StopIteration:
                     raise  # Stop iteration when any dataset is exhausted
                 except Exception as err:  # noqa: BLE001 # Exception logged
                     error_count += 1
-                    consecutive_errors += 1
-                    logger.error(f"Skipping data row due to error: {err}")
-                    if consecutive_errors == self._CONSECUTIVE_ERROR_WARN_THRESHOLD:
-                        logger.warning(
-                            f"{self._CONSECUTIVE_ERROR_WARN_THRESHOLD} "
-                            f"consecutive row errors encountered "
-                            f"({error_count} total errors out of "
-                            f"{gen_count} rows). Check data format and "
-                            f"preprocessor configuration."
-                        )
+                    logger.error(
+                        "Skipping data row due to error: {}. "
+                        "Check data format and preprocessor configuration.",
+                        err,
+                    )
                     gen_count -= 1
 
         if gen_count > 0 and yield_count == 0:
-            logger.warning(
+            raise ValueError(
                 f"Dataset iterator processed {gen_count} rows but yielded "
                 f"zero results ({error_count} errors). This usually means "
                 f"the column mapper could not match any dataset columns. "

--- a/src/guidellm/data/loaders.py
+++ b/src/guidellm/data/loaders.py
@@ -95,7 +95,6 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         gen_count = 0
         yield_count = 0
         error_count = 0
-        empty_count = 0
 
         with contextlib.suppress(StopIteration):
             dataset_iters = []

--- a/src/guidellm/data/loaders.py
+++ b/src/guidellm/data/loaders.py
@@ -85,7 +85,9 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
     def set_epoch(self, epoch: int):
         self.epoch = epoch
 
-    def generator(
+    _CONSECUTIVE_ERROR_WARN_THRESHOLD = 50
+
+    def generator(  # noqa: C901
         self,
         max_items: int | None = None,
         modulus: int | None = None,
@@ -93,6 +95,9 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         epoch: int = 0,
     ) -> Iterator[DataT]:
         gen_count = 0
+        yield_count = 0
+        error_count = 0
+        consecutive_errors = 0
 
         with contextlib.suppress(StopIteration):
             dataset_iters = []
@@ -121,12 +126,33 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
                     for preprocessor in self.preprocessors:
                         row = preprocessor(row)
 
-                    yield self.finalizer(row)
+                    result = self.finalizer(row)
+                    yield result
+                    yield_count += 1
+                    consecutive_errors = 0
                 except StopIteration:
                     raise  # Stop iteration when any dataset is exhausted
                 except Exception as err:  # noqa: BLE001 # Exception logged
+                    error_count += 1
+                    consecutive_errors += 1
                     logger.error(f"Skipping data row due to error: {err}")
+                    if consecutive_errors == self._CONSECUTIVE_ERROR_WARN_THRESHOLD:
+                        logger.warning(
+                            f"{self._CONSECUTIVE_ERROR_WARN_THRESHOLD} "
+                            f"consecutive row errors encountered "
+                            f"({error_count} total errors out of "
+                            f"{gen_count} rows). Check data format and "
+                            f"preprocessor configuration."
+                        )
                     gen_count -= 1
+
+        if gen_count > 0 and yield_count == 0:
+            logger.warning(
+                f"Dataset iterator processed {gen_count} rows but yielded "
+                f"zero results ({error_count} errors). This usually means "
+                f"the column mapper could not match any dataset columns. "
+                f"Check --data-column-mapper and dataset column names."
+            )
 
         if max_items is not None and gen_count < max_items:
             raise ValueError(

--- a/src/guidellm/data/loaders.py
+++ b/src/guidellm/data/loaders.py
@@ -95,6 +95,7 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         gen_count = 0
         yield_count = 0
         error_count = 0
+        empty_count = 0
 
         with contextlib.suppress(StopIteration):
             dataset_iters = []
@@ -144,9 +145,8 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         if gen_count > 0 and yield_count == 0:
             raise ValueError(
                 f"Dataset iterator processed {gen_count} rows but yielded "
-                f"zero results ({error_count} errors). This usually means "
-                f"the column mapper could not match any dataset columns. "
-                f"Check --data-column-mapper and dataset column names."
+                f"zero results ({error_count} errors; {gen_count - error_count} "
+                f"empty). Check your data and data arguments."
             )
 
         if max_items is not None and gen_count < max_items:

--- a/src/guidellm/data/preprocessors/mappers.py
+++ b/src/guidellm/data/preprocessors/mappers.py
@@ -113,6 +113,22 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
         datasets: list[Dataset | IterableDataset],
         input_mappings: dict[str, str | list[str]] | None = None,
     ) -> dict[DatasetColumnKey, list[DatasetColumnValue]]:
+        """
+        Resolve column mappings across one or more datasets.
+
+        For each dataset, matches actual column names against the requested
+        mapping names (or :attr:`defaults`) using regex patterns that account
+        for pluralisation and turn suffixes (e.g. ``prompt-0``, ``prompt-1``).
+
+        :param datasets: The loaded datasets to inspect for column names.
+        :param input_mappings: Optional explicit column mappings. When ``None``,
+            :attr:`defaults` is used. Values may be a single name or a list of
+            candidate names in priority order.
+        :return: A dict keyed by ``(column_type, turn_index)`` whose values are
+            lists of ``(dataset_index, column_name)`` pairs indicating where
+            each logical column can be found. Categories with no matching
+            columns are silently omitted from the result.
+        """
         mappings: dict[DatasetColumnKey, list[DatasetColumnValue]] = defaultdict(list)
         input_map: dict[str, list[str]] = cls.defaults
         if input_mappings:
@@ -204,28 +220,11 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
         )
 
         if not self.datasets_column_mappings:
-            available_cols: list[str] = []
-            for ds in datasets:
-                cols = ds.column_names or list(next(iter(ds)).keys())
-                available_cols.extend(cols)
             logger.warning(
                 "GenerativeColumnMapper found no matching columns. "
-                "Available dataset columns: {}. "
                 "Requested mappings: {}. "
                 "Every row will produce an empty result.",
-                available_cols,
-                self.input_mappings or self.defaults,
-            )
-        elif not any(
-            ct == "text_column" for ct, _turn in self.datasets_column_mappings
-        ):
-            mapped_types = sorted({ct for ct, _ in self.datasets_column_mappings})
-            logger.debug(
-                "GenerativeColumnMapper mapped columns but none resolved to "
-                "'text_column'. Mapped types: {}. "
-                "This is expected for non-text datasets (e.g. image, audio, "
-                "geospatial). If text content was intended, check column names.",
-                mapped_types,
+                self.input_mappings or "default mappings",
             )
 
 

--- a/src/guidellm/data/preprocessors/mappers.py
+++ b/src/guidellm/data/preprocessors/mappers.py
@@ -11,6 +11,7 @@ from guidellm.data.preprocessors.preprocessor import (
     PreprocessorRegistry,
 )
 from guidellm.data.schemas import GenerativeDatasetColumnType
+from guidellm.logger import logger
 
 __all__ = ["GenerativeColumnMapper", "PoolingColumnMapper"]
 
@@ -201,6 +202,27 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
         self.datasets_column_mappings = self.datasets_mappings(
             datasets, self.input_mappings
         )
+
+        if not self.datasets_column_mappings:
+            available_cols: list[str] = []
+            for ds in datasets:
+                cols = ds.column_names or list(next(iter(ds)).keys())
+                available_cols.extend(cols)
+            logger.warning(
+                "GenerativeColumnMapper found no matching columns. "
+                f"Available dataset columns: {available_cols}. "
+                f"Requested mappings: {self.input_mappings or self.defaults}. "
+                "Every row will produce an empty result."
+            )
+        elif not any(
+            ct == "text_column" for ct, _turn in self.datasets_column_mappings
+        ):
+            mapped_types = sorted({ct for ct, _ in self.datasets_column_mappings})
+            logger.warning(
+                "GenerativeColumnMapper mapped columns but none resolved to "
+                f"'text_column'. Mapped types: {mapped_types}. "
+                "Requests will have no text content."
+            )
 
 
 @PreprocessorRegistry.register("pooling_column_mapper")

--- a/src/guidellm/data/preprocessors/mappers.py
+++ b/src/guidellm/data/preprocessors/mappers.py
@@ -210,18 +210,22 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
                 available_cols.extend(cols)
             logger.warning(
                 "GenerativeColumnMapper found no matching columns. "
-                f"Available dataset columns: {available_cols}. "
-                f"Requested mappings: {self.input_mappings or self.defaults}. "
-                "Every row will produce an empty result."
+                "Available dataset columns: {}. "
+                "Requested mappings: {}. "
+                "Every row will produce an empty result.",
+                available_cols,
+                self.input_mappings or self.defaults,
             )
         elif not any(
             ct == "text_column" for ct, _turn in self.datasets_column_mappings
         ):
             mapped_types = sorted({ct for ct, _ in self.datasets_column_mappings})
-            logger.warning(
+            logger.debug(
                 "GenerativeColumnMapper mapped columns but none resolved to "
-                f"'text_column'. Mapped types: {mapped_types}. "
-                "Requests will have no text content."
+                "'text_column'. Mapped types: {}. "
+                "This is expected for non-text datasets (e.g. image, audio, "
+                "geospatial). If text content was intended, check column names.",
+                mapped_types,
             )
 
 

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -542,7 +542,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         else:
             return str(uuid.uuid4())
 
-    def requests_generator(  # noqa: C901
+    def requests_generator(
         self,
         requests: DatasetIterT[RequestT],
     ) -> Generator[ConversationT[RequestT], None, None]:
@@ -593,31 +593,12 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                         stop_queueing = True
                         return
 
-            empty_count = 0
             for request_chain in requests:
-                conversation = list(_turn_iter(request_chain))
-                if not conversation:
-                    empty_count += 1
-                    if empty_count == 1:
-                        logger.warning(
-                            "requests_generator received an empty conversation "
-                            "from the data pipeline (no turns). This usually "
-                            "means the column mapper could not match dataset "
-                            "columns. Check --data-column-mapper settings."
-                        )
-                    continue
-
-                yield conversation
+                yield list(_turn_iter(request_chain))
 
                 if stop_queueing:
                     self.stop_send_requests_event.set()
                     return
-
-            if count == 0:
-                raise RuntimeError(
-                    "Dataset produced zero valid requests. "
-                    "Check --data-column-mapper and dataset column names."
-                )
 
             # Reached the end, inject a RequestsExhaustedConstraint to record
             self._locked_update(

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -542,7 +542,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         else:
             return str(uuid.uuid4())
 
-    def requests_generator(
+    def requests_generator(  # noqa: C901
         self,
         requests: DatasetIterT[RequestT],
     ) -> Generator[ConversationT[RequestT], None, None]:
@@ -593,12 +593,31 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                         stop_queueing = True
                         return
 
+            empty_count = 0
             for request_chain in requests:
-                yield list(_turn_iter(request_chain))
+                conversation = list(_turn_iter(request_chain))
+                if not conversation:
+                    empty_count += 1
+                    if empty_count == 1:
+                        logger.warning(
+                            "requests_generator received an empty conversation "
+                            "from the data pipeline (no turns). This usually "
+                            "means the column mapper could not match dataset "
+                            "columns. Check --data-column-mapper settings."
+                        )
+                    continue
+
+                yield conversation
 
                 if stop_queueing:
                     self.stop_send_requests_event.set()
                     return
+
+            if count == 0:
+                raise RuntimeError(
+                    "Dataset produced zero valid requests. "
+                    "Check --data-column-mapper and dataset column names."
+                )
 
             # Reached the end, inject a RequestsExhaustedConstraint to record
             self._locked_update(


### PR DESCRIPTION
## Summary

Adds warnings and errors so that problems in the datasets are visible, rather than silently failing.
In main, if the dataset isn't processed correctly, GuideLLM deadlocks while the datasets are pending.

## Details

- Adds failure condition in scheduler/worker_group.py to abort if there are no requests.
- Adds some other warnings when there are no matching columns

## Test Plan

Currently, due to the other bugs, this command triggers the problem:
```
guidellm benchmark run \
  --target http://localhost:8000/ \
  --data "abisee/cnn_dailymail" \
  --data-args '{"name": "3.0.0"}' \
  --data-column-mapper '{"text_column":"article"}'
```

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [x] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
