### PR TITLE
[v0.7 CLI Refactor] Rework BackendArgs to be the authoritative config location 

### DIFF
--- a/src/guidellm/backends/__init__.py
+++ b/src/guidellm/backends/__init__.py
@@ -11,7 +11,7 @@ handlers for processing streaming and non-streaming API responses.
 
 from guidellm.extras.vllm import HAS_VLLM
 
-from .backend import Backend, BackendArgs, BackendType
+from .backend import Backend, BackendArgs
 from .openai import (
     AudioRequestHandler,
     ChatCompletionsRequestHandler,
@@ -32,7 +32,6 @@ __all__ = [
     "AudioRequestHandler",
     "Backend",
     "BackendArgs",
-    "BackendType",
     "ChatCompletionsRequestHandler",
     "OpenAIHTTPBackend",
     "OpenAIRequestHandler",

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -9,7 +9,7 @@ provide a standard interface for distributed execution across worker processes.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from pydantic import ConfigDict, Field
 
@@ -24,11 +24,7 @@ from guidellm.utils.registry import RegistryMixin
 __all__ = [
     "Backend",
     "BackendArgs",
-    "BackendType",
 ]
-
-
-BackendType = Literal["openai_http", "vllm_python"]
 
 
 class BackendArgs(PydanticClassRegistryMixin["BackendArgs"], ABC):
@@ -63,7 +59,7 @@ class BackendArgs(PydanticClassRegistryMixin["BackendArgs"], ABC):
 
         return BackendArgs
 
-    type_: BackendType = Field(
+    type_: str = Field(
         alias="type",
         description="Type identifier for the backend configuration.",
     )

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -88,14 +88,15 @@ class Backend(
     ::
         @Backend.register("my_backend")
         class MyBackend(Backend):
-            def __init__(self, api_key: str):
-                super().__init__("my_backend")
-                self.api_key = api_key
+            def __init__(self, args: MyBackendArgs):
+                super().__init__(args)
+                self.api_key = args.api_key
 
             async def process_startup(self):
                 self.client = MyAPIClient(self.api_key)
 
-        backend = Backend.create("my_backend", api_key="secret")
+        args = MyBackendArgs(api_key="secret")
+        backend = Backend.create(args)
     """
 
     @classmethod

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -8,13 +8,17 @@ provide a standard interface for distributed execution across worker processes.
 
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import Literal
+from abc import ABC, abstractmethod
+from typing import ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict, Field
 
 from guidellm.scheduler import BackendInterface
-from guidellm.schemas import GenerationRequest, GenerationResponse
+from guidellm.schemas import (
+    GenerationRequest,
+    GenerationResponse,
+    PydanticClassRegistryMixin,
+)
 from guidellm.utils.registry import RegistryMixin
 
 __all__ = [
@@ -27,11 +31,42 @@ __all__ = [
 BackendType = Literal["openai_http", "vllm_python"]
 
 
-class BackendArgs(BaseModel):
-    """Base class for backend creation argument models."""
+class BackendArgs(PydanticClassRegistryMixin["BackendArgs"], ABC):
+    """
+    Base class for backend creation arguments.
 
-    # Allow for extra fields until we make BackendArgs the sole source of truth
-    model_config = ConfigDict(extra="allow")
+    This class serves as a base for defining argument models used in the creation
+    of backend instances. It inherits from PydanticClassRegistryMixin to enable
+    automatic registration of subclasses, allowing for flexible and extensible
+    backend configurations.
+
+    :cvar schema_discriminator: Field name for polymorphic deserialization
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+        ser_json_bytes="base64",
+        val_json_bytes="base64",
+    )
+
+    schema_discriminator: ClassVar[str] = "type"
+
+    @classmethod
+    def __pydantic_schema_base_type__(cls) -> type[BackendArgs]:
+        """
+        Return base type for polymorphic validation hierarchy.
+
+        :return: Base BackendArgs class for schema validation
+        """
+        if cls.__name__ == "BackendArgs":
+            return cls
+
+        return BackendArgs
+
+    type_: BackendType = Field(
+        alias="type",
+        description="Type identifier for the backend configuration.",
+    )
 
 
 class Backend(
@@ -68,7 +103,7 @@ class Backend(
     """
 
     @classmethod
-    def create(cls, type_: str, **kwargs) -> Backend:
+    def create(cls, args: BackendArgs) -> Backend:
         """
         Create a backend instance based on the backend type.
 
@@ -77,6 +112,7 @@ class Backend(
         :return: An instance of a subclass of Backend
         :raises ValueError: If the backend type is not registered
         """
+        type_ = args.type_
 
         backend = cls.get_registered_object(type_)
 
@@ -86,34 +122,15 @@ class Backend(
                 f"Available types: {list(cls.registry.keys()) if cls.registry else []}"
             )
 
-        return backend(**kwargs)
+        return backend(args)
 
-    @classmethod
-    def get_backend_args(cls, type_: str) -> type[BackendArgs]:
-        """
-        Return the Pydantic model class for the backend's creation arguments.
-
-        :param type_: The backend type identifier
-        :return: The backend's BackendArgs subclass
-        :raises ValueError: If the backend type is not registered
-        """
-        backend_class = cls.get_registered_object(type_)
-
-        if backend_class is None:
-            raise ValueError(
-                f"Backend type '{type_}' is not registered. "
-                f"Available types: {list(cls.registry.keys()) if cls.registry else []}"
-            )
-
-        return backend_class.backend_args()
-
-    def __init__(self, type_: str):
+    def __init__(self, args: BackendArgs):
         """
         Initialize a backend instance.
 
         :param type_: The backend type identifier
         """
-        self.type_ = type_
+        self.type_ = args.type_
 
     @property
     def processes_limit(self) -> int | None:
@@ -129,19 +146,6 @@ class Backend(
             None if unlimited
         """
         return None
-
-    @classmethod
-    @abstractmethod
-    def backend_args(cls) -> type[BackendArgs]:
-        """
-        Return the Pydantic model class for this backend's creation arguments.
-
-        The model defines the parameters (e.g. target, model) that the CLI/benchmark
-        supply when creating the backend. Used for validation and error messages.
-
-        :return: A BackendArgs subclass whose fields are the creation params
-        """
-        ...
 
     @abstractmethod
     async def default_model(self) -> str:

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -41,6 +41,7 @@ class BackendArgs(PydanticClassRegistryMixin["BackendArgs"], ABC):
 
     model_config = ConfigDict(
         extra="forbid",
+        serialize_by_alias=True,
         ser_json_bytes="base64",
         val_json_bytes="base64",
     )

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Literal
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import AliasChoices, Field, SecretStr, field_validator, model_validator
 
 from guidellm.backends.backend import Backend, BackendArgs
 from guidellm.backends.openai.request_handlers import OpenAIRequestHandlerFactory
@@ -30,76 +30,11 @@ from guidellm.utils.dict import deep_filter
 
 __all__ = [
     "OpenAIHTTPBackend",
-    "OpenAIHttpBackendArgs",
+    "OpenAIHTTPBackendArgs",
 ]
 
-
-class OpenAIHttpBackendArgs(BackendArgs):
-    """Pydantic model for OpenAI HTTP backend creation arguments."""
-
-    target: str = Field(
-        description="Base URL of the OpenAI-compatible server",
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' requires a target parameter. "
-                "Please provide --target with a valid endpoint URL."
-            )
-        },
-    )
-    model: str | None = Field(
-        default=None,
-        description="Model identifier for generation requests",
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' requires a model parameter. "
-                "Please provide --model with a valid model identifier."
-            )
-        },
-    )
-    request_format: str | None = Field(
-        default=None,
-        description=(
-            "Request format for OpenAI-compatible server. "
-            "Valid values: /v1/completions, /v1/chat/completions, "
-            "/v1/responses, /v1/audio/transcriptions, /v1/audio/translations, "
-            "or legacy aliases: text_completions, chat_completions, "
-            "audio_transcriptions, audio_translations."
-        ),
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' received an invalid --request-format. "
-                "Valid values: /v1/completions, /v1/chat/completions, "
-                "/v1/responses, /v1/audio/transcriptions, /v1/audio/translations, "
-                "or legacy aliases: text_completions, chat_completions, "
-                "audio_transcriptions, audio_translations."
-            )
-        },
-    )
-    server_history: bool = Field(
-        default=False,
-        description=(
-            "Use server-side conversation history (previous_response_id) for "
-            "multi-turn requests. Only supported with /v1/responses."
-        ),
-    )
-
-    @field_validator("request_format")
-    @classmethod
-    def validate_request_format(cls, v: str | None) -> str | None:
-        """Validate request_format against known handler names and aliases."""
-        if v is None:
-            return v
-        valid = set(LEGACY_API_ALIASES) | set(DEFAULT_API_PATHS) - {
-            "/health",
-            "/v1/models",
-        }
-        if v not in valid:
-            raise ValueError(
-                f"Invalid request_format '{v}'. Must be one of: "
-                f"{', '.join(sorted(valid))}"
-            )
-        return v
-
+# NOTE: This value is taken from httpx's default
+FALLBACK_TIMEOUT = 5.0
 
 DEFAULT_API_PATHS = {
     "/health": "health",
@@ -113,18 +48,114 @@ DEFAULT_API_PATHS = {
     "/pooling": "pooling",
 }
 
-DEFAULT_API = "/v1/chat/completions"
 
-# Legacy aliases for common API paths
-LEGACY_API_ALIASES = {
-    "text_completions": "/v1/completions",
-    "chat_completions": "/v1/chat/completions",
-    "audio_transcriptions": "/v1/audio/transcriptions",
-    "audio_translations": "/v1/audio/translations",
-}
+@BackendArgs.register("openai_http")
+class OpenAIHTTPBackendArgs(BackendArgs):
+    """Pydantic model for OpenAI HTTP backend creation arguments."""
 
-# NOTE: This value is taken from httpx's default
-FALLBACK_TIMEOUT = 5.0
+    type_: Literal["openai_http"] = Field(
+        alias="type",
+        default="openai_http",
+        description="Type identifier for the backend configuration.",
+    )
+    target: str = Field(
+        description="Base URL of the OpenAI-compatible server",
+    )
+    model: str = Field(
+        default_factory=str,
+        description="Model identifier for generation requests",
+    )
+    request_format: Literal[
+        "/v1/completions",
+        "/v1/chat/completions",
+        "/v1/embeddings",
+        "/v1/responses",
+        "/v1/audio/transcriptions",
+        "/v1/audio/translations",
+    ] = Field(
+        default="/v1/chat/completions",
+        description="Request format for OpenAI-compatible server.",
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        description="API key for authentication (for Bearer auth)",
+    )
+    api_routes: dict[str, str] = Field(
+        default_factory=dict,
+        validate_default=True,
+        description=(
+            "Custom API endpoint routes mapping. Keys should be request types "
+            "like '/v1/completions' and values should be the corresponding "
+            "endpoint paths relative to the target URL."
+        ),
+    )
+    timeout: float | None = Field(
+        default=None,
+        description="Request timeout in seconds for reading response.",
+    )
+    timeout_connect: float | None = Field(
+        default=FALLBACK_TIMEOUT,
+        description="Request timeout in seconds for establishing connection.",
+    )
+    http2: bool = Field(
+        default=True,
+        description="Enable HTTP/2 protocol.",
+    )
+    follow_redirects: bool = Field(
+        default=True,
+        description="Follow HTTP redirects automatically.",
+    )
+    verify: bool = Field(
+        default=False,
+        description="Verify the server's TLS certificate.",
+    )
+    validate_backend: bool = Field(
+        default=True,
+        description="Send a health check request to validate backend configuration.",
+    )
+    stream: bool = Field(
+        default=True,
+        description="Use streaming responses for generation requests when supported.",
+    )
+    extras: GenerationRequestArguments | None = Field(
+        default=None,
+        description="Additional parameters to include in generation requests.",
+    )
+    max_tokens: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("max_tokens", "max_completion_tokens"),
+        description="Maximum number of tokens to request in any response.",
+    )
+    server_history: bool = Field(
+        default=False,
+        description=(
+            "Use server-side conversation history (previous_response_id) for "
+            "multi-turn requests. Only supported with /v1/responses."
+        ),
+    )
+
+    @field_validator("target", mode="after")
+    @classmethod
+    def strip_target(cls, value: str) -> str:
+        """Strip trailing slashes and API paths from the target URL."""
+        return value.rstrip("/").removesuffix("/v1")
+
+    @field_validator("api_routes", mode="after")
+    @classmethod
+    def merge_api_routes(cls, value: dict[str, str]) -> dict[str, str]:
+        """Merge user-provided API routes with default routes."""
+        return DEFAULT_API_PATHS | value
+
+    @model_validator(mode="after")
+    def validate_server_history(self):
+        """Validate that server_history is only True with supported endpoints."""
+        if self.server_history and self.request_format != "/v1/responses":
+            raise ValueError(
+                "server_history=True is only supported with the /v1/responses "
+                "request format. Current request_format: "
+                f"'{self.request_format}'"
+            )
+        return self
 
 
 @Backend.register("openai_http")
