### PR TITLE
Fix TTFT measurement for reasoning-capable models

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -815,8 +815,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choice: dict[str, dict] = choices[0] if choices else {}
         delta = choice.get("delta", {}) if choices else {}
 
-        if reasoning := delta.get("reasoning"):
-            self.streaming_texts.append(reasoning)
+        if delta.get("reasoning"):
             updated = True
         if content := delta.get("content"):
             self.streaming_texts.append(content)

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -815,6 +815,9 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choice: dict[str, dict] = choices[0] if choices else {}
         delta = choice.get("delta", {}) if choices else {}
 
+        if reasoning := delta.get("reasoning"):
+            self.streaming_texts.append(reasoning)
+            updated = True
         if content := delta.get("content"):
             self.streaming_texts.append(content)
             updated = True

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -964,3 +964,80 @@ class TestCheckToolCallExpectations:
 
         with pytest.raises(ValueError, match="tool call"):
             backend._check_tool_call_expectations(req, resp)
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_resolve_stream_reasoning_tokens_ttft(
+        self,
+        httpx_mock: HTTPXMock,
+    ):
+        """
+        Test that TTFT is measured correctly when reasoning tokens arrive first.
+
+        Validates that the first_token_iteration timing is set on the first
+        reasoning token, not waiting for the first content token.
+        This is an integration test for issue #737.
+
+        ### WRITTEN BY AI ###
+        """
+        # Create a realistic reasoning model response stream
+        stream_chunks = [
+            # First chunk: reasoning token (should trigger TTFT)
+            b'data: {"id": "chatcmpl-123", "choices": '
+            b'[{"index": 0, "delta": {"reasoning": "Let me think"}}]}\n\n',
+            # More reasoning tokens
+            b'data: {"choices": [{"delta": {"reasoning": " about this..."}}]}\n\n',
+            # Finally, content tokens
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+            b'data: {"choices": [{"delta": {"content": " world"}}], '
+            b'"usage": {"prompt_tokens": 5, "completion_tokens": 10}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+
+        httpx_mock.add_response(
+            url="http://test/v1/chat/completions",
+            stream=IteratorStream(stream_chunks),
+        )
+
+        backend = _make_backend(
+            target="http://test",
+            model="reasoning-model",
+            stream=True,
+            validate_backend=False,
+            request_format="/v1/chat/completions",
+        )
+        await backend.process_startup()
+
+        request = GenerationRequest()
+        request_info = RequestInfo(
+            request_id="test-id",
+            status="pending",
+            scheduler_node_id=1,
+            scheduler_process_id=1,
+            scheduler_start_time=123.0,
+            timings=RequestTimings(),
+        )
+
+        responses = []
+        async for response, info in backend.resolve(request, request_info):
+            responses.append((response, info))
+
+        # Verify we got a response
+        assert len(responses) > 0
+        final_response, final_info = responses[-1]
+
+        # Verify TTFT was measured (first_token_iteration should be set)
+        assert final_info.timings.first_token_iteration is not None, (
+            "TTFT (first_token_iteration) should be set when reasoning tokens arrive"
+        )
+
+        # Verify the response contains both reasoning and content
+        assert final_response.text is not None
+        assert "Let me think" in final_response.text
+        assert "about this..." in final_response.text
+        assert "Hello world" in final_response.text
+
+        # Verify token counts
+        assert final_info.timings.token_iterations > 0
+        assert final_response.output_metrics.text_tokens == 10

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -1032,10 +1032,10 @@ class TestCheckToolCallExpectations:
             "TTFT (first_token_iteration) should be set when reasoning tokens arrive"
         )
 
-        # Verify the response contains both reasoning and content
+        # Reasoning tokens should NOT appear in text; only content is captured
         assert final_response.text is not None
-        assert "Let me think" in final_response.text
-        assert "about this..." in final_response.text
+        assert "Let me think" not in final_response.text
+        assert "about this..." not in final_response.text
         assert "Hello world" in final_response.text
 
         # Verify token counts

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -927,6 +927,110 @@ class TestChatCompletionsRequestHandler:
         assert response.input_metrics.text_tokens == expected_input_tokens
         assert response.output_metrics.text_tokens == expected_output_tokens
 
