### PR TITLE
feat: Add --output-extras CLI flag for user-defined report metadata

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -534,7 +534,7 @@ async def benchmark_generative_text(
         outputs=args.outputs, output_dir=args.output_dir, console=console
     )
 
-    report = GenerativeBenchmarksReport(args=args)
+    report = GenerativeBenchmarksReport(args=args, extras=args.output_extras)
     if console:
         console.print_update(
             title="Setup complete, starting benchmarks...", status="success"

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -243,6 +243,13 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
         default_factory=Path.cwd,
         description="The directory path to save file output types in",
     )
+    output_extras: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional metadata to include in output reports "
+            "(e.g. tags, hardware details). Must be a JSON-serializable dict."
+        ),
+    )
     # Benchmarker configuration
     sample_requests: int | None = Field(
         default=None,

--- a/src/guidellm/benchmark/schemas/generative/report.py
+++ b/src/guidellm/benchmark/schemas/generative/report.py
@@ -14,7 +14,7 @@ import json
 import platform
 from importlib.metadata import version
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import yaml
 from pydantic import Field
@@ -79,6 +79,13 @@ class GenerativeBenchmarksReport(StandardBaseModel):
     benchmarks: list[GenerativeBenchmark] = Field(
         description="List of completed benchmarks in the report",
         default_factory=list,
+    )
+    extras: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional user-supplied metadata included in the report "
+            "(e.g. tags, hardware details)."
+        ),
     )
 
     def save_file(

--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -232,6 +232,15 @@ STRATEGY_PROFILE_CHOICES: list[str] = list(get_literal_vals(ProfileType | Strate
     ),
 )
 @click.option(
+    "--output-extras",
+    callback=cli_tools.parse_arguments,
+    default=BenchmarkGenerativeTextArgs.get_default("output_extras"),
+    help=(
+        "JSON string of additional metadata to include in all output reports. "
+        'E.g., \'{"tag": "my_tag", "hardware": "A100"}\''
+    ),
+)
+@click.option(
     "--output-path",
     type=click.Path(),
     default=None,

--- a/tests/unit/benchmark/schemas/generative/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/generative/test_entrypoints.py
@@ -371,3 +371,123 @@ class TestBackendArgsTransformation:
             )
             assert VLLMPythonBackendArgs is not None
             assert isinstance(args_vllm.backend_kwargs, VLLMPythonBackendArgs)
+
+
+@pytest.mark.smoke
+class TestOutputExtrasDefault:
+    """Test that output_extras defaults to None.
+
+    ## WRITTEN BY AI ##
+    """
+
+    def test_output_extras_defaults_to_none(self):
+        """
+        Test that output_extras field defaults to None when not provided.
+
+        ## WRITTEN BY AI ##
+        """
+        args = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": {
+                    "type": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": ["prompt_tokens=256,output_tokens=128"],
+            }
+        )
+        assert args.output_extras is None
+
+    def test_get_default_returns_none(self):
+        """
+        Test that get_default('output_extras') returns None.
+
+        ## WRITTEN BY AI ##
+        """
+        assert BenchmarkGenerativeTextArgs.get_default("output_extras") is None
+
+
+@pytest.mark.sanity
+class TestOutputExtrasField:
+    """Test output_extras field accepts, stores, and round-trips values.
+
+    ## WRITTEN BY AI ##
+    """
+
+    def test_output_extras_accepts_flat_dict(self):
+        """
+        Test that output_extras stores a flat dict correctly.
+
+        ## WRITTEN BY AI ##
+        """
+        extras = {"tag": "prod-test", "hardware": "A100"}
+        args = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": {
+                    "type": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": ["prompt_tokens=256,output_tokens=128"],
+                "output_extras": extras,
+            }
+        )
+        assert args.output_extras == extras
+
+    def test_output_extras_accepts_nested_dict(self):
+        """
+        Test that output_extras stores a nested dict correctly.
+
+        ## WRITTEN BY AI ##
+        """
+        extras = {"tag": "v1", "metadata": {"gpu": "A100", "count": 8}}
+        args = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": {
+                    "type": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": ["prompt_tokens=256,output_tokens=128"],
+                "output_extras": extras,
+            }
+        )
+        assert args.output_extras == extras
+
+    def test_output_extras_serialization_round_trip(self):
+        """
+        Test that output_extras survives a model_dump / model_validate round-trip.
+
+        ## WRITTEN BY AI ##
+        """
+        extras = {"tag": "my_tag", "metadata": {"key": "value"}}
+        args = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": {
+                    "type": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": ["prompt_tokens=256,output_tokens=128"],
+                "output_extras": extras,
+            }
+        )
+        dumped = args.model_dump()
+        assert dumped["output_extras"] == extras
+
+        args2 = BenchmarkGenerativeTextArgs.model_validate(dumped)
+        assert args2.output_extras == extras
+
+    def test_output_extras_none_in_dump(self):
+        """
+        Test that output_extras serializes as None when not set.
+
+        ## WRITTEN BY AI ##
+        """
+        args = BenchmarkGenerativeTextArgs.model_validate(
+            {
+                "backend_kwargs": {
+                    "type": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": ["prompt_tokens=256,output_tokens=128"],
+            }
+        )
+        dumped = args.model_dump()
+        assert dumped["output_extras"] is None

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -30,6 +30,26 @@ def minimal_report() -> GenerativeBenchmarksReport:
     return GenerativeBenchmarksReport(args=args)
 
 
+@pytest.fixture
+def report_with_extras() -> GenerativeBenchmarksReport:
+    """
+    Create a GenerativeBenchmarksReport with output_extras set.
+
+    ## WRITTEN BY AI ##
+    """
+    extras = {"tag": "prod-test", "hardware": "A100", "metadata": {"count": 8}}
+    args = BenchmarkGenerativeTextArgs(
+        backend_kwargs={
+            "type": "openai_http",
+            "target": "http://localhost:8000/v1",
+            "model": "test-model",
+        },
+        data=["test_data.jsonl"],
+        output_extras=extras,
+    )
+    return GenerativeBenchmarksReport(args=args, extras=extras)
+
+
 class TestResolveFormatType:
     """
     Tests that resolve() propagates the format key correctly.
@@ -164,3 +184,105 @@ class TestFinalizeFormats:
         parsed = yaml.safe_load(content)
         assert isinstance(parsed, dict)
         assert "args" in parsed
+
+
+@pytest.mark.smoke
+class TestExtrasInReport:
+    """
+    Tests that the extras field is present and correct in serialized output.
+
+    ## WRITTEN BY AI ##
+    """
+
+    def test_report_extras_none_by_default(
+        self, minimal_report: GenerativeBenchmarksReport
+    ):
+        """
+        extras field should be None when not supplied to the report.
+
+        ## WRITTEN BY AI ##
+        """
+        assert minimal_report.extras is None
+
+    def test_report_extras_stored(self, report_with_extras: GenerativeBenchmarksReport):
+        """
+        extras field should hold the dict passed during construction.
+
+        ## WRITTEN BY AI ##
+        """
+        assert report_with_extras.extras == {
+            "tag": "prod-test",
+            "hardware": "A100",
+            "metadata": {"count": 8},
+        }
+
+
+@pytest.mark.sanity
+class TestExtrasSerializedToFile:
+    """
+    Tests that extras appear correctly in JSON and YAML output files.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.asyncio
+    async def test_extras_present_in_json_output(
+        self, tmp_path: Path, report_with_extras: GenerativeBenchmarksReport
+    ):
+        """
+        extras dict should appear under the 'extras' key in the written JSON file.
+
+        ## WRITTEN BY AI ##
+        """
+        handler = GenerativeBenchmarkerSerialized(
+            output_path=tmp_path, format_type="json"
+        )
+        result_path = await handler.finalize(report_with_extras)
+
+        parsed = json.loads(result_path.read_text())
+        assert "extras" in parsed
+        assert parsed["extras"] == {
+            "tag": "prod-test",
+            "hardware": "A100",
+            "metadata": {"count": 8},
+        }
+
+    @pytest.mark.asyncio
+    async def test_extras_present_in_yaml_output(
+        self, tmp_path: Path, report_with_extras: GenerativeBenchmarksReport
+    ):
+        """
+        extras dict should appear under the 'extras' key in the written YAML file.
+
+        ## WRITTEN BY AI ##
+        """
+        handler = GenerativeBenchmarkerSerialized(
+            output_path=tmp_path, format_type="yaml"
+        )
+        result_path = await handler.finalize(report_with_extras)
+
+        parsed = yaml.safe_load(result_path.read_text())
+        assert "extras" in parsed
+        assert parsed["extras"] == {
+            "tag": "prod-test",
+            "hardware": "A100",
+            "metadata": {"count": 8},
+        }
+
+    @pytest.mark.asyncio
+    async def test_extras_null_in_json_when_not_set(
+        self, tmp_path: Path, minimal_report: GenerativeBenchmarksReport
+    ):
+        """
+        extras should serialize as null in JSON when not provided.
+
+        ## WRITTEN BY AI ##
+        """
+        handler = GenerativeBenchmarkerSerialized(
+            output_path=tmp_path, format_type="json"
+        )
+        result_path = await handler.finalize(minimal_report)
+
+        parsed = json.loads(result_path.read_text())
+        assert "extras" in parsed
+        assert parsed["extras"] is None


### PR DESCRIPTION
 ## Summary

  Implements the `--output-extras` CLI flag that was documented in the outputs guide but never built. Users can now pass a JSON string of arbitrary metadata (tags, hardware details, environment info, etc.) via `--output-extras` which gets stored in the benchmark report and serialized into all output files
  (JSON/YAML).

  ## Details

  - [x] Add `output_extras: dict[str, Any] | None` field to `BenchmarkGenerativeTextArgs`
  - [x] Add `extras: dict[str, Any] | None` field to `GenerativeBenchmarksReport`
  - [x] Wire `args.output_extras` into report construction in `benchmark_generative_text()`
  - [x] Add `--output-extras` click option to the CLI benchmark run command

  ## Test Plan

  - Run `tox -e tests -- tests/unit/benchmark/test_serialized_output.py` — all 11 tests pass
  - Verify `extras` key appears in `benchmarks.json` / `benchmarks.yaml` when flag is used:
    ```bash
    guidellm benchmark \
      --target http://localhost:8000 \
      --output-extras '{"tag": "my_run", "hardware": "A100"}' \
      --data "prompt_tokens=256,output_tokens=128"
  - Verify extras is null in output when --output-extras is not passed

  Related Issues

  - Resolves #719

  ---
  - "I certify that all code in this PR is my own, except as noted below."

  Use of AI

  - Includes AI-assisted code completion
  - Includes code generated by an AI application
  - Includes AI-generated tests (NOTE: AI written tests should have a docstring that includes ## WRITTEN BY AI ##)