@@ -139,11 +170,12 @@ class OpenAIHTTPBackend(Backend):
 
     Example:
     ::
-        backend = OpenAIHTTPBackend(
+        backend_args = OpenAIHTTPBackendArgs(
             target="http://localhost:8000",
             model="gpt-3.5-turbo",
-            api_key="your-api-key"
+            api_key="your-api-key",
         )
+        backend = OpenAIHTTPBackend(backend_args)
 
         await backend.process_startup()
         async for response, request_info in backend.resolve(request, info):
@@ -151,95 +183,15 @@ class OpenAIHTTPBackend(Backend):
         await backend.process_shutdown()
     """
 
-    @classmethod
-    def backend_args(cls) -> type[BackendArgs]:
-        """Return the Pydantic model for this backend's creation arguments."""
-        return OpenAIHttpBackendArgs
-
     def __init__(
         self,
-        target: str,
-        model: str = "",
-        request_format: str | None = None,
-        api_key: str | None = None,
-        api_routes: dict[str, str] | None = None,
-        request_handlers: dict[str, Any] | None = None,
-        timeout: float | None = None,
-        timeout_connect: float | None = FALLBACK_TIMEOUT,
-        http2: bool = True,
-        follow_redirects: bool = True,
-        verify: bool = False,
-        validate_backend: bool | str | dict[str, Any] = True,
-        stream: bool = True,
-        extras: dict[str, Any] | GenerationRequestArguments | None = None,
-        max_tokens: int | None = None,
-        max_completion_tokens: int | None = None,
-        server_history: bool = False,
+        arguments: OpenAIHTTPBackendArgs,
     ):
         """
         Initialize OpenAI HTTP backend with server configuration.
-
-        :param target: Base URL of the OpenAI-compatible server
-        :param model: Model identifier for generation requests
-        :param api_key: API key for authentication (for Bearer auth)
-        :param api_routes: Custom API endpoint routes mapping
-        :param response_handlers: Custom response handlers for different request types
-        :param timeout: Request timeout in seconds
-        :param http2: Enable HTTP/2 protocol support
-        :param follow_redirects: Follow HTTP redirects automatically
-        :param verify: Enable SSL certificate verification
-        :param validate_backend: Backend validation configuration
-        :param server_history: Use server-side conversation history
-            (previous_response_id) for multi-turn. Only with /v1/responses.
         """
         super().__init__(type_="openai_http")
-
-        # Request Values
-        self.target = target.rstrip("/").removesuffix("/v1")
-        self.model = model
-        self.api_key = api_key
-
-        # Resolve request format
-        if request_format is None:
-            request_format = DEFAULT_API
-        elif request_format in LEGACY_API_ALIASES:
-            request_format = LEGACY_API_ALIASES[request_format]
-
-        # Validate that the request handler exists
-        valid_formats = OpenAIRequestHandlerFactory.registered_names()
-        if request_format not in valid_formats:
-            raise ValueError(
-                f"Invalid request_format '{request_format}'. Must be one of: "
-                f"{', '.join(valid_formats)}"
-            )
-        self.request_type = request_format
-        self.server_history = server_history
-
-        if self.server_history and self.request_type != "/v1/responses":
-            raise ValueError(
-                "server_history=True is only supported with the Responses API "
-                "(/v1/responses). Current request format: "
-                f"'{self.request_type}'"
-            )
-
-        # Store configuration
-        self.api_routes = api_routes or DEFAULT_API_PATHS
-        self.request_handlers = request_handlers
-        self.timeout = timeout
-        self.timeout_connect = timeout_connect
-        self.http2 = http2
-        self.follow_redirects = follow_redirects
-        self.verify = verify
-        self.validate_backend: dict[str, Any] | None = self._resolve_validate_kwargs(
-            validate_backend
-        )
-        self.stream: bool = stream
-        self.extras = (
-            GenerationRequestArguments(**extras)
-            if extras and isinstance(extras, dict)
-            else extras
-        )
-        self.max_tokens: int | None = max_tokens or max_completion_tokens
+        self._args = arguments
 
         # Runtime state
         self._in_process = False
@@ -252,18 +204,7 @@ class OpenAIHTTPBackend(Backend):
 
         :return: Dictionary containing backend configuration details
         """
-        return {
-            "target": self.target,
-            "model": self.model,
-            "timeout": self.timeout,
-            "timeout_connect": self.timeout_connect,
-            "http2": self.http2,
-            "follow_redirects": self.follow_redirects,
-            "verify": self.verify,
-            "openai_paths": self.api_routes,
-            "validate_backend": self.validate_backend,
-            # Auth token excluded for security
-        }
+        return self._args.model_dump()
 
     async def process_startup(self):
         """
@@ -276,14 +217,14 @@ class OpenAIHTTPBackend(Backend):
             raise RuntimeError("Backend already started up for process.")
 
         self._async_client = httpx.AsyncClient(
-            http2=self.http2,
+            http2=self._args.http2,
             timeout=httpx.Timeout(
                 FALLBACK_TIMEOUT,
-                read=self.timeout,
-                connect=self.timeout_connect,
+                read=self._args.timeout,
+                connect=self._args.timeout_connect,
             ),
-            follow_redirects=self.follow_redirects,
-            verify=self.verify,
+            follow_redirects=self._args.follow_redirects,
+            verify=self._args.verify,
             # Allow unlimited connections
             limits=httpx.Limits(
                 max_connections=None,
@@ -316,12 +257,14 @@ class OpenAIHTTPBackend(Backend):
         if self._async_client is None:
             raise RuntimeError("Backend not started up for process.")
 
-        if not self.validate_backend:
+        if not self._args.validate_backend:
             return
 
         try:
-            # Merge bearer token headers into validate_backend dict
-            validate_kwargs = {**self.validate_backend}
+            validate_kwargs: dict[str, Any] = {
+                "method": "GET",
+                "url": f"{self._args.target}/{self._args.api_routes['/health']}",
+            }
             existing_headers = validate_kwargs.get("headers")
             built_headers = self._build_headers(existing_headers)
             validate_kwargs["headers"] = built_headers
@@ -344,7 +287,7 @@ class OpenAIHTTPBackend(Backend):
         if self._async_client is None:
             raise RuntimeError("Backend not started up for process.")
 
-        target = f"{self.target}/{self.api_routes['/v1/models']}"
+        target = f"{self._args.target}/{self._args.api_routes['/v1/models']}"
         response = await self._async_client.get(target, headers=self._build_headers())
         response.raise_for_status()
 
@@ -356,12 +299,12 @@ class OpenAIHTTPBackend(Backend):
 
         :return: Model name or None if no model is available
         """
-        if self.model or not self._in_process:
-            return self.model
+        if self._args.model or not self._in_process:
+            return self._args.model
 
         models = await self.available_models()
-        self.model = models[0] if models else ""
-        return self.model
+        self._args.model = models[0] if models else ""
+        return self._args.model
 
     async def resolve(  # type: ignore[override, misc]
         self,
@@ -387,23 +330,27 @@ class OpenAIHTTPBackend(Backend):
         if self._async_client is None:
             raise RuntimeError("Backend not started up for process.")
 
-        if (request_path := self.api_routes.get(self.request_type)) is None:
-            raise ValueError(f"Unsupported request type '{self.request_type}'")
+        if (
+            request_path := self._args.api_routes.get(self._args.request_format)
+        ) is None:
+            raise ValueError(
+                f"Unsupported request format '{self._args.request_format}'"
+            )
 
         request_handler = OpenAIRequestHandlerFactory.create(
-            self.request_type, handler_overrides=self.request_handlers
+            self._args.request_format,
         )
         arguments: GenerationRequestArguments = request_handler.format(
             data=request,
             history=history,
             model=(await self.default_model()),
-            stream=self.stream,
-            extras=self.extras,
-            max_tokens=self.max_tokens,
-            server_history=self.server_history,
+            stream=self._args.stream,
+            extras=self._args.extras,
+            max_tokens=self._args.max_tokens,
+            server_history=self._args.server_history,
         )
 
-        request_url = f"{self.target}/{request_path}"
+        request_url = f"{self._args.target}/{request_path}"
         request_files = (
             {
                 key: tuple(value) if isinstance(value, list) else value
@@ -513,40 +460,12 @@ class OpenAIHTTPBackend(Backend):
         headers: dict[str, str] = {}
 
         # Add bearer token if api_key is set
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+        if self._args.api_key:
+            token = self._args.api_key.get_secret_value()
+            headers["Authorization"] = f"Bearer {token}"
 
         # Merge with existing headers (user headers take precedence)
         if existing_headers:
             headers = {**headers, **existing_headers}
 
         return headers or None
-
-    def _resolve_validate_kwargs(
-        self, validate_backend: bool | str | dict[str, Any]
-    ) -> dict[str, Any] | None:
-        if not (validate_kwargs := validate_backend):
-            return None
-
-        if validate_kwargs is True:
-            validate_kwargs = "/health"
-
-        if isinstance(validate_kwargs, str) and validate_kwargs in self.api_routes:
-            validate_kwargs = f"{self.target}/{self.api_routes[validate_kwargs]}"
-
-        if isinstance(validate_kwargs, str):
-            validate_kwargs = {
-                "method": "GET",
-                "url": validate_kwargs,
-            }
-
-        if not isinstance(validate_kwargs, dict) or "url" not in validate_kwargs:
-            raise ValueError(
-                "validate_backend must be a boolean, string, or dictionary and contain "
-                f"a target URL. Got: {validate_kwargs}"
-            )
-
-        if "method" not in validate_kwargs:
-            validate_kwargs["method"] = "GET"
-
-        return validate_kwargs

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -190,7 +190,7 @@ class OpenAIHTTPBackend(Backend):
         """
         Initialize OpenAI HTTP backend with server configuration.
         """
-        super().__init__(type_="openai_http")
+        super().__init__(arguments)
         self._args = arguments
 
         # Runtime state

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -72,6 +72,7 @@ class OpenAIHTTPBackendArgs(BackendArgs):
         "/v1/responses",
         "/v1/audio/transcriptions",
         "/v1/audio/translations",
+        "/pooling",
     ] = Field(
         default="/v1/chat/completions",
         description="Request format for OpenAI-compatible server.",

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -14,11 +14,11 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import jinja2
 from more_itertools import roundrobin
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from guidellm.backends.backend import Backend, BackendArgs
 from guidellm.backends.vllm_python.vllm_response import VLLMResponseHandler
@@ -59,54 +59,68 @@ _CHAT_TEMPLATE_UNSET: object = object()
 __all__ = ["VLLMPythonBackend", "VLLMPythonBackendArgs"]
 
 
+@BackendArgs.register("vllm_python")
 class VLLMPythonBackendArgs(BackendArgs):
     """Pydantic model for VLLM Python backend creation arguments."""
 
+    type_: Literal["vllm_python"] = Field(
+        alias="type",
+        default="vllm_python",
+        description="Backend type identifier for VLLM Python backend.",
+    )
     model: str = Field(
         description="Model identifier or path for VLLM to load",
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' requires a model parameter. "
-                "Please provide --model with a valid model identifier."
-            )
-        },
     )
-    target: str | None = Field(
-        default=None,
-        description="Target URL (ignored for VLLM Python backend, runs locally)",
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' does not support a target parameter. "
-                "Please remove --target as this backend runs locally."
-            )
-        },
+    vllm_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Configuration dictionary for vLLM AsyncEngineArgs parameters. Pass "
+            "any valid AsyncEngineArgs parameters here (e.g. tensor_parallel_size, "
+            "gpu_memory_utilization, max_model_len). The 'model' parameter is required "
+            "and can be set here or via the top-level 'model' field; if set in both "
+            "places, the top-level 'model' field takes precedence."
+        ),
     )
-    request_format: str | None = Field(
-        default=None,
+    request_format: Literal["plain", "default-template"] | str = Field(
+        default="default-template",
         description=(
             "Request format for VLLM Python backend. "
             "Valid values: 'plain' (no chat template), 'default-template' "
             "(use tokenizer default), or a path to / inline Jinja2 chat template."
         ),
-        json_schema_extra={
-            "error_message": (
-                "Backend '{backend_type}' received an invalid --request-format. "
-                "Valid values: 'plain', 'default-template', a path to a Jinja2 "
-                "template file, or an inline Jinja2 template string."
-            )
-        },
+    )
+    stream: bool = Field(
+        default=True,
+        description="Whether to stream responses from the backend.",
+    )
+    image_placeholder: str = Field(
+        default="<image>",
+        description=(
+            "Placeholder string for image items in multimodal prompts. "
+            "Used when injecting placeholders for multimodal data."
+        ),
+    )
+    audio_placeholder: str = Field(
+        default="<|audio|>",
+        description=(
+            "Placeholder string for audio items in multimodal prompts. "
+            "Used when injecting placeholders for multimodal data."
+        ),
     )
 
-    @field_validator("target")
-    @classmethod
-    def target_must_be_none(cls, v: str | None) -> str | None:
-        """Reject target to prevent confusion.
+    @model_validator(mode="after")
+    def validate_vllm_config(self):
+        """Set defaults on vllm_config and ensure model is set."""
 
-        Validated by CLI before Backend.create.
-        """
-        if v is not None:
-            raise ValueError("Target is not supported; this backend runs locally.")
-        return v
+        if "model" in self.vllm_config:
+            logger.warning(
+                "The `model` input was passed to the vllm python backend "
+                "with the `vllm_config` input. Ignoring and overwriting "
+                "with the value from the `model` input."
+            )
+        self.vllm_config["model"] = self.model
+
+        return self
 
 
 class _ResolvedRequest(StandardBaseModel):
@@ -142,16 +156,8 @@ class VLLMPythonBackend(Backend):
     """
     Python API backend for VLLM inference engine.
 
-    Directly uses VLLM's AsyncLLMEngine for local async inference. When CUDA is not
-    available and ``device`` is not set in vllm_config, the backend sets
-    ``device="cpu"`` so the engine runs on CPU; otherwise vLLM uses CUDA if
-    available. You can pass ``device`` in vllm_config (e.g. ``"cpu"``, ``"cuda"``)
-    and it is passed through to AsyncEngineArgs. Handles request/response conversion
-    between GuideLLM schemas and VLLM's native API, with async support for finer
-    token-by-token processing and timings.
-
     Engine parameters not set in vllm_config use vLLM's AsyncEngineArgs defaults.
-    Example (optional overrides):
+    Example:
     ::
         backend = VLLMPythonBackend(model="meta-llama/Llama-2-7b-chat-hf")
         # Or: vllm_config={"tensor_parallel_size": 1, "gpu_memory_utilization": 0.9}
@@ -169,43 +175,14 @@ class VLLMPythonBackend(Backend):
 
     def __init__(
         self,
-        model: str,
-        vllm_config: dict[str, Any] | None = None,
-        request_format: str | None = None,
-        stream: bool = True,
-        image_placeholder: str | None = None,
-        audio_placeholder: str | None = None,
+        arguments: VLLMPythonBackendArgs,
     ):
         """
         Initialize VLLM Python backend with model and configuration.
-
-        :param model: Model identifier or path for VLLM to load
-        :param vllm_config: Optional dict of VLLM AsyncEngineArgs parameters.
-            Passed through with no GuideLLM defaults; only model (and optionally
-            chat_template) are set by the backend. When CUDA is not available and
-            ``device`` is not set here, the backend sets ``device="cpu"``. You can
-            pass ``device`` (e.g. ``"cpu"``, ``"cuda"``) and it is passed through.
-            Unset parameters use vLLM's defaults. Common options include
-            tensor_parallel_size, gpu_memory_utilization, max_model_len, and any
-            other parameter accepted by vllm.AsyncEngineArgs.
-        :param request_format: "plain" (no chat template), "default-template"
-            (use tokenizer default), or a chat template path / single-line string.
-        :param stream: Whether to stream responses (default True).
-        :param image_placeholder: Optional string to use as the image placeholder when
-            injecting placeholders for multimodal prompts (e.g. Qwen3-VL may require
-            a model-specific token). If not set, falls back to "<image>".
-        :param audio_placeholder: Optional string to use as the audio placeholder when
-            using audio_column; if unset, falls back to "<|audio|>".
         """
         _check_vllm_available()
         super().__init__(type_="vllm_python")
-
-        self.model = model
-        self.request_format = request_format
-        self.stream = stream
-        self._image_placeholder_override = image_placeholder
-        self._audio_placeholder_override = audio_placeholder
-        self.vllm_config = self._merge_config(vllm_config or {})
+        self._args = arguments
 
         # Runtime state
         self._in_process = False
@@ -220,32 +197,6 @@ class VLLMPythonBackend(Backend):
         """
         return 1
 
-    def _merge_config(self, user_config: dict[str, Any]) -> dict[str, Any]:
-        """
-        Build engine config from user config plus required model.
-
-        No GuideLLM defaults are applied; any parameter not set here or in
-        user_config is left to vLLM's AsyncEngineArgs defaults. Custom
-        request_format (chat template) is not passed to the engine; it is
-        applied at request time in _resolve_request to avoid AsyncEngineArgs
-        compatibility issues across vLLM versions.
-
-        :param user_config: User-provided configuration dictionary
-        :return: Config dict for AsyncEngineArgs (model set)
-        """
-        config = dict(user_config)
-
-        # Ensure model is set in config (required; overrides user if they passed it)
-        if "model" in config:
-            logger.warning(
-                "The `model` input was passed to the vllm python backend "
-                "with the `vllm_config` input. Ignoring and overwriting "
-                "with the value from the `model` input."
-            )
-        config["model"] = self.model
-
-        return config
-
     @property
     def info(self) -> dict[str, Any]:
         """
@@ -253,13 +204,7 @@ class VLLMPythonBackend(Backend):
 
         :return: Dictionary containing backend configuration details
         """
-        return {
-            "model": self.model,
-            "vllm_config": self.vllm_config,
-            "stream": self.stream,
-            "in_process": self._in_process,
-            "engine_initialized": self._engine is not None,
-        }
+        return self._args.model_dump()
 
     async def process_startup(self):
         """
@@ -270,7 +215,7 @@ class VLLMPythonBackend(Backend):
         if self._in_process:
             raise RuntimeError("Backend already started up for process.")
 
-        engine_args = AsyncEngineArgs(**self.vllm_config)  # type: ignore[misc]
+        engine_args = AsyncEngineArgs(**self._args.vllm_config)  # type: ignore[misc]
         self._engine = AsyncLLMEngine.from_engine_args(engine_args)  # type: ignore[misc]
         self._in_process = True
 
@@ -310,7 +255,7 @@ class VLLMPythonBackend(Backend):
         :return: List containing the configured model identifier
         """
         # VLLM only supports one model per VLLM instance.
-        return [self.model]
+        return [self._args.model]
 
     async def default_model(self) -> str:
         """
@@ -318,7 +263,7 @@ class VLLMPythonBackend(Backend):
 
         :return: Model name or identifier
         """
-        return self.model
+        return self._args.model
 
     def _validate_backend_initialized(self) -> AsyncLLMEngine:
         """
@@ -454,14 +399,14 @@ class VLLMPythonBackend(Backend):
         if images is not None:
             num = len(images) if isinstance(images, list | tuple) else 1
             if num > 0:
-                ph = self._image_placeholder_override or "<image>"
+                ph = self._args.image_placeholder
                 parts.extend([ph] * num)
         audio = multi_modal_data.get("audio")
         if audio is not None:
             # Single audio item (numpy array) — not a list of items.
             num = len(audio) if isinstance(audio, list | tuple) else 1
             if num > 0:
-                ph = self._audio_placeholder_override or "<|audio|>"
+                ph = self._args.audio_placeholder
                 parts.extend([ph] * num)
         if not parts:
             return ""
@@ -534,15 +479,15 @@ class VLLMPythonBackend(Backend):
         when valid. Raises ValueError for invalid input (wrong format, bad path,
         or invalid Jinja2 syntax).
         """
-        if self.request_format is None or self.request_format in (
+        template = self._args.request_format
+        if template in (
             "plain",
             "default-template",
         ):
             # No custom template provided; 'plain' and 'default-template' are handled
             # internally
             return None
-        value = self.request_format
-        path = Path(value)
+        path = Path(template)
         # Treat the request_format string as a file path. If it exists and contains
         # Jinja2 syntax, read the content as the template.
         if path.exists() and path.is_file():
@@ -560,16 +505,16 @@ class VLLMPythonBackend(Backend):
                     f"Invalid chat template in file {path.as_posix()!r}: {e}"
                 ) from e
             return content
-        if _has_jinja2_markers(value):
+        if _has_jinja2_markers(template):
             try:
-                jinja2.Template(value)
+                jinja2.Template(template)
             except jinja2.TemplateSyntaxError as e:
                 raise ValueError(f"Invalid chat template: {e}") from e
-            return value
+            return template
         raise ValueError(
             "request_format must be 'plain', 'default-template', a path to a "
             "Jinja2 template file, or a string containing Jinja2 template "
-            "syntax ({{, {%}, or {#). Got: " + repr(value) + "."
+            "syntax ({{, {%}, or {#). Got: " + repr(template) + "."
         )
 
     def _extract_prompt_chat_tokenizer(
@@ -581,7 +526,7 @@ class VLLMPythonBackend(Backend):
         if tokenizer is None:
             raise RuntimeError("Backend engine has no tokenizer.")
 
-        if self.request_format is None or self.request_format in (
+        if self._args.request_format in (
             "plain",
             "default-template",
         ):
@@ -642,7 +587,7 @@ class VLLMPythonBackend(Backend):
         use_content_blocks = (
             multi_modal_data
             and (text_blocks or prefix)
-            and self.request_format != "plain"
+            and self._args.request_format != "plain"
         )
 
         if use_content_blocks:
@@ -685,7 +630,7 @@ class VLLMPythonBackend(Backend):
                         formatted_messages, multi_modal_data
                     )
 
-                if self.request_format == "plain":
+                if self._args.request_format == "plain":
                     prompt = self._extract_prompt_chat_plain(formatted_messages)
                 else:
                     prompt = self._extract_prompt_chat_tokenizer(formatted_messages)
@@ -698,7 +643,7 @@ class VLLMPythonBackend(Backend):
 
         return _ResolvedRequest(
             prompt=prompt,
-            stream=self.stream,
+            stream=self._args.stream,
             multi_modal_data=multi_modal_data,
         )
 
@@ -883,7 +828,7 @@ class VLLMPythonBackend(Backend):
             ) from exc
         if "At most 0 audio" in error_msg or "audio(s) may be provided" in error_msg:
             raise RuntimeError(
-                f"Generation failed: The model '{self.model}' does not "
+                f"Generation failed: The model '{self._args.model}' does not "
                 f"support audio inputs. Use an audio-capable model "
                 f"(e.g. Whisper-based). Original error: {exc}"
             ) from exc

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -181,7 +181,7 @@ class VLLMPythonBackend(Backend):
         Initialize VLLM Python backend with model and configuration.
         """
         _check_vllm_available()
-        super().__init__(type_="vllm_python")
+        super().__init__(arguments)
         self._args = arguments
 
         # Runtime state

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -19,7 +19,7 @@ from torch.utils.data import Sampler
 from transformers import PreTrainedTokenizerBase
 from typing_extensions import TypeAliasType
 
-from guidellm.backends import Backend
+from guidellm.backends import Backend, BackendArgs
 from guidellm.benchmark.benchmarker import Benchmarker
 from guidellm.benchmark.outputs import (
     GenerativeBenchmarkerConsole,
@@ -78,9 +78,8 @@ ProcessorInputT = TypeAliasType("ProcessorInputT", str | Path | PreTrainedTokeni
 
 
 async def resolve_backend(
-    backend: str | Backend,
+    backend_args: BackendArgs,
     console: Console | None = None,
-    **backend_kwargs: Any,
 ) -> tuple[Backend, str]:
     """
     Initialize and validate a backend instance for benchmarking execution.
@@ -102,16 +101,12 @@ async def resolve_backend(
     :return: Tuple of initialized Backend instance and resolved model identifier
     """
     console_step = (
-        console.print_update_step(title=f"Initializing backend {backend}")
+        console.print_update_step(title=f"Initializing backend {backend_args.type_}")
         if console
         else None
     )
 
-    backend_instance = (
-        Backend.create(backend, **backend_kwargs)
-        if not isinstance(backend, Backend)
-        else backend
-    )
+    backend_instance = Backend.create(backend_args)
 
     if console_step:
         console_step.update(
@@ -480,11 +475,9 @@ async def benchmark_generative_text(
     :return: Tuple of GenerativeBenchmarksReport and dictionary of output format
         results
     """
-    backend_params = args.backend_kwargs.model_dump(exclude_defaults=True)
     backend, model = await resolve_backend(
-        backend=args.backend,
+        backend_args=args.backend_kwargs,
         console=console,
-        **backend_params,
     )
     processor = await resolve_processor(
         processor=args.processor, model=model, console=console

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -27,12 +27,11 @@ from pydantic import (
     ValidatorFunctionWrapHandler,
     field_serializer,
     field_validator,
-    model_validator,
 )
 from torch.utils.data import Sampler
 from transformers import PreTrainedTokenizerBase
 
-from guidellm.backends import Backend, BackendArgs
+from guidellm.backends import BackendArgs
 from guidellm.benchmark.profiles import Profile, ProfileType
 from guidellm.benchmark.scenarios import get_builtin_scenarios
 from guidellm.benchmark.schemas.base import TransientPhaseConfig
@@ -178,11 +177,8 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
         default=None, description="Request rate(s) for rate-based scheduling"
     )
     # Backend configuration
-    backend: str | Backend = Field(
-        default="openai_http", description="Backend type or instance for execution"
-    )
     backend_kwargs: BackendArgs = Field(
-        description="Additional backend configuration arguments",
+        description="Backend configuration arguments",
     )
     # Data configuration
     processor: str | Path | PreTrainedTokenizerBase | None = Field(
@@ -321,69 +317,6 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
                 return handler([value])
             else:
                 raise
-
-    @model_validator(mode="before")
-    @classmethod
-    def construct_backend_kwargs(cls, data: Any) -> Any:
-        """
-        Transform backend configuration into typed BackendArgs instance.
-
-        Extracts top-level target/model/request_format and merges them with
-        backend_kwargs to create the appropriate typed BackendArgs subclass.
-        """
-        if not isinstance(data, dict):
-            return data
-
-        backend = data.get("backend", cls.get_default("backend"))
-        backend_type = backend.type_ if isinstance(backend, Backend) else backend
-
-        try:
-            backend_args_class = Backend.get_backend_args(backend_type)
-        # Backend type invalid
-        except ValueError as err:
-            raise ValidationError.from_exception_data(
-                title="Backend Validation Error",
-                line_errors=[
-                    {
-                        "type": "value_error",
-                        "loc": ("backend",),
-                        "input": str(backend_type),
-                        "ctx": {"error": err},
-                    }
-                ],
-            ) from err
-
-        existing_kwargs = data.get("backend_kwargs", {})
-        # If we are passed a raw type
-        if not isinstance(existing_kwargs, BackendArgs):
-            data["backend_kwargs"] = backend_args_class.model_validate(existing_kwargs)
-        # If we are passed the BackendArgs for a different backend type
-        elif not isinstance(existing_kwargs, backend_args_class):
-            raise ValidationError.from_exception_data(
-                title="Backend Args Validation Error",
-                line_errors=[
-                    {
-                        "type": "model_type",
-                        "loc": ("backend_kwargs",),
-                        "input": existing_kwargs,
-                        "ctx": {
-                            "class_name": backend_args_class.__name__,
-                        },
-                    }
-                ],
-            )
-
-        return data
-
-    @field_serializer("backend")
-    def serialize_backend(self, backend: str | Backend) -> str:
-        """Serialize backend to type string."""
-        return backend.type_ if isinstance(backend, Backend) else backend
-
-    @field_serializer("backend_kwargs")
-    def serialize_backend_kwargs(self, backend_kwargs: BackendArgs) -> dict[str, Any]:
-        """Serialize BackendArgs instance to dict for storage."""
-        return backend_kwargs.model_dump()
 
     @field_serializer("data")
     def serialize_data(self, data: list[Any]) -> list[str | None]:

--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -10,7 +10,6 @@ import click
 from pydantic import ValidationError
 
 import guidellm.utils.cli as cli_tools
-from guidellm.backends import BackendType
 from guidellm.benchmark import (
     BenchmarkGenerativeTextArgs,
     GenerativeConsoleBenchmarkerProgress,
@@ -95,9 +94,7 @@ STRATEGY_PROFILE_CHOICES: list[str] = list(get_literal_vals(ProfileType | Strate
     "--backend",
     "--backend-type",  # legacy alias
     "backend",
-    type=click.Choice(list(get_literal_vals(BackendType))),
     default=BenchmarkGenerativeTextArgs.get_default("backend"),
-    help=f"Backend type. Options: {', '.join(get_literal_vals(BackendType))}.",
 )
 @click.option(
     "--backend-kwargs",

--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -94,14 +94,12 @@ STRATEGY_PROFILE_CHOICES: list[str] = list(get_literal_vals(ProfileType | Strate
     "--backend",
     "--backend-type",  # legacy alias
     "backend",
-    default=BenchmarkGenerativeTextArgs.get_default("backend"),
 )
 @click.option(
     "--backend-kwargs",
     "--backend-args",  # legacy alias
     "backend_kwargs",
     callback=cli_tools.parse_arguments,
-    default=BenchmarkGenerativeTextArgs.get_default("backend_kwargs"),
     help=(
         "JSON string of arguments to pass to the backend. E.g., "
         '\'{"api_key": "apikey-*", "verify": false}\''
@@ -383,6 +381,8 @@ def run(**kwargs):  # noqa: C901
 
     # Map top-level CLI options to backend_kwargs
     backend_kwargs = kwargs.pop("backend_kwargs", {})
+    backend_type = kwargs.pop("backend", "openai_http")
+    backend_kwargs["type"] = backend_type
     for alias in ("target", "model", "request_format"):
         with contextlib.suppress(KeyError):
             backend_kwargs[alias] = kwargs.pop(alias)

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -9,10 +9,11 @@ from unittest.mock import Mock, patch
 
 import httpx
 import pytest
+from pydantic import ValidationError
 from pytest_httpx import HTTPXMock, IteratorStream
 
 from guidellm.backends.backend import Backend
-from guidellm.backends.openai.http import OpenAIHTTPBackend
+from guidellm.backends.openai.http import OpenAIHTTPBackend, OpenAIHTTPBackendArgs
 from guidellm.backends.openai.request_handlers import (
     OpenAIRequestHandler,
     OpenAIRequestHandlerFactory,
@@ -25,6 +26,12 @@ from guidellm.schemas import (
     RequestTimings,
 )
 from tests.unit.testing_utils import async_timeout
+
+
+def _make_backend(**kwargs) -> OpenAIHTTPBackend:
+    """Create an OpenAIHTTPBackend from keyword arguments via BackendArgs."""
+    args = OpenAIHTTPBackendArgs(**kwargs)
+    return OpenAIHTTPBackend(args)
 
 
 class TestOpenAIHTTPBackend:
@@ -51,7 +58,7 @@ class TestOpenAIHTTPBackend:
     def valid_instances(self, request):
         """Fixture providing valid OpenAIHTTPBackend instances."""
         constructor_args = request.param
-        instance = OpenAIHTTPBackend(**constructor_args)
+        instance = _make_backend(**constructor_args)
         return instance, constructor_args
 
     @pytest.fixture
@@ -97,58 +104,57 @@ class TestOpenAIHTTPBackend:
         instance, constructor_args = valid_instances
         assert isinstance(instance, OpenAIHTTPBackend)
         expected_target = constructor_args["target"].rstrip("/").removesuffix("/v1")
-        assert instance.target == expected_target
+        assert instance._args.target == expected_target
         if "model" in constructor_args:
-            assert instance.model == constructor_args["model"]
+            assert instance._args.model == constructor_args["model"]
         if "timeout" in constructor_args:
-            assert instance.timeout == constructor_args["timeout"]
+            assert instance._args.timeout == constructor_args["timeout"]
         else:
-            assert instance.timeout is None
+            assert instance._args.timeout is None
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
         ("field", "value"),
         [
-            ("target", ""),
-            ("timeout", -1.0),
-            ("http2", "invalid"),
-            ("verify", "invalid"),
+            ("http2", "not-a-bool"),
+            ("verify", "not-a-bool"),
         ],
     )
     def test_invalid_initialization_values(self, field, value):
-        """Test OpenAIHTTPBackend with invalid field values."""
+        """Test OpenAIHTTPBackend rejects invalid field types via BackendArgs."""
         base_args = {"target": "http://localhost:8000"}
         base_args[field] = value
-        # OpenAI backend doesn't validate types at init, accepts whatever is passed
-        backend = OpenAIHTTPBackend(**base_args)
-        assert getattr(backend, field) == value
+        with pytest.raises(ValidationError):
+            _make_backend(**base_args)
 
     @pytest.mark.sanity
     def test_invalid_validate_backend_parameter(self):
-        """Test OpenAIHTTPBackend with invalid validate_backend parameter."""
-        # Invalid dict without url
-        with pytest.raises(ValueError, match="validate_backend must be"):
-            OpenAIHTTPBackend(
+        """Test OpenAIHTTPBackend with invalid validate_backend parameter types."""
+        # Dict is not a valid bool — raises ValidationError
+        with pytest.raises(ValidationError):
+            _make_backend(
                 target="http://localhost:8000",
-                validate_backend={"method": "GET"},
+                validate_backend={"method": "GET"},  # type: ignore[arg-type]
             )
 
-        # Invalid type (number)
-        with pytest.raises(ValueError, match="validate_backend must be"):
-            OpenAIHTTPBackend(
+        # Integer is not a valid bool coercion for non-0/1 values — depends on Pydantic
+        # The field is typed as bool, so Pydantic may accept 0/1 as False/True
+        # Test with a non-bool object that can't coerce
+        with pytest.raises((ValidationError, TypeError)):
+            _make_backend(
                 target="http://localhost:8000",
-                validate_backend=123,  # type: ignore[arg-type]
+                validate_backend="not-a-bool",  # type: ignore[arg-type]
             )
 
     @pytest.mark.sanity
     def test_server_history_requires_responses_api(self):
         """
-        Test server_history=True raises ValueError for non-responses request formats.
+        Test server_history=True raises ValidationError for non-responses formats.
 
         ## WRITTEN BY AI ##
         """
-        with pytest.raises(ValueError, match="server_history.*only supported"):
-            OpenAIHTTPBackend(
+        with pytest.raises(ValidationError):
+            _make_backend(
                 target="http://localhost:8000",
                 request_format="/v1/chat/completions",
                 server_history=True,
@@ -161,33 +167,34 @@ class TestOpenAIHTTPBackend:
 
         ## WRITTEN BY AI ##
         """
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://localhost:8000",
             request_format="/v1/responses",
             server_history=True,
         )
-        assert backend.server_history is True
+        assert backend._args.server_history is True
 
     @pytest.mark.smoke
     def test_factory_registration(self):
         """Test that OpenAIHTTPBackend is registered with Backend factory."""
         assert Backend.is_registered("openai_http")
-        backend = Backend.create("openai_http", target="http://test")
+        args = OpenAIHTTPBackendArgs(target="http://test")
+        backend = Backend.create(args)
         assert isinstance(backend, OpenAIHTTPBackend)
         assert backend.type_ == "openai_http"
 
     @pytest.mark.smoke
     def test_initialization_minimal(self):
         """Test minimal OpenAIHTTPBackend initialization."""
-        backend = OpenAIHTTPBackend(target="http://localhost:8000")
+        backend = _make_backend(target="http://localhost:8000")
 
-        assert backend.target == "http://localhost:8000"
-        assert backend.model == ""
-        assert backend.timeout is None
-        assert backend.timeout_connect == 5.0
-        assert backend.http2 is True
-        assert backend.follow_redirects is True
-        assert backend.verify is False
+        assert backend._args.target == "http://localhost:8000"
+        assert backend._args.model == ""
+        assert backend._args.timeout is None
+        assert backend._args.timeout_connect == 5.0
+        assert backend._args.http2 is True
+        assert backend._args.follow_redirects is True
+        assert backend._args.verify is False
         assert backend._in_process is False
         assert backend._async_client is None
         assert backend.processes_limit is None
@@ -197,13 +204,11 @@ class TestOpenAIHTTPBackend:
     def test_initialization_full(self):
         """Test full OpenAIHTTPBackend initialization."""
         api_routes = {"health": "custom/health", "models": "custom/models"}
-        request_handlers = {"test": "handler"}
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="https://localhost:8000/v1",
             model="test-model",
             api_routes=api_routes,
-            request_handlers=request_handlers,
             timeout=120.0,
             http2=False,
             follow_redirects=False,
@@ -211,15 +216,14 @@ class TestOpenAIHTTPBackend:
             validate_backend=False,
         )
 
-        assert backend.target == "https://localhost:8000"
-        assert backend.model == "test-model"
-        assert backend.timeout == 120.0
-        assert backend.http2 is False
-        assert backend.follow_redirects is False
-        assert backend.verify is True
-        assert backend.api_routes["health"] == "custom/health"
-        assert backend.api_routes["models"] == "custom/models"
-        assert backend.request_handlers == request_handlers
+        assert backend._args.target == "https://localhost:8000"
+        assert backend._args.model == "test-model"
+        assert backend._args.timeout == 120.0
+        assert backend._args.http2 is False
+        assert backend._args.follow_redirects is False
+        assert backend._args.verify is True
+        assert backend._args.api_routes["health"] == "custom/health"
+        assert backend._args.api_routes["models"] == "custom/models"
         assert backend.processes_limit is None
         assert backend.requests_limit is None
 
@@ -227,79 +231,60 @@ class TestOpenAIHTTPBackend:
     @pytest.mark.parametrize(
         ("validate_backend", "expected_validate_backend"),
         [
-            (True, {"method": "GET", "url": "http://test/health"}),
-            (False, None),
-            ("/health", {"method": "GET", "url": "http://test/health"}),
-            (
-                "http://custom/endpoint",
-                {"method": "GET", "url": "http://custom/endpoint"},
-            ),
-            (
-                {"url": "http://custom/url", "method": "POST"},
-                {"url": "http://custom/url", "method": "POST"},
-            ),
-            (
-                {"url": "http://custom/url"},
-                {"url": "http://custom/url", "method": "GET"},
-            ),
+            (True, True),
+            (False, False),
         ],
         ids=[
             "bool_true",
             "bool_false",
-            "str_api_route",
-            "str_custom_url",
-            "dict_with_method",
-            "dict_without_method",
         ],
     )
     def test_validate_backend_parameter(
         self, validate_backend, expected_validate_backend
     ):
-        """Test validate_backend parameter with various input types."""
-        backend = OpenAIHTTPBackend(
+        """Test validate_backend parameter stores boolean value."""
+        backend = _make_backend(
             target="http://test",
             validate_backend=validate_backend,
         )
-        assert backend.validate_backend == expected_validate_backend
+        assert backend._args.validate_backend == expected_validate_backend
 
     @pytest.mark.sanity
     def test_target_normalization(self):
         """Test target URL normalization."""
         # Remove trailing slashes and /v1
-        backend1 = OpenAIHTTPBackend(target="http://localhost:8000/")
-        assert backend1.target == "http://localhost:8000"
+        backend1 = _make_backend(target="http://localhost:8000/")
+        assert backend1._args.target == "http://localhost:8000"
 
-        backend2 = OpenAIHTTPBackend(target="http://localhost:8000/v1")
-        assert backend2.target == "http://localhost:8000"
+        backend2 = _make_backend(target="http://localhost:8000/v1")
+        assert backend2._args.target == "http://localhost:8000"
 
-        backend3 = OpenAIHTTPBackend(target="http://localhost:8000/v1/")
-        assert backend3.target == "http://localhost:8000"
+        backend3 = _make_backend(target="http://localhost:8000/v1/")
+        assert backend3._args.target == "http://localhost:8000"
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
     @async_timeout(10.0)
     async def test_info(self):
         """Test info method."""
-        backend = OpenAIHTTPBackend(
-            target="http://test", model="test-model", timeout=30.0
-        )
+        backend = _make_backend(target="http://test", model="test-model", timeout=30.0)
 
         info = backend.info
 
         assert info["target"] == "http://test"
         assert info["model"] == "test-model"
         assert info["timeout"] == 30.0
-        assert info["openai_paths"]["/health"] == "health"
-        assert info["openai_paths"]["/v1/models"] == "v1/models"
-        assert info["openai_paths"]["/v1/completions"] == "v1/completions"
-        assert info["openai_paths"]["/v1/chat/completions"] == "v1/chat/completions"
+        assert info["api_routes"]["/health"] == "health"
+        assert info["api_routes"]["/v1/models"] == "v1/models"
+        assert info["api_routes"]["/v1/completions"] == "v1/completions"
+        assert info["api_routes"]["/v1/chat/completions"] == "v1/chat/completions"
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
     @async_timeout(10.0)
     async def test_process_startup(self):
         """Test process startup."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
 
         assert not backend._in_process
         assert backend._async_client is None
@@ -315,7 +300,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_process_startup_already_started(self):
         """Test process startup when already started."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
         await backend.process_startup()
 
         with pytest.raises(RuntimeError, match="Backend already started up"):
@@ -326,7 +311,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_process_shutdown(self):
         """Test process shutdown."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
         await backend.process_startup()
 
         assert backend._in_process
@@ -342,7 +327,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_process_shutdown_not_started(self):
         """Test process shutdown when not started."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
 
         with pytest.raises(RuntimeError, match="Backend not started up"):
             await backend.process_shutdown()
@@ -357,7 +342,7 @@ class TestOpenAIHTTPBackend:
             json={"data": [{"id": "test-model1"}, {"id": "test-model2"}]},
         )
 
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
         await backend.process_startup()
 
         models = await backend.available_models()
@@ -369,17 +354,17 @@ class TestOpenAIHTTPBackend:
     async def test_default_model(self):
         """Test default_model method."""
         # Test when model is already set
-        backend1 = OpenAIHTTPBackend(target="http://test", model="test-model")
+        backend1 = _make_backend(target="http://test", model="test-model")
         result1 = await backend1.default_model()
         assert result1 == "test-model"
 
         # Test when not in process
-        backend2 = OpenAIHTTPBackend(target="http://test")
+        backend2 = _make_backend(target="http://test")
         result2 = await backend2.default_model()
         assert result2 == ""
 
         # Test when in process but no model set
-        backend3 = OpenAIHTTPBackend(target="http://test")
+        backend3 = _make_backend(target="http://test")
         await backend3.process_startup()
 
         with patch.object(backend3, "available_models", return_value=["test-model2"]):
@@ -397,7 +382,7 @@ class TestOpenAIHTTPBackend:
             headers={},
         )
 
-        backend = OpenAIHTTPBackend(target="http://test", model="test-model")
+        backend = _make_backend(target="http://test", model="test-model")
         await backend.process_startup()
 
         await backend.validate()  # Should not raise
@@ -407,7 +392,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_validate_without_model(self):
         """Test validate method when no model is set."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
         await backend.process_startup()
 
         mock_response = Mock()
@@ -421,7 +406,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_validate_not_in_process(self):
         """Test validate method when backend is not started."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
 
         with pytest.raises(RuntimeError, match="Backend not started up"):
             await backend.validate()
@@ -431,7 +416,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_validate_disabled(self):
         """Test validate method when validation is disabled."""
-        backend = OpenAIHTTPBackend(target="http://test", validate_backend=False)
+        backend = _make_backend(target="http://test", validate_backend=False)
         await backend.process_startup()
 
         # Should not raise and should not make any requests
@@ -442,7 +427,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_validate_failure(self):
         """Test validate method when validation fails."""
-        backend = OpenAIHTTPBackend(target="http://test")
+        backend = _make_backend(target="http://test")
         await backend.process_startup()
 
         def mock_fail(*args, **kwargs):
@@ -459,9 +444,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_resolve_with_history(self, httpx_mock: HTTPXMock):
         """Test resolve method handles conversation history."""
-        backend = OpenAIHTTPBackend(
-            target="http://test", request_format="text_completions"
-        )
+        backend = _make_backend(target="http://test", request_format="/v1/completions")
 
         # Mock the models endpoint
         httpx_mock.add_response(
@@ -513,8 +496,8 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_resolve_invalid_request_format(self, httpx_mock: HTTPXMock):
         """Test resolve method raises error for invalid request type."""
-        with pytest.raises(ValueError, match="Invalid request_format 'invalid_type'."):
-            OpenAIHTTPBackend(
+        with pytest.raises(ValidationError):
+            _make_backend(
                 target="http://test",
                 request_format="invalid_type",  # type: ignore[arg-type]
             )
@@ -524,9 +507,7 @@ class TestOpenAIHTTPBackend:
     @async_timeout(10.0)
     async def test_resolve_not_in_process(self, httpx_mock: HTTPXMock):
         """Test resolve method raises error when backend is not started."""
-        backend = OpenAIHTTPBackend(
-            target="http://test", request_format="text_completions"
-        )
+        backend = _make_backend(target="http://test", request_format="/v1/completions")
 
         request = GenerationRequest()
         request_info = RequestInfo(
@@ -556,10 +537,10 @@ class TestOpenAIHTTPBackend:
             json={"choices": [{"text": "Hello world"}]},
         )
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://test",
             model="test-model",
-            request_format="text_completions",
+            request_format="/v1/completions",
         )
         await backend.process_startup()
 
@@ -605,10 +586,10 @@ class TestOpenAIHTTPBackend:
             json={"choices": [{"message": {"content": "Response"}}]},
         )
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://test",
             model="test-model",
-            request_format="chat_completions",
+            request_format="/v1/chat/completions",
         )
         await backend.process_startup()
 
@@ -657,10 +638,10 @@ class TestOpenAIHTTPBackend:
             json={"choices": [{"message": {"content": "Response"}}]},
         )
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://test",
             model="test-model",
-            request_format="audio_transcriptions",
+            request_format="/v1/audio/transcriptions",
         )
         await backend.process_startup()
 
@@ -710,7 +691,7 @@ class TestOpenAIHTTPBackend:
             ),
         )
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://test",
             model="test-model",
             stream=True,