+    @pytest.mark.sanity
+    def test_streaming_reasoning_tokens(self, valid_instances, generation_request):
+        """Test that reasoning tokens are properly detected for TTFT measurement.
+
+        Reasoning-capable models (e.g., DeepSeek-R1, o1) emit delta.reasoning
+        before delta.content. This test verifies that the first reasoning token
+        triggers the updated flag, ensuring accurate TTFT measurement.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            # First chunk has reasoning token
+            (
+                'data: {"id": "chatcmpl-123", "choices": '
+                '[{"index": 0, "delta": {"reasoning": "Okay"}}], "usage": {}}'
+            ),
+            # More reasoning tokens
+            'data: {"choices": [{"delta": {"reasoning": ", let me"}}], "usage": {}}',
+            'data: {"choices": [{"delta": {"reasoning": " think..."}}], "usage": {}}',
+            # Finally content tokens
+            'data: {"choices": [{"delta": {"content": "Hello"}}], "usage": {}}',
+            (
+                'data: {"choices": [{"delta": {"content": " world!"}}], '
+                '"usage": {"prompt_tokens": 5, "completion_tokens": 10}}'
+            ),
+            "data: [DONE]",
+        ]
+
+        updated_count = 0
+        first_update_on_line = None
+        for idx, line in enumerate(lines):
+            result = instance.add_streaming_line(line)
+            if result == 1:
+                updated_count += 1
+                if first_update_on_line is None:
+                    first_update_on_line = idx
+            elif result is None:
+                break
+
+        # Verify that the first update happened on the first reasoning token (line 0)
+        assert first_update_on_line == 0, (
+            f"Expected first token detection on line 0 (reasoning token), "
+            f"but got {first_update_on_line}"
+        )
+
+        # Verify all chunks with content were counted (5 lines with tokens)
+        assert updated_count == 5
+
+        response = instance.compile_streaming(generation_request, arguments)
+        # Verify that both reasoning and content are in the final text
+        assert "Okay" in response.text
+        assert "let me think..." in response.text
+        assert "Hello world!" in response.text
+        assert response.text == "Okay, let me think...Hello world!"
+        assert response.input_metrics.text_tokens == 5
+        assert response.output_metrics.text_tokens == 10
+
+    @pytest.mark.sanity
+    def test_streaming_both_reasoning_and_content_in_same_chunk(
+        self, valid_instances, generation_request
+    ):
+        """Test handling chunks with both reasoning and content fields.
+
+        Edge case: verify that if a chunk contains both delta.reasoning
+        and delta.content, both are properly captured and counted.
+
+        ### WRITTEN BY AI ###
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            # Chunk with both reasoning and content (edge case)
+            (
+                'data: {"choices": [{"delta": '
+                '{"reasoning": "Let me think...", "content": "Answer: "}}], '
+                '"usage": {}}'
+            ),
+            'data: {"choices": [{"delta": {"content": "42"}}], "usage": {}}',
+            "data: [DONE]",
+        ]
+
+        updated_count = 0
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+            if result > 0:
+                updated_count += 1
+
+        # First chunk has both reasoning and content (counts as 1 iteration)
+        # Second chunk has content only (counts as 1 iteration)
+        assert updated_count == 2
+
+        response = instance.compile_streaming(generation_request, arguments)
+        # Both reasoning and content from the same chunk should be present
+        assert "Let me think..." in response.text
+        assert "Answer: " in response.text
+        assert "42" in response.text
+        assert response.text == "Let me think...Answer: 42"
+
     # Tool call response handling tests
 
     @pytest.mark.sanity

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -979,11 +979,10 @@ class TestChatCompletionsRequestHandler:
         assert updated_count == 5
 
         response = instance.compile_streaming(generation_request, arguments)
-        # Verify that both reasoning and content are in the final text
-        assert "Okay" in response.text
-        assert "let me think..." in response.text
-        assert "Hello world!" in response.text
-        assert response.text == "Okay, let me think...Hello world!"
+        # Reasoning tokens should NOT appear in response.text; only content does
+        assert "Okay" not in response.text
+        assert "let me think..." not in response.text
+        assert response.text == "Hello world!"
         assert response.input_metrics.text_tokens == 5
         assert response.output_metrics.text_tokens == 10
 
@@ -994,7 +993,8 @@ class TestChatCompletionsRequestHandler:
         """Test handling chunks with both reasoning and content fields.
 
         Edge case: verify that if a chunk contains both delta.reasoning
-        and delta.content, both are properly captured and counted.
+        and delta.content, reasoning triggers the update flag but only
+        content is captured in the response text.
 
         ### WRITTEN BY AI ###
         """
@@ -1025,11 +1025,9 @@ class TestChatCompletionsRequestHandler:
         assert updated_count == 2
 
         response = instance.compile_streaming(generation_request, arguments)
-        # Both reasoning and content from the same chunk should be present
-        assert "Let me think..." in response.text
-        assert "Answer: " in response.text
-        assert "42" in response.text
-        assert response.text == "Let me think...Answer: 42"
+        # Reasoning text should NOT appear; only content is captured
+        assert "Let me think..." not in response.text
+        assert response.text == "Answer: 42"
 
     # Tool call response handling tests
 


### PR DESCRIPTION
## Summary

Fixes TTFT (Time to First Token) measurement for reasoning-capable models that emit `delta.reasoning` tokens before `delta.content` tokens.

When benchmarking models through the OpenAI-compatible backend, the TTFT was incorrectly measured if the model first streams reasoning tokens before content tokens. The implementation only considered `delta.content` as the "first token" and ignored `delta.reasoning`, causing TTFT to appear larger than it really is.

This extends `ChatCompletionsRequestHandler.add_streaming_line` to detect both `delta.reasoning` and `delta.content` tokens, ensuring accurate TTFT measurement regardless of which token type arrives first.

## Details

- [x] Add `delta.reasoning` detection in `ChatCompletionsRequestHandler.add_streaming_line`
- [x] Check reasoning tokens before content tokens to maintain logical ordering
- [x] Handle edge case where both fields exist in the same chunk
- [x] Add comprehensive unit tests for reasoning token detection
- [x] Add integration test validating full TTFT measurement flow

## Test Plan

- Run unit tests: `uv run pytest tests/unit/backends/openai/test_request_handlers.py::TestChatCompletionsRequestHandler`
- Run integration test: `uv run pytest tests/unit/backends/openai/test_http.py::TestOpenAIHTTPBackend::test_resolve_stream_reasoning_tokens_ttft`
- All 199 OpenAI backend tests pass
- Code formatting and linting checks pass (`uv run ruff check` and `uv run ruff format --check`)

## Related Issues

- Resolves #737

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent