### PR TITLE
Fix blank HTML report by serving UI assets from GitHub Pages

### DIFF
--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -58,7 +58,7 @@ class ReportGenerationSettings(BaseModel):
     Report generation settings for the application
     """
 
-    source: str = "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/v0.5.4/index.html"
+    source: str = "https://vllm-project.github.io/guidellm/ui/v0.5.4/index.html"
 
 
 class Settings(BaseSettings):

--- a/src/ui/.env.development
+++ b/src/ui/.env.development
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/dev
+ASSET_PREFIX=https://vllm-project.github.io/guidellm/ui/dev
 BASE_PATH=/ui/dev
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/src/ui/.env.production
+++ b/src/ui/.env.production
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/latest
+ASSET_PREFIX=https://vllm-project.github.io/guidellm/ui/latest
 BASE_PATH=/ui/latest
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/src/ui/.env.staging
+++ b/src/ui/.env.staging
@@ -1,3 +1,3 @@
-ASSET_PREFIX=https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/release/latest
+ASSET_PREFIX=https://vllm-project.github.io/guidellm/ui/release/latest
 BASE_PATH=/ui/release/latest
 NEXT_PUBLIC_USE_MOCK_API=true

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -10,9 +10,7 @@ from guidellm.settings import (
     settings,
 )
 
-BASE_URL = (
-    "https://raw.githubusercontent.com/vllm-project/guidellm/refs/heads/gh-pages/ui/"
-)
+BASE_URL = "https://vllm-project.github.io/guidellm/ui/"
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

The generated HTML benchmark report renders as a blank page when opened in a browser, even though the benchmark data is embedded in the file. The report's JS bundle is loaded from `raw.githubusercontent.com`, which serves every file as `Content-Type: text/plain` with `X-Content-Type-Options: nosniff`. Browsers refuse to execute scripts under those headers, so the UI never mounts. The webpack runtime's baked-in `publicPath` also points at `raw.githubusercontent.com`, so dynamically-imported chunks fail the same way.

The exact same `gh-pages` branch is already published via GitHub Pages at `https://vllm-project.github.io/guidellm/`, which serves the identical files with the correct `application/javascript` MIME type and no `nosniff` block. This PR points the report source and the UI build `ASSET_PREFIX` at the Pages URL instead of the raw URL.

This regressed in 23e9af78 ("Move html template source location to raw github"), which moved hosting off the now-retired `blog.vllm.ai` Pages site (it now 301-redirects to a Vercel-hosted blog) onto the raw.githubusercontent URL.

## Details

- [x] `src/guidellm/settings.py`: report `source` → `vllm-project.github.io`
- [x] `src/ui/.env.production`, `.env.staging`, `.env.development`: `ASSET_PREFIX` → `vllm-project.github.io`
- [x] `tests/unit/test_settings.py`: update expected `BASE_URL` prefix

Host swap only; paths/versions are unchanged. All four target URLs (`ui/v0.5.4/index.html`, `ui/latest`, `ui/dev`, `ui/release/latest`) were verified to return `200` with `content-type: application/javascript` on the Pages host.

## Test Plan

- `pytest tests/unit/test_settings.py` — passes (10/10).
- Manual: generated a report against a vLLM endpoint, opened the HTML in a browser. With the raw URL the page is blank (JS blocked by `text/plain`+`nosniff`); after repointing assets to the Pages host the report renders fully (charts + statistics tables).
- Verified `application/javascript` MIME for both the bootstrap chunks and the dynamically-loaded chunks (`d55cc8df.*`, `652.*`) on the Pages host.

## Related Issues

- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