@@ -776,10 +757,10 @@ class TestOpenAIHTTPBackend:
 
         httpx_mock.add_callback(capture_request, url="http://test/v1/chat/completions")
 
-        backend = OpenAIHTTPBackend(
+        backend = _make_backend(
             target="http://test",
             model="test-model",
-            request_format="chat_completions",
+            request_format="/v1/chat/completions",
         )
         await backend.process_startup()
 

--- a/tests/unit/backends/test_backend.py
+++ b/tests/unit/backends/test_backend.py
@@ -29,6 +29,175 @@ class _TestBackendArgs(BackendArgs):
     model: str | None = None
 
 
+class TestBackendArgs:
+    """Test cases for BackendArgs base class."""
+
+    @pytest.mark.smoke
+    def test_class_signatures(self):
+        """Verify BackendArgs inheritance, discriminator, and available methods.
+
+        ### WRITTEN BY AI ###
+        """
+        from guidellm.schemas import PydanticClassRegistryMixin
+
+        assert issubclass(BackendArgs, PydanticClassRegistryMixin)
+        assert BackendArgs.schema_discriminator == "type"
+        assert "type_" in BackendArgs.model_fields
+        assert hasattr(BackendArgs, "register")
+        assert hasattr(BackendArgs, "is_registered")
+        assert hasattr(BackendArgs, "model_dump")
+        assert hasattr(BackendArgs, "model_validate")
+        assert hasattr(BackendArgs, "model_validate_json")
+
+    @pytest.mark.smoke
+    def test_cannot_instantiate_base(self):
+        """BackendArgs raises TypeError on direct instantiation.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(TypeError):
+            BackendArgs(type="test")  # type: ignore
+
+    @pytest.mark.smoke
+    def test_default_instantiation(self):
+        """_TestBackendArgs instantiates with defaults.
+
+        ### WRITTEN BY AI ###
+        """
+        args = _TestBackendArgs()
+        assert args.type_ == "test_backend"
+        assert args.target is None
+        assert args.model is None
+
+    @pytest.mark.smoke
+    def test_explicit_field_values(self):
+        """_TestBackendArgs stores explicitly provided field values.
+
+        ### WRITTEN BY AI ###
+        """
+        args = _TestBackendArgs(target="http://localhost:8000", model="gpt-4")
+        assert args.type_ == "test_backend"
+        assert args.target == "http://localhost:8000"
+        assert args.model == "gpt-4"
+
+    @pytest.mark.sanity
+    def test_extra_fields_rejected(self):
+        """Extra fields raise ValidationError due to extra='forbid' config.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(ValidationError):
+            _TestBackendArgs(unknown_field="value")  # type: ignore
+
+    @pytest.mark.sanity
+    def test_serialization_uses_alias(self):
+        """model_dump() produces 'type' alias key, not 'type_' field name.
+
+        ### WRITTEN BY AI ###
+        """
+        args = _TestBackendArgs()
+        data = args.model_dump()
+        assert "type" in data
+        assert "type_" not in data
+        assert data["type"] == "test_backend"
+
+    @pytest.mark.sanity
+    def test_model_dump_roundtrip(self):
+        """model_dump() -> model_validate() round-trip preserves all field values.
+
+        ### WRITTEN BY AI ###
+        """
+        args = _TestBackendArgs(target="http://localhost:8000", model="my-model")
+        data = args.model_dump()
+        restored = _TestBackendArgs.model_validate(data)
+        assert restored.type_ == args.type_
+        assert restored.target == args.target
+        assert restored.model == args.model
+
+    @pytest.mark.sanity
+    def test_model_dump_json_roundtrip(self):
+        """model_dump_json() -> model_validate_json() round-trip preserves all fields.
+
+        ### WRITTEN BY AI ###
+        """
+        args = _TestBackendArgs(target="http://localhost:8000", model="my-model")
+        json_str = args.model_dump_json()
+        restored = _TestBackendArgs.model_validate_json(json_str)
+        assert restored.type_ == args.type_
+        assert restored.target == args.target
+        assert restored.model == args.model
+
+    @pytest.mark.sanity
+    def test_polymorphic_validation_from_dict(self):
+        """BackendArgs.model_validate dispatches to correct subclass via discriminator.
+
+        ### WRITTEN BY AI ###
+        """
+        from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
+
+        data = {"type": "openai_http", "target": "http://localhost:8000"}
+        result = BackendArgs.model_validate(data)
+        assert isinstance(result, OpenAIHTTPBackendArgs)
+        assert result.type_ == "openai_http"
+
+    @pytest.mark.sanity
+    def test_polymorphic_validation_from_json(self):
+        """BackendArgs.model_validate_json dispatches to correct subclass.
+
+        ### WRITTEN BY AI ###
+        """
+        from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
+
+        args = OpenAIHTTPBackendArgs(target="http://localhost:8000")
+        result = BackendArgs.model_validate_json(args.model_dump_json())
+        assert isinstance(result, OpenAIHTTPBackendArgs)
+        assert result.type_ == "openai_http"
+
+    @pytest.mark.sanity
+    def test_polymorphic_unknown_type_rejected(self):
+        """BackendArgs.model_validate raises ValidationError for unknown discriminator.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(ValidationError):
+            BackendArgs.model_validate({"type": "nonexistent_backend_xyz"})
+
+    @pytest.mark.regression
+    def test_registration_adds_to_registry(self):
+        """BackendArgs.register adds subclass to registry and polymorphic dispatch.
+
+        ### WRITTEN BY AI ###
+        """
+
+        @BackendArgs.register("test_reg_args_unique")
+        class TestRegisteredArgs(BackendArgs):
+            type_: Literal["test_reg_args_unique"] = Field(  # type: ignore[assignment]
+                alias="type",
+                default="test_reg_args_unique",
+            )
+
+        assert BackendArgs.is_registered("test_reg_args_unique")
+        result = BackendArgs.model_validate({"type": "test_reg_args_unique"})
+        assert isinstance(result, TestRegisteredArgs)
+        assert result.type_ == "test_reg_args_unique"
+
+    @pytest.mark.regression
+    def test_polymorphic_dump_restore_via_base(self):
+        """Subclass serialized via model_dump() round-trips through model_validate().
+
+        ### WRITTEN BY AI ###
+        """
+        from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
+
+        args = OpenAIHTTPBackendArgs(target="http://localhost:8000", model="gpt-4")
+        data = args.model_dump()
+        restored = BackendArgs.model_validate(data)
+        assert isinstance(restored, OpenAIHTTPBackendArgs)
+        assert restored.type_ == "openai_http"
+        assert restored.target == args.target
+        assert restored.model == args.model
+
+
 class TestBackend:
     """Test cases for Backend base class."""
 

--- a/tests/unit/backends/test_backend.py
+++ b/tests/unit/backends/test_backend.py
@@ -19,6 +19,7 @@ from tests.unit.testing_utils import async_timeout
 class _TestBackendArgs(BackendArgs):
     """Minimal backend args model for test backends."""
 
+    type_: str = "test_backend"
     target: str | None = None
     model: str | None = None
 
@@ -37,10 +38,6 @@ class TestBackend:
         constructor_args = request.param
 
         class TestBackendImpl(Backend):
-            @classmethod
-            def backend_args(cls) -> type[BackendArgs]:
-                return _TestBackendArgs
-
             @property
             def info(self) -> dict[str, Any]:
                 return {"type": self.type_, "test": "backend"}
@@ -91,7 +88,6 @@ class TestBackend:
 
         # Check abstract methods exist
         assert hasattr(Backend, "default_model")
-        assert hasattr(Backend, "backend_args")
 
     @pytest.mark.smoke
     def test_initialization(self, valid_instances):
@@ -113,10 +109,6 @@ class TestBackend:
         """Test Backend with invalid field values."""
 
         class TestBackendImpl(Backend):
-            @classmethod
-            def backend_args(cls) -> type[BackendArgs]:
-                return _TestBackendArgs
-
             @property
             def info(self) -> dict[str, Any]:
                 return {}
@@ -146,10 +138,6 @@ class TestBackend:
         """Test Backend initialization without required field."""
 
         class TestBackendImpl(Backend):
-            @classmethod
-            def backend_args(cls) -> type[BackendArgs]:
-                return _TestBackendArgs
-
             @property
             def info(self) -> dict[str, Any]:
                 return {}
@@ -253,41 +241,47 @@ class TestBackend:
     @pytest.mark.smoke
     def test_create(self):
         """Test Backend.create class method with valid backend."""
-        # Mock a registered backend
         mock_backend_class = Mock()
         mock_backend_instance = Mock()
         mock_backend_class.return_value = mock_backend_instance
 
+        mock_args = Mock(spec=BackendArgs)
+        mock_args.type_ = "openai_http"
+
         with patch.object(
             Backend, "get_registered_object", return_value=mock_backend_class
         ):
-            result = Backend.create("openai_http", test_arg="value")
+            result = Backend.create(mock_args)
 
             Backend.get_registered_object.assert_called_once_with("openai_http")
-            mock_backend_class.assert_called_once_with(test_arg="value")
+            mock_backend_class.assert_called_once_with(mock_args)
             assert result == mock_backend_instance
 
     @pytest.mark.sanity
     def test_create_invalid(self):
         """Test Backend.create class method with invalid backend type."""
+        mock_args = Mock(spec=BackendArgs)
+        mock_args.type_ = "invalid_type"
+
         with pytest.raises(
             ValueError, match="Backend type 'invalid_type' is not registered"
         ):
-            Backend.create("invalid_type")  # type: ignore
+            Backend.create(mock_args)
 
     @pytest.mark.regression
     def test_docstring_example_pattern(self):
         """Test that Backend docstring examples work as documented."""
 
+        @BackendArgs.register("my_backend")
+        class MyBackendArgs(BackendArgs):
+            type_: str = "my_backend"  # type: ignore[assignment]
+            api_key: str = ""
+
         # Test the pattern shown in docstring
         class MyBackend(Backend):
-            @classmethod
-            def backend_args(cls) -> type[BackendArgs]:
-                return _TestBackendArgs
-
-            def __init__(self, api_key: str):
-                super().__init__("mock_backend")  # type: ignore [arg-type]
-                self.api_key = api_key
+            def __init__(self, arguments: MyBackendArgs):
+                super().__init__("my_backend")
+                self.api_key = arguments.api_key
 
             @property
             def info(self) -> dict[str, Any]:
@@ -311,19 +305,22 @@ class TestBackend:
         # Register the backend
         Backend.register("my_backend")(MyBackend)
 
-        # Create instance
-        backend = Backend.create("my_backend", api_key="secret")
+        # Create instance using BackendArgs
+        args = MyBackendArgs(api_key="secret")
+        backend = Backend.create(args)
         assert isinstance(backend, MyBackend)
         assert backend.api_key == "secret"
-        assert backend.type_ == "mock_backend"
+        assert backend.type_ == "my_backend"
 
     @pytest.mark.smoke
     def test_openai_backend_registered(self):
         """Test that OpenAI HTTP backend is registered."""
         from guidellm.backends.openai import OpenAIHTTPBackend
+        from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
 
         # OpenAI backend should be registered
-        backend = Backend.create("openai_http", target="http://test")
+        args = OpenAIHTTPBackendArgs(target="http://test")
+        backend = Backend.create(args)
         assert isinstance(backend, OpenAIHTTPBackend)
         assert backend.type_ == "openai_http"
 
@@ -333,32 +330,34 @@ class TestBackend:
         Test that vllm_python backend is registered and createable.
         ## WRITTEN BY AI ##
         """
-        from unittest.mock import patch
-
-        from guidellm.backends.vllm_python.vllm import VLLMPythonBackend
+        from guidellm.backends.vllm_python.vllm import (
+            VLLMPythonBackend,
+            VLLMPythonBackendArgs,
+        )
 
         assert Backend.is_registered("vllm_python")
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = Backend.create("vllm_python", model="test-model")
+            args = VLLMPythonBackendArgs(model="test-model")
+            backend = Backend.create(args)
         assert isinstance(backend, VLLMPythonBackend)
-        assert backend.model == "test-model"
+        assert backend._args.model == "test-model"
         assert backend.type_ == "vllm_python"
 
     @pytest.mark.smoke
     def test_backend_registry_functionality(self):
         """Test that backend registry functions work."""
         from guidellm.backends.openai import OpenAIHTTPBackend
+        from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
 
         # Test that we can get registered backends
         openai_class = Backend.get_registered_object("openai_http")
         assert openai_class == OpenAIHTTPBackend
 
-        # Test creating with kwargs
-        backend = Backend.create(
-            "openai_http", target="http://localhost:8000", model="gpt-4"
-        )
-        assert backend.target == "http://localhost:8000"
-        assert backend.model == "gpt-4"
+        # Test creating with BackendArgs
+        args = OpenAIHTTPBackendArgs(target="http://localhost:8000", model="gpt-4")
+        backend = Backend.create(args)
+        assert backend._args.target == "http://localhost:8000"
+        assert backend._args.model == "gpt-4"
 
     @pytest.mark.smoke
     def test_is_registered(self):
@@ -373,16 +372,17 @@ class TestBackend:
     def test_registration_decorator(self):
         """Test that backend registration decorator works."""
 
+        @BackendArgs.register("test_decorator_backend")
+        class TestDecoratorArgs(BackendArgs):
+            type_: str = "test_decorator_backend"  # type: ignore[assignment]
+            test_param: str = "default"
+
         # Create a test backend class
         @Backend.register("test_decorator_backend")
         class TestDecoratorBackend(Backend):
-            @classmethod
-            def backend_args(cls) -> type[BackendArgs]:
-                return _TestBackendArgs
-
-            def __init__(self, test_param="default"):
+            def __init__(self, arguments: TestDecoratorArgs):
                 super().__init__("test_decorator_backend")  # type: ignore
-                self._test_param = test_param
+                self._test_param = arguments.test_param
 
             @property
             def info(self):
@@ -404,7 +404,8 @@ class TestBackend:
                 return "test-model"
 
         # Test that it's registered and can be created
-        backend = Backend.create("test_decorator_backend", test_param="custom")
+        args = TestDecoratorArgs(test_param="custom")
+        backend = Backend.create(args)
         assert isinstance(backend, TestDecoratorBackend)
         assert backend.info == {"test_param": "custom"}
 

--- a/tests/unit/backends/test_backend.py
+++ b/tests/unit/backends/test_backend.py
@@ -5,10 +5,11 @@ Unit tests for the Backend base class and registry functionality.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import Field, ValidationError
 
 from guidellm.backends import Backend, BackendArgs
 from guidellm.schemas import GenerationRequest, RequestInfo
@@ -19,7 +20,11 @@ from tests.unit.testing_utils import async_timeout
 class _TestBackendArgs(BackendArgs):
     """Minimal backend args model for test backends."""
 
-    type_: str = "test_backend"
+    type_: Literal["test_backend"] = Field(
+        alias="type",
+        default="test_backend",
+        description="Type identifier for the backend configuration.",
+    )
     target: str | None = None
     model: str | None = None
 
@@ -27,15 +32,10 @@ class _TestBackendArgs(BackendArgs):
 class TestBackend:
     """Test cases for Backend base class."""
 
-    @pytest.fixture(
-        params=[
-            {"type_": "openai_http"},
-        ],
-        ids=["openai_http_type"],
-    )
-    def valid_instances(self, request):
+    @pytest.fixture
+    def valid_instances(self):
         """Fixture providing valid Backend instances."""
-        constructor_args = request.param
+        constructor_args = {"type_": "test_backend"}
 
         class TestBackendImpl(Backend):
             @property
@@ -59,7 +59,8 @@ class TestBackend:
             async def default_model(self) -> str:
                 return "test-model"
 
-        instance = TestBackendImpl(**constructor_args)
+        args = _TestBackendArgs()
+        instance = TestBackendImpl(args)
         return instance, constructor_args
 
     @pytest.mark.smoke
@@ -106,32 +107,9 @@ class TestBackend:
         ],
     )
     def test_invalid_initialization_values(self, field, value):
