### PR TITLE
Add instructions against common AI poor code quality habits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ tox -e tests -- -m regression
 - All tests must pass before committing
 - Markdown files must be properly formatted
 - Public functions in `src/` code must use the reStructuredText docstring format
-- All imports must be done at the top of the file unless necessary for functionality
-- Use of `getattr` should be avoided if possible as it hides incorrect usage of types
+- All imports **SHALL** be done at the top of the file
+- **DO NOT** use `getattr` or `setattr` as it hides incorrect usage of types
 
 ## Common Tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,15 +65,23 @@ tox -e tests -- -m regression
 - Use appropriate markers (`smoke`, `sanity`, `regression`)
 - Tests should be placed in files matching the name and path of the file under tests. E.g. `src/guidellm/benchmark/schemas/generative/entrypoints.py` -> `tests/unit/benchmark/schemas/generative/test_entrypoints.py`.
 
-### Style Requirements
+### Quality Requirements
 
 - All Python code must pass linting and formatting
 - All Python code must pass type checking
 - All tests must pass before committing
 - Markdown files must be properly formatted
+
+### Style Requirements
+
 - Public functions in `src/` code must use the reStructuredText docstring format
 - All imports **SHALL** be done at the top of the file
 - **DO NOT** use `getattr` or `setattr` as it hides incorrect usage of types
+
+### Design Requirements
+
+- Only touch sections of code that need to be changed for the given task
+- Prefer solutions that keep non-generic code out of generic pathways
 
 ## Common Tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ tox -e tests -- -m regression
 ### Design Requirements
 
 - Only touch sections of code that need to be changed for the given task
-- Prefer solutions that keep non-generic code out of generic pathways
+- When handling variant-specific logic, encapsulate it in methods on registry class implementations rather than adding if/else branches to generic code paths
+- Class implementations must fully encapsulate their unique logic and that logic must not leak into caller code paths.
 
 ## Common Tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ tox -e tests -- -m regression
 - All tests must pass before committing
 - Markdown files must be properly formatted
 - Public functions in `src/` code must use the reStructuredText docstring format
+- All imports must be done at the top of the file unless necessary for functionality
+- Use of `getattr` should be avoided if possible as it hides incorrect usage of types
 
 ## Common Tasks
 


### PR DESCRIPTION
## Summary

AI bots very frequently tend to import things inline and use `getattr`. But we have always found that to be a bad design, so this documents AI chatbots not to do these things.

## Details

- Inline imports are not ideal from a code style and maintainability standpoint 
- getattr is frequently used by AI to speculatively use values that don't exist on a type, reducing quality of the code.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [ ] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