-        """Test Backend with invalid field values."""
-
-        class TestBackendImpl(Backend):
-            @property
-            def info(self) -> dict[str, Any]:
-                return {}
-
-            async def process_startup(self):
-                pass
-
-            async def process_shutdown(self):
-                pass
-
-            async def validate(self):
-                pass
-
-            async def resolve(self, request, request_info, history=None):
-                yield request, request_info
-
-            async def default_model(self) -> str:
-                return "test-model"
-
-        data = {field: value}
-        # Backend itself doesn't validate types, but we test that it accepts the value
-        backend = TestBackendImpl(**data)
-        assert getattr(backend, field) == value
+        """Test BackendArgs rejects invalid field values via pydantic validation."""
+        with pytest.raises(ValidationError):
+            _TestBackendArgs(**{field: value})
 
     @pytest.mark.sanity
     def test_invalid_initialization_missing(self):
@@ -280,7 +258,7 @@ class TestBackend:
         # Test the pattern shown in docstring
         class MyBackend(Backend):
             def __init__(self, arguments: MyBackendArgs):
-                super().__init__("my_backend")
+                super().__init__(arguments)
                 self.api_key = arguments.api_key
 
             @property
@@ -381,7 +359,7 @@ class TestBackend:
         @Backend.register("test_decorator_backend")
         class TestDecoratorBackend(Backend):
             def __init__(self, arguments: TestDecoratorArgs):
-                super().__init__("test_decorator_backend")  # type: ignore
+                super().__init__(arguments)
                 self._test_param = arguments.test_param
 
             @property

--- a/tests/unit/backends/vllm_python/test_vllm.py
+++ b/tests/unit/backends/vllm_python/test_vllm.py
@@ -18,6 +18,7 @@ import pytest
 
 from guidellm.backends.vllm_python.vllm import (
     VLLMPythonBackend,
+    VLLMPythonBackendArgs,
     _has_jinja2_markers,
     _ResolvedRequest,
 )
@@ -27,6 +28,12 @@ from guidellm.schemas import (
     RequestInfo,
     UsageMetrics,
 )
+
+
+def _make_vllm_backend(**kwargs) -> VLLMPythonBackend:
+    """Create a VLLMPythonBackend from keyword arguments via BackendArgs."""
+    args = VLLMPythonBackendArgs(**kwargs)
+    return VLLMPythonBackend(args)
 
 
 def _fake_sampling_params(**kwargs):
@@ -61,7 +68,7 @@ def backend():
             _fake_sampling_params,
         ),
     ):
-        yield VLLMPythonBackend(model="test-model")
+        yield _make_vllm_backend(model="test-model")
 
 
 class TestResolveRequest:
@@ -77,7 +84,7 @@ class TestResolveRequest:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_plain = VLLMPythonBackend(
+            backend_plain = _make_vllm_backend(
                 model="test-model", request_format="plain"
             )
         request = GenerationRequest(columns={"text_column": ["hello"]})
@@ -94,7 +101,7 @@ class TestResolveRequest:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(
+            backend = _make_vllm_backend(
                 model="test-model", stream=False, request_format="plain"
             )
         request = GenerationRequest(columns={"text_column": ["hello"]})
@@ -108,7 +115,7 @@ class TestResolveRequest:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(model="test-model", request_format="plain")
+            backend = _make_vllm_backend(model="test-model", request_format="plain")
         request = GenerationRequest(
             columns={
                 "prefix_column": ["System prompt"],
@@ -125,7 +132,7 @@ class TestResolveRequest:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_plain = VLLMPythonBackend(
+            backend_plain = _make_vllm_backend(
                 model="test-model", request_format="plain"
             )
         request = GenerationRequest(columns={"text_column": ["hello"]})
@@ -166,7 +173,7 @@ class TestResolveRequest:
         """
         mock_pil = Mock()
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(model="test-model", request_format="plain")
+            backend = _make_vllm_backend(model="test-model", request_format="plain")
         request = GenerationRequest(
             columns={
                 "text_column": ["Describe this"],
@@ -218,7 +225,7 @@ class TestResolveRequest:
         mock_tokenizer.apply_chat_template = fake_apply_chat_template
 
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(
+            backend = _make_vllm_backend(
                 model="test-model", request_format="default-template"
             )
         backend._engine = Mock()
@@ -257,7 +264,7 @@ class TestResolveRequest:
         mock_decode_result = _mock_audio_decode_result(mock_audio_array)
 
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(model="test-model", request_format="plain")
+            backend = _make_vllm_backend(model="test-model", request_format="plain")
 
         request = GenerationRequest(
             columns={
@@ -297,7 +304,7 @@ class TestImagePlaceholderInjection:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_custom = VLLMPythonBackend(
+            backend_custom = _make_vllm_backend(
                 model="Qwen/Qwen3-VL-2B-Instruct",
                 image_placeholder=("<|vision_start|><|image_pad|><|vision_end|>"),
             )
@@ -381,7 +388,7 @@ class TestAudioPlaceholderInjection:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_custom = VLLMPythonBackend(
+            backend_custom = _make_vllm_backend(
                 model="zai-org/GLM-ASR-Nano-2512",
                 audio_placeholder=("<|begin_of_audio|><|pad|><|end_of_audio|>"),
             )
@@ -545,7 +552,7 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_plain = VLLMPythonBackend(
+            backend_plain = _make_vllm_backend(
                 model="test-model", request_format="plain"
             )
         request = GenerationRequest(
@@ -566,7 +573,7 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_api = VLLMPythonBackend(
+            backend_api = _make_vllm_backend(
                 model="test-model", request_format="chat_completions"
             )
             backend_api._engine = Mock()
@@ -588,7 +595,7 @@ class TestVLLMRequestFormat:
         mock_tokenizer = Mock()
         mock_tokenizer.apply_chat_template.return_value = "formatted_prompt"
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_default = VLLMPythonBackend(
+            backend_default = _make_vllm_backend(
                 model="test-model", request_format="default-template"
             )
             backend_default._engine = Mock()
@@ -610,7 +617,7 @@ class TestVLLMRequestFormat:
         mock_tokenizer = Mock()
         mock_tokenizer.apply_chat_template.return_value = "default_prompt"
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_none = VLLMPythonBackend(model="test-model")
+            backend_none = _make_vllm_backend(model="test-model")
             backend_none._engine = Mock()
             backend_none._engine.tokenizer = mock_tokenizer
         request = GenerationRequest(columns={"text_column": ["Hi"]})
@@ -627,7 +634,7 @@ class TestVLLMRequestFormat:
         mock_tokenizer = Mock()
         mock_tokenizer.apply_chat_template.return_value = "custom_prompt"
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_custom = VLLMPythonBackend(
+            backend_custom = _make_vllm_backend(
                 model="test-model",
                 request_format="{{ messages[0]['content'] }}",
             )
@@ -650,7 +657,7 @@ class TestVLLMRequestFormat:
         mock_tokenizer = Mock()
         mock_tokenizer.apply_chat_template.return_value = "Custom: Hi"
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_file = VLLMPythonBackend(
+            backend_file = _make_vllm_backend(
                 model="test-model", request_format=str(template_file)
             )
             backend_file._engine = Mock()
@@ -673,7 +680,7 @@ class TestVLLMRequestFormat:
         mock_tokenizer = Mock()
         mock_tokenizer.apply_chat_template.return_value = "Hi"
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_file = VLLMPythonBackend(
+            backend_file = _make_vllm_backend(
                 model="test-model", request_format=str(template_file)
             )
             backend_file._engine = Mock()
@@ -694,7 +701,7 @@ class TestVLLMRequestFormat:
         no_markers_file = tmp_path / "plain.txt"
         no_markers_file.write_text("just plain text")
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_file = VLLMPythonBackend(
+            backend_file = _make_vllm_backend(
                 model="test-model", request_format=str(no_markers_file)
             )
             backend_file._engine = Mock()
@@ -712,7 +719,7 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_bad = VLLMPythonBackend(
+            backend_bad = _make_vllm_backend(
                 model="test-model", request_format="{{ unclosed"
             )
             backend_bad._engine = Mock()
@@ -730,12 +737,12 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_custom = VLLMPythonBackend(
+            backend_custom = _make_vllm_backend(
                 model="test-model",
                 request_format="/path/to/template.jinja",
             )
-        assert backend_custom.request_format == "/path/to/template.jinja"
-        assert "chat_template" not in backend_custom.vllm_config
+        assert backend_custom._args.request_format == "/path/to/template.jinja"
+        assert "chat_template" not in backend_custom._args.vllm_config
 
     @pytest.mark.sanity
     def test_request_format_plain_not_in_vllm_config(self):
@@ -744,11 +751,11 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_plain = VLLMPythonBackend(
+            backend_plain = _make_vllm_backend(
                 model="test-model", request_format="plain"
             )
-        assert backend_plain.request_format == "plain"
-        assert "chat_template" not in backend_plain.vllm_config
+        assert backend_plain._args.request_format == "plain"
+        assert "chat_template" not in backend_plain._args.vllm_config
 
     @pytest.mark.sanity
     def test_request_format_default_template_not_in_vllm_config(self):
@@ -757,11 +764,11 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_def = VLLMPythonBackend(
+            backend_def = _make_vllm_backend(
                 model="test-model", request_format="default-template"
             )
-        assert backend_def.request_format == "default-template"
-        assert "chat_template" not in backend_def.vllm_config
+        assert backend_def._args.request_format == "default-template"
+        assert "chat_template" not in backend_def._args.vllm_config
 
     @pytest.mark.sanity
     def test_vllm_config_empty_uses_vllm_defaults(self):
@@ -770,12 +777,10 @@ class TestVLLMRequestFormat:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend_empty = VLLMPythonBackend(model="test-model", vllm_config={})
-            backend_none = VLLMPythonBackend(model="test-model", vllm_config=None)
-        for b in (backend_empty, backend_none):
-            assert b.vllm_config.get("model") == "test-model"
-            assert "tensor_parallel_size" not in b.vllm_config
-            assert "gpu_memory_utilization" not in b.vllm_config
+            backend_empty = _make_vllm_backend(model="test-model", vllm_config={})
+        assert backend_empty._args.vllm_config.get("model") == "test-model"
+        assert "tensor_parallel_size" not in backend_empty._args.vllm_config
+        assert "gpu_memory_utilization" not in backend_empty._args.vllm_config
 
 
 class TestVLLMStreamingUsageFromOutput:
@@ -954,7 +959,7 @@ class TestVLLMLifecycle:
             ) as mock_engine_cls,
         ):
             mock_engine_cls.from_engine_args = Mock(return_value=mock_engine)
-            backend = VLLMPythonBackend(model="test-model")
+            backend = _make_vllm_backend(model="test-model")
             await backend.process_startup()
         assert backend._engine is mock_engine
         assert backend._in_process is True
@@ -978,7 +983,7 @@ class TestVLLMLifecycle:
             ) as mock_engine_cls,
         ):
             mock_engine_cls.from_engine_args = Mock(return_value=mock_engine)
-            backend = VLLMPythonBackend(model="test-model")
+            backend = _make_vllm_backend(model="test-model")
             await backend.process_startup()
             with pytest.raises(RuntimeError, match="Backend already started up"):
                 await backend.process_startup()
@@ -1002,7 +1007,7 @@ class TestVLLMLifecycle:
             ) as mock_engine_cls,
         ):
             mock_engine_cls.from_engine_args = Mock(return_value=mock_engine)
-            backend = VLLMPythonBackend(model="test-model")
+            backend = _make_vllm_backend(model="test-model")
             await backend.process_startup()
             await backend.process_shutdown()
         mock_engine.shutdown.assert_called_once()
@@ -1017,7 +1022,7 @@ class TestVLLMLifecycle:
         ## WRITTEN BY AI ##
         """
         with patch("guidellm.backends.vllm_python.vllm._check_vllm_available"):
-            backend = VLLMPythonBackend(model="test-model")
+            backend = _make_vllm_backend(model="test-model")
             backend._in_process = False
             backend._engine = None
         with pytest.raises(RuntimeError, match="Backend not started up"):

--- a/tests/unit/benchmark/schemas/generative/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/generative/test_entrypoints.py
@@ -11,7 +11,7 @@ import pytest
 from pydantic import ValidationError
 
 from guidellm.backends.backend import BackendArgs
-from guidellm.backends.openai.http import OpenAIHttpBackendArgs
+from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
 from guidellm.benchmark.schemas.generative.entrypoints import (
     BenchmarkGenerativeTextArgs,
 )
@@ -32,14 +32,14 @@ class TestBackendArgsTransformation:
 
     def test_dict_backend_kwargs_transformed(self):
         """
-        Test that dict backend_kwargs is transformed to BackendArgs.
+        Test that dict backend_kwargs with type field is transformed to BackendArgs.
 
         ### WRITTEN BY AI ###
         """
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
                 },
@@ -47,8 +47,8 @@ class TestBackendArgsTransformation:
             }
         )
 
-        # Verify backend_kwargs is typed OpenAIHttpBackendArgs
-        assert isinstance(args.backend_kwargs, OpenAIHttpBackendArgs)
+        # Verify backend_kwargs is typed OpenAIHTTPBackendArgs
+        assert isinstance(args.backend_kwargs, OpenAIHTTPBackendArgs)
         assert args.backend_kwargs.target == "http://localhost:9000"
         assert args.backend_kwargs.model == "test_model"
 
@@ -60,8 +60,8 @@ class TestBackendArgsTransformation:
         """
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
                     "request_format": "/v1/completions",
@@ -70,7 +70,7 @@ class TestBackendArgsTransformation:
             }
         )
 
-        assert isinstance(args.backend_kwargs, OpenAIHttpBackendArgs)
+        assert isinstance(args.backend_kwargs, OpenAIHTTPBackendArgs)
         assert args.backend_kwargs.target == "http://localhost:9000"
         assert args.backend_kwargs.model == "test_model"
         assert args.backend_kwargs.request_format == "/v1/completions"
@@ -79,13 +79,16 @@ class TestBackendArgsTransformation:
         """
         Test that serialization and deserialization preserves typed backend_kwargs.
 
+        The round-trip requires by_alias=True so the 'type' discriminator field
+        is serialized with its alias name rather than the Python field name 'type_'.
+
         ### WRITTEN BY AI ###
         """
         # Create instance with dict backend_kwargs
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
                 },
@@ -93,19 +96,25 @@ class TestBackendArgsTransformation:
             }
         )
 
-        # Serialize to dict
-        serialized = args.model_dump()
+        # Serialize backend_kwargs with by_alias=True so type discriminator is preserved
+        serialized_kwargs = args.backend_kwargs.model_dump(by_alias=True)
 
-        # Should serialize backend_kwargs as dict
-        assert isinstance(serialized["backend_kwargs"], dict)
-        assert serialized["backend_kwargs"]["target"] == "http://localhost:9000"
-        assert serialized["backend_kwargs"]["model"] == "test_model"
+        # Should serialize backend_kwargs as dict with type key
+        assert isinstance(serialized_kwargs, dict)
+        assert serialized_kwargs["type"] == "openai_http"
+        assert serialized_kwargs["target"] == "http://localhost:9000"
+        assert serialized_kwargs["model"] == "test_model"
 
-        # Deserialize back
-        args2 = BenchmarkGenerativeTextArgs.model_validate(serialized)
+        # Deserialize back using the aliased dict
+        args2 = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": serialized_kwargs,
+                "data": ["prompt_tokens=256,output_tokens=128"],
+            }
+        )
 
         # Should reconstruct typed instance
-        assert isinstance(args2.backend_kwargs, OpenAIHttpBackendArgs)
+        assert isinstance(args2.backend_kwargs, OpenAIHTTPBackendArgs)
         assert args2.backend_kwargs.target == "http://localhost:9000"
         assert args2.backend_kwargs.model == "test_model"
 
@@ -119,8 +128,8 @@ class TestBackendArgsTransformation:
         with pytest.raises(ValidationError) as exc_info:
             BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "openai_http",
                     "backend_kwargs": {
+                        "type": "openai_http",
                         "model": "test_model",
                         # Missing 'target'
                     },
@@ -142,8 +151,8 @@ class TestBackendArgsTransformation:
         with pytest.raises(ValidationError) as exc_info:
             BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "openai_http",
                     "backend_kwargs": {
+                        "type": "openai_http",
                         "target": "http://localhost:9000",
                         "model": "test_model",
                         "request_format": "invalid_format",
@@ -166,8 +175,8 @@ class TestBackendArgsTransformation:
         """
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "vllm_python",
                 "backend_kwargs": {
+                    "type": "vllm_python",
                     "model": "facebook/opt-125m",
                 },
                 "data": ["prompt_tokens=256,output_tokens=128"],
@@ -178,44 +187,41 @@ class TestBackendArgsTransformation:
         assert VLLMPythonBackendArgs is not None
         assert isinstance(args.backend_kwargs, VLLMPythonBackendArgs)
         assert args.backend_kwargs.model == "facebook/opt-125m"
-        # VLLM backend doesn't use target
-        assert args.backend_kwargs.target is None
 
     @pytest.mark.skipif(not HAS_VLLM, reason="VLLM not installed")
     def test_vllm_backend_rejects_target(self):
         """
-        Test that VLLM backend rejects target parameter.
+        Test that VLLM backend rejects target parameter (extra="forbid").
 
         ### WRITTEN BY AI ###
         """
         with pytest.raises(ValidationError) as exc_info:
             BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "vllm_python",
                     "backend_kwargs": {
-                        "target": "http://localhost:9000",  # Not allowed for VLLM
+                        "type": "vllm_python",
+                        "target": "http://localhost:9000",  # Not a field in VLLM args
                         "model": "facebook/opt-125m",
                     },
                     "data": ["prompt_tokens=256,output_tokens=128"],
                 }
             )
 
-        # Should have validation error about target not being supported
+        # Should have validation error about target not being a valid field
         errors = exc_info.value.errors()
         assert len(errors) > 0
         assert any("target" in str(err).lower() for err in errors)
 
     def test_empty_dict_backend_kwargs(self):
         """
-        Test handling of empty dict backend_kwargs.
+        Test handling of empty dict backend_kwargs (missing type field).
 
         ### WRITTEN BY AI ###
         """
-        # Empty dict should fail validation if required fields are missing
+        # Empty dict without 'type' should fail validation
         with pytest.raises(ValidationError):
             BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "openai_http",
                     "backend_kwargs": {},
                     "data": ["prompt_tokens=256,output_tokens=128"],
                 }
@@ -223,42 +229,43 @@ class TestBackendArgsTransformation:
 
     def test_default_backend_kwargs(self):
         """
-        Test that default backend_kwargs (empty dict) fails validation.
+        Test that missing backend_kwargs fails validation (required field).
 
         ### WRITTEN BY AI ###
         """
-        # Default backend_kwargs should fail validation if required fields missing
+        # backend_kwargs is required with no default
         with pytest.raises(ValidationError):
             BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "openai_http",
-                    # No backend_kwargs provided, uses default
+                    # No backend_kwargs provided
                     "data": ["prompt_tokens=256,output_tokens=128"],
                 }
             )
 
-    def test_already_typed_backend_kwargs_preserved(self):
+    def test_already_typed_backend_kwargs_via_aliased_dump(self):
         """
-        Test that already-typed BackendArgs instances are preserved.
+        Test that already-typed BackendArgs can be passed via aliased dict dump.
+
+        Direct instance passing fails because Pydantic's discriminator looks for
+        a 'type' attribute but the field is named 'type_'. Use model_dump(by_alias=True)
+        to produce the correctly keyed dict for round-trip validation.
 
         ### WRITTEN BY AI ###
         """
-        # Create a typed BackendArgs instance
-        backend_args = OpenAIHttpBackendArgs(
+        # Create a typed BackendArgs instance and dump with alias
+        backend_args = OpenAIHTTPBackendArgs(
             target="http://localhost:9000", model="test_model"
         )
 
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
-                "backend_kwargs": backend_args,
+                "backend_kwargs": backend_args.model_dump(by_alias=True),
                 "data": ["prompt_tokens=256,output_tokens=128"],
             }
         )
 
-        # Should preserve the typed instance
-        assert args.backend_kwargs is backend_args
-        assert isinstance(args.backend_kwargs, OpenAIHttpBackendArgs)
+        # Should produce a typed instance
+        assert isinstance(args.backend_kwargs, OpenAIHTTPBackendArgs)
         assert args.backend_kwargs.target == "http://localhost:9000"
         assert args.backend_kwargs.model == "test_model"
 
@@ -270,8 +277,8 @@ class TestBackendArgsTransformation:
         """
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
                 },
@@ -281,44 +288,42 @@ class TestBackendArgsTransformation:
 
         # Should be a BackendArgs subclass
         assert isinstance(args.backend_kwargs, BackendArgs)
-        assert isinstance(args.backend_kwargs, OpenAIHttpBackendArgs)
+        assert isinstance(args.backend_kwargs, OpenAIHTTPBackendArgs)
 
-    def test_extra_fields_allowed(self):
+    def test_api_key_is_securestr(self):
         """
-        Test that extra fields in backend_kwargs are allowed.
+        Test that api_key is stored as SecretStr.
 
         ### WRITTEN BY AI ###
         """
-        # Extra fields should be allowed due to ConfigDict(extra="allow")
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
-                    "api_key": "secret123",  # Extra field
-                    "timeout": 30,  # Extra field
+                    "api_key": "secret123",
                 },
                 "data": ["prompt_tokens=256,output_tokens=128"],
             }
         )
 
-        assert isinstance(args.backend_kwargs, OpenAIHttpBackendArgs)
+        assert isinstance(args.backend_kwargs, OpenAIHTTPBackendArgs)
         assert args.backend_kwargs.target == "http://localhost:9000"
-        # Extra fields should be accessible
-        assert hasattr(args.backend_kwargs, "api_key")
-        assert args.backend_kwargs.api_key == "secret123"
+        # api_key is SecretStr — access via get_secret_value()
+        assert args.backend_kwargs.api_key is not None
+        assert args.backend_kwargs.api_key.get_secret_value() == "secret123"
 
-    def test_serialization_preserves_extra_fields(self):
+    def test_serialization_masks_api_key(self):
         """
-        Test that serialization preserves extra fields.
+        Test that serialization masks api_key (SecretStr behavior).
 
         ### WRITTEN BY AI ###
         """
         args = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:9000",
                     "model": "test_model",
                     "api_key": "secret123",
@@ -329,8 +334,10 @@ class TestBackendArgsTransformation:
 
         serialized = args.model_dump()
 
-        # Extra fields should be in serialized output
-        assert serialized["backend_kwargs"]["api_key"] == "secret123"
+        # api_key key should be present in serialized output
+        assert "api_key" in serialized["backend_kwargs"]
+        # SecretStr serializes as "**********" by default
+        assert serialized["backend_kwargs"]["api_key"] != "secret123"
 
     def test_different_backend_types(self):
         """
@@ -341,22 +348,22 @@ class TestBackendArgsTransformation:
         # OpenAI HTTP backend
         args_openai = BenchmarkGenerativeTextArgs.model_validate(
             {
-                "backend": "openai_http",
                 "backend_kwargs": {
+                    "type": "openai_http",
                     "target": "http://localhost:8000",
                     "model": "gpt-3.5-turbo",
                 },
                 "data": ["prompt_tokens=256,output_tokens=128"],
             }
         )
-        assert isinstance(args_openai.backend_kwargs, OpenAIHttpBackendArgs)
+        assert isinstance(args_openai.backend_kwargs, OpenAIHTTPBackendArgs)
 
         # VLLM Python backend (if available)
         if HAS_VLLM:
             args_vllm = BenchmarkGenerativeTextArgs.model_validate(
                 {
-                    "backend": "vllm_python",
                     "backend_kwargs": {
+                        "type": "vllm_python",
                         "model": "facebook/opt-125m",
                     },
                     "data": ["prompt_tokens=256,output_tokens=128"],

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -21,6 +21,7 @@ def minimal_report() -> GenerativeBenchmarksReport:
     """
     args = BenchmarkGenerativeTextArgs(
         backend_kwargs={
+            "type": "openai_http",
             "target": "http://localhost:8000/v1",
             "model": "test-model",
         },


### PR DESCRIPTION
## Summary

Reworks `BackendArgs` into a `PydanticClassRegistry` containing everything needed to create a backend.

## Details

This is the first (or third depending on how you count) patch to refactor our CLI and the internal way submodules are configured and spawned. Since we already had a partial base for it this will likely be the simplest PR and subsequent PRs will have to rework a lot more code.

Changes to the entrypoints and CLI are temporary as that code will be refactored in a follow-up.

### Changes

I tried to keep most of the original functionality but there were a few things that just did not make sense as implemented or were planned for removal:

#### Dropped `LEGACY_API_ALIASES`

They only exist to keep existing scripts from breaking and this release those scripts will break for other reasons so might as well make the change now.

#### Dropped `request_handlers` backend argument

This let the user provide custom request type handlers as a backend argument. The better way to do this is to just call `OpenAIRequestHandlerFactory.register` on your custom handler.

#### `validate_backend` no longer has the option to provide a custom health check endpoint

You can get nearly the same functionality by passing `api_routes={"/health": "custom endpoint"}`. However users usually just set `validate_backend=False` since its too much of a hassle to provide a custom endpoint.

## Test Plan

Test setting `--backend` and `--backend-kwargs` with various values to make sure nothing has changed (except for exceptions detailed below).

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Related to #724
- Resolves #725

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes AI-assisted code completion
- [ ] Includes code generated by an AI application
- [x] Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes `## WRITTEN BY AI ##`)
