### PR TITLE
Enable multiprocessing support for trace replay strategy

### DIFF
--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -139,14 +139,15 @@ class ReplayProfileArgs(ProfileArgs):
 @ProfileFactory.register("replay")
 class ReplayProfile(Profile):
     """
-    Replay a trace file:
-    schedule each request at start_time + time_scale * relative_timestamp[i].
+    Replay a trace file using per-row ``relative_timestamp`` from the dataset.
 
-    For this profile, the ``rate`` argument is interpreted as time_scale (scale factor
-    applied to relative timestamps), not as requests per second.
+    Each request is scheduled at
+    ``start_time + time_scale * relative_timestamp`` via ``RequestSettings`` on
+    the dataset finalizer output. For this profile, ``rate`` is interpreted as
+    ``time_scale`` (not requests per second).
 
-    When ``data_samples`` is set, the replayed timestamps are truncated to match
-    the sampled dataset size.
+    When ``data_samples`` is set, the default ``max_requests`` constraint matches
+    the truncated dataset size.
     """
 
     args: ReplayProfileArgs
@@ -169,7 +170,6 @@ class ReplayProfile(Profile):
                 )
             )
             self.constraints = new_constraints
-        self.relative_timestamps = relative_timestamps
 
     @property
     def strategy_types(self) -> list[str]:
@@ -184,7 +184,4 @@ class ReplayProfile(Profile):
         # Replay has a single strategy; return it once, then None
         if prev_strategy is not None:
             return None
-        return TraceReplayStrategy(
-            relative_timestamps=self.relative_timestamps,
-            time_scale=self.args.time_scale,
-        )
+        return TraceReplayStrategy(time_scale=self.args.time_scale)

--- a/src/guidellm/data/deserializers/trace_synthetic.py
+++ b/src/guidellm/data/deserializers/trace_synthetic.py
@@ -185,7 +185,7 @@ class TraceSyntheticDatasetDeserializer(DatasetDeserializer):
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
     ) -> Dataset:
-        if not (path := Path(config.path)).exists() or not path.is_file():
+        if not (path := config.path).exists() or not path.is_file():
             raise DataNotSupportedError(
                 "TraceSyntheticDatasetDeserializer expects a path to a trace file, "
                 f"got {path}"
@@ -206,6 +206,10 @@ class TraceSyntheticDatasetDeserializer(DatasetDeserializer):
         base_prompt_token_ids = _create_base_prompt_token_ids(
             processor, faker, max_prompt_tokens
         )
+
+        timestamps = [row["timestamp"] for row in rows]
+        t0 = timestamps[0]
+        relative_timestamps = [t - t0 for t in timestamps]
 
         prompts: list[str] = []
         prompt_tokens_counts: list[int] = []
@@ -230,6 +234,7 @@ class TraceSyntheticDatasetDeserializer(DatasetDeserializer):
                 "prompt": prompts,
                 "prompt_tokens_count": prompt_tokens_counts,
                 "output_tokens_count": output_tokens_counts,
+                "relative_timestamp": relative_timestamps,
             },
             **config.load_kwargs,
         )

--- a/src/guidellm/data/finalizers/generative.py
+++ b/src/guidellm/data/finalizers/generative.py
@@ -7,7 +7,7 @@ from pydantic import Field
 
 from guidellm.data.finalizers.finalizer import DatasetFinalizer, FinalizerRegistry
 from guidellm.data.schemas import DataFinalizerArgs
-from guidellm.schemas import GenerationRequest, UsageMetrics
+from guidellm.schemas import GenerationRequest, RequestSettings, UsageMetrics
 
 __all__ = ["GenerativeRequestFinalizer"]
 
@@ -129,4 +129,13 @@ class GenerativeRequestFinalizer(DatasetFinalizer[Iterable[GenerationRequest]]):
             expects_tool_call=expects_tool_call,
             input_metrics=input_metrics,
             output_metrics=output_metrics,
+            settings=self._request_settings_from_columns(columns),
         )
+
+    def _request_settings_from_columns(
+        self, columns: dict[str, Any]
+    ) -> RequestSettings:
+        relative_values = columns.get("relative_timestamp_column", [])
+        if relative_values and relative_values[0] is not None:
+            return RequestSettings(relative_timestamp=float(relative_values[0]))
+        return RequestSettings()

--- a/src/guidellm/data/preprocessors/mappers.py
+++ b/src/guidellm/data/preprocessors/mappers.py
@@ -101,6 +101,7 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
             "tool_result",
             "tool_output",
         ],
+        "relative_timestamp_column": ["relative_timestamp"],
     }
     column_name_pattern: str = (
         r"^(?P<full_name>(?P<match_name>({name})(es|s)?)([-_](?P<turn>\d+))?)$"

--- a/src/guidellm/data/schemas/base.py
+++ b/src/guidellm/data/schemas/base.py
@@ -21,6 +21,7 @@ GenerativeDatasetColumnType = Literal[
     "audio_column",
     "tools_column",
     "tool_response_column",
+    "relative_timestamp_column",
 ]
 
 DatasetType: TypeAlias = Dataset | DatasetDict | IterableDataset | IterableDatasetDict

--- a/src/guidellm/scheduler/strategies.py
+++ b/src/guidellm/scheduler/strategies.py
@@ -26,7 +26,7 @@ from typing import Annotated, ClassVar, Literal, TypeVar
 
 from pydantic import Field, NonNegativeFloat, NonNegativeInt, PositiveInt, PrivateAttr
 
-from guidellm.schemas import PydanticClassRegistryMixin, RequestInfo
+from guidellm.schemas import PydanticClassRegistryMixin, RequestInfo, RequestSettings
 from guidellm.utils.mixins import InfoMixin
 
 __all__ = [
@@ -220,6 +220,26 @@ class SchedulingStrategy(PydanticClassRegistryMixin["SchedulingStrategy"], InfoM
         :param request_info: Completed request metadata including timing details
             and completion status
         """
+
+    async def resolve_dequeued_target_start(
+        self,
+        worker_index: NonNegativeInt,
+        provisional_start: float,
+        settings: RequestSettings,
+    ) -> float:
+        """
+        Resolve scheduled start time after dequeue using per-request settings.
+
+        Default returns ``provisional_start`` unchanged. Strategies with
+        enqueue-bound timing metadata can override to reinterpret settings.
+
+        :param worker_index: Worker process index handling the request
+        :param provisional_start: Start time from the worker's scheduling slot
+        :param settings: Per-request scheduling metadata attached at enqueue
+        :return: Unix timestamp when the request should begin processing
+        """
+        _ = (worker_index, settings)
+        return provisional_start
 
     def requeue_delay(self) -> float:
         """
@@ -679,18 +699,18 @@ class TraceReplayStrategy(SchedulingStrategy):
     """
     Replay scheduling from a trace of timestamps.
 
-    Schedules each request at start_time + time_scale * relative_timestamp[i],
-    so the trace's inter-arrival pattern is reproduced with an optional time scale.
+    Each request carries a ``relative_timestamp`` in ``RequestSettings`` from the
+    dataset finalizer. ``next_request_time`` schedules dequeue immediately at
+    benchmark start; ``resolve_dequeued_target_start`` applies the trace offset via
+    ``start_time + time_scale * relative_timestamp``, reproducing inter-arrival
+    timing under multiprocessing.
     """
 
     type_: Literal["trace"] = "trace"  # type: ignore[assignment]
-    relative_timestamps: list[float] = Field(
-        description="Request start times relative to first event (first = 0)",
-    )
     time_scale: float = Field(
         default=1.0,
         gt=0,
-        description="Scale factor applied to relative timestamps",
+        description="Scale factor applied to relative timestamps from the dataset",
     )
 
     def __str__(self) -> str:
@@ -698,10 +718,7 @@ class TraceReplayStrategy(SchedulingStrategy):
 
     @property
     def processes_limit(self) -> PositiveInt | None:
-        # Trace replay is currently constrained to one process until each
-        # scheduled timestamp is bound to its request before workers compete
-        # for queue items.
-        return 1
+        return None
 
     @property
     def requests_limit(self) -> PositiveInt | None:
@@ -709,18 +726,19 @@ class TraceReplayStrategy(SchedulingStrategy):
 
     async def next_request_time(self, worker_index: NonNegativeInt) -> float:
         _ = worker_index
+        return await self.get_processes_start_time()
+
+    async def resolve_dequeued_target_start(
+        self,
+        worker_index: NonNegativeInt,
+        provisional_start: float,
+        settings: RequestSettings,
+    ) -> float:
+        _ = (worker_index, provisional_start)
+        if settings.relative_timestamp is None:
+            return await self.get_processes_start_time()
         start_time = await self.get_processes_start_time()
-        if not self.relative_timestamps:
-            return start_time
-
-        idx = self.next_request_index()
-        if idx > len(self.relative_timestamps):
-            # Trace exhausted: park this worker slot until the scheduler cancels
-            # the processing loop via constraint_reached_event. CancelledError
-            # propagates up cleanly, matching the exit path of all other strategies.
-            await asyncio.Event().wait()
-
-        return start_time + self.time_scale * self.relative_timestamps[idx - 1]
+        return start_time + self.time_scale * settings.relative_timestamp
 
     def request_completed(self, request_info: RequestInfo):
         _ = request_info

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -391,8 +391,17 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             history, conversation = await self._dequeue_next_conversation(target_start)
             request, request_info = conversation.pop(0)
 
+            effective_target_start = await self.strategy.resolve_dequeued_target_start(
+                self.worker_index,
+                target_start,
+                request_info.settings,
+            )
+            if effective_target_start != target_start:
+                request_info.timings.targeted_start = effective_target_start
+                self._send_update("pending", None, request, request_info)
+
             # Schedule the request and send "in_progress" update
-            await self._schedule_request(request, request_info, target_start)
+            await self._schedule_request(request, request_info, effective_target_start)
 
             async for resp, info in self.backend.resolve(  # type: ignore[attr-defined]
                 request, request_info, history or None

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -39,7 +39,7 @@ from guidellm.scheduler.schemas import (
 )
 from guidellm.scheduler.strategies import SchedulingStrategy
 from guidellm.scheduler.worker import WorkerProcess
-from guidellm.schemas import RequestInfo
+from guidellm.schemas import GenerationRequest, RequestInfo, RequestSettings
 from guidellm.settings import settings
 from guidellm.utils.messaging import (
     InterProcessMessaging,
@@ -333,6 +333,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         self.state = WorkerGroupState[RequestT, ResponseT](
             start_time=start_time,
             processes=self.processes,
+            strategy=self.strategy,
             constraints=self.constraints,
             stop_send_requests_event=stop_send_requests_event,
             send_requests_stopped_event=send_requests_stopped_event,
@@ -491,6 +492,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         self,
         start_time: float,
         processes: list[BaseProcess],
+        strategy: SchedulingStrategy,
         constraints: dict[str, Constraint],
         stop_send_requests_event: threading.Event,
         send_requests_stopped_event: threading.Event,
@@ -505,6 +507,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
 
         :param start_time: Unix timestamp when processing should begin
         :param processes: List of worker process instances
+        :param strategy: Scheduling strategy for request timing at dequeue
         :param constraints: Named constraints for controlling execution behavior
         :param stop_send_requests_event: Threading event for stopping request generation
         :param send_requests_stopped_event: Threading event for request coordination
@@ -515,6 +518,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         """
         self.start_time = start_time
         self.processes = processes
+        self.strategy = strategy
         self.constraints = constraints
         self.stop_send_requests_event = stop_send_requests_event
         self.send_requests_stopped_event = send_requests_stopped_event
@@ -541,6 +545,16 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             return str(request.id)
         else:
             return str(uuid.uuid4())
+
+    @staticmethod
+    def _request_settings_from_request(request: RequestT) -> RequestSettings:
+        if isinstance(request, GenerationRequest):
+            return request.settings
+        if isinstance(request, dict):
+            settings = request.get("settings")
+            if isinstance(settings, RequestSettings):
+                return settings
+        return RequestSettings()
 
     def requests_generator(
         self,
@@ -578,6 +592,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                         status="queued",
                         scheduler_process_id=0,
                         scheduler_start_time=self.start_time,
+                        settings=self._request_settings_from_request(request),
                     )
                     state_update = self._locked_update(request_info)
                     request_info.timings.queued = time.time()

--- a/src/guidellm/schemas/__init__.py
+++ b/src/guidellm/schemas/__init__.py
@@ -22,7 +22,7 @@ from .base import (
     SuccessfulT,
     TotalT,
 )
-from .info import RequestInfo, RequestTimings
+from .info import RequestInfo, RequestSettings, RequestTimings
 from .request import (
     GenerationRequest,
     GenerationRequestArguments,
@@ -53,6 +53,7 @@ __all__ = [
     "RegisterClassT",
     "ReloadableBaseModel",
     "RequestInfo",
+    "RequestSettings",
     "RequestTimings",
     "StandardBaseDict",
     "StandardBaseModel",

--- a/src/guidellm/schemas/info.py
+++ b/src/guidellm/schemas/info.py
@@ -16,7 +16,7 @@ from pydantic import Field, computed_field
 
 from guidellm.schemas.base import StandardBaseDict, StandardBaseModel
 
-__all__ = ["RequestInfo", "RequestTimings"]
+__all__ = ["RequestInfo", "RequestSettings", "RequestTimings"]
 
 
 class RequestTimings(StandardBaseDict):
@@ -111,6 +111,28 @@ class RequestTimings(StandardBaseDict):
         return max(valid_timings) if valid_timings else None
 
 
+class RequestSettings(StandardBaseDict):
+    """
+    Per-request scheduling metadata attached at enqueue, before worker dequeue.
+
+    Populated by dataset finalizers (for example from trace ``relative_timestamp``
+    columns). Scheduling strategies read these fields at dequeue. For trace replay,
+    a non-null ``relative_timestamp`` becomes an absolute start time at dequeue:
+    ``start_time + time_scale * relative_timestamp``. When ``relative_timestamp``
+    is null, trace replay schedules the request at benchmark start (no trace offset).
+    """
+
+    relative_timestamp: float | None = Field(
+        default=None,
+        description=(
+            "Trace offset in seconds from the first event after sorting (0 for the "
+            "earliest event). Trace replay converts this to an absolute start time "
+            "at dequeue: start_time + time_scale * relative_timestamp. When null, "
+            "trace replay uses benchmark start time only."
+        ),
+    )
+
+
 class RequestInfo(StandardBaseModel):
     """
     Complete information about a request in the scheduler system.
@@ -167,6 +189,10 @@ class RequestInfo(StandardBaseModel):
         default_factory=RequestTimings,
         description="Timing measurements for the request lifecycle",
     )
+    settings: RequestSettings = Field(
+        default_factory=RequestSettings,
+        description="Per-request scheduling metadata for strategy interpretation",
+    )
 
     error: str | None = Field(
         default=None, description="Error message if the request status is 'errored'"
@@ -206,6 +232,7 @@ class RequestInfo(StandardBaseModel):
         return super().model_copy(
             update={
                 "timings": self.timings.model_copy(),
+                "settings": self.settings.model_copy(),
             },
             deep=False,
         )

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -15,6 +15,7 @@ from typing import Any
 from pydantic import Field, computed_field
 
 from guidellm.schemas.base import StandardBaseDict, StandardBaseModel
+from guidellm.schemas.info import RequestSettings
 from guidellm.utils.dict import deep_update
 
 __all__ = [
@@ -251,4 +252,11 @@ class GenerationRequest(StandardBaseModel):
     output_metrics: UsageMetrics = Field(
         default_factory=UsageMetrics,
         description="Output statistics including counts, sizes, and durations.",
+    )
+    settings: RequestSettings = Field(
+        default_factory=RequestSettings,
+        description=(
+            "Per-request scheduling metadata from the dataset finalizer, "
+            "for example trace replay relative timestamps."
+        ),
     )

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -1,0 +1,216 @@
+"""
+Integration test: trace file through dataset pipeline and TraceReplayStrategy.
+
+Validates multiprocess worker scheduling using real trace replay (not a test-only
+strategy): trace_synthetic deserializer, generative mapper/finalizer, and
+``TraceReplayStrategy.resolve_dequeued_target_start``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from guidellm.data.deserializers.trace_synthetic import (
+    TraceSyntheticDataArgs,
+    TraceSyntheticDatasetDeserializer,
+)
+from guidellm.data.finalizers.generative import (
+    GenerativeRequestFinalizer,
+    GenerativeRequestFinalizerConfig,
+)
+from guidellm.data.preprocessors.mappers import (
+    GenerativeColumnMapper,
+    GenerativeColumnMapperArgs,
+)
+from guidellm.scheduler import (
+    BackendInterface,
+    MaxNumberConstraint,
+    TraceReplayStrategy,
+    WorkerProcessGroup,
+)
+from guidellm.schemas import GenerationRequest, RequestSettings
+from tests.unit.testing_utils import async_timeout
+
+TIME_SCALE = 2.0
+RESOLVE_DELAY = 0.03
+# Sorted trace: earliest ts=2 -> 0.0, ts=5 -> 3.0, ts=8 -> 6.0 (duplicates below)
+EXPECTED_RELATIVE = [0.0, 0.0, 0.0, 0.1, 0.1, 1.5, 2.0, 2.0, 3.5, 7.0]
+NUM_REQUESTS = len(EXPECTED_RELATIVE)
+
+
+def _mock_processor() -> Mock:
+    proc = Mock()
+    proc.encode.side_effect = lambda text: list(range(len(text.split())))
+    proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
+        f"tok{i}" for i, _ in enumerate(tokens)
+    )
+    return proc
+
+
+def _write_trace(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines))
+    return path
+
+
+def _requests_from_trace(
+    trace_path: Path,
+) -> tuple[list[list[GenerationRequest]], list[float]]:
+    deserializer = TraceSyntheticDatasetDeserializer()
+    dataset = deserializer(
+        config=TraceSyntheticDataArgs(path=trace_path),
+        processor_factory=_mock_processor,
+        random_seed=42,
+    )
+
+    mapper = GenerativeColumnMapper(GenerativeColumnMapperArgs())
+    mapper.setup_data([dataset])
+    finalizer = GenerativeRequestFinalizer(GenerativeRequestFinalizerConfig())
+
+    conversations: list[list[GenerationRequest]] = []
+    relative_timestamps: list[float] = []
+    for index in range(len(dataset)):
+        row = {column: dataset[column][index] for column in dataset.column_names}
+        mapped = mapper([{"dataset": row}])
+        requests = finalizer(mapped)
+        assert len(requests) == 1
+        request = requests[0]
+        request.request_id = f"req_{index}"
+        conversations.append([request])
+        offset = request.settings.relative_timestamp
+        assert offset is not None
+        relative_timestamps.append(offset)
+
+    return conversations, relative_timestamps
+
+
+class FastMockBackend(BackendInterface):
+    """Backend with short resolve delay to exercise multiprocess dequeue."""
+
+    def __init__(self, resolve_delay: float = RESOLVE_DELAY):
+        self._resolve_delay = resolve_delay
+
+    @property
+    def processes_limit(self) -> int | None:
+        return None
+
+    @property
+    def requests_limit(self) -> int | None:
+        return None
+
+    def info(self) -> dict[str, Any]:
+        return {"type": "fast_mock_trace_replay", "delay": self._resolve_delay}
+
+    async def process_startup(self):
+        pass
+
+    async def validate(self):
+        pass
+
+    async def process_shutdown(self):
+        pass
+
+    async def resolve(self, request, request_info, request_history):
+        _ = request_history
+        await asyncio.sleep(self._resolve_delay)
+        yield f"ok_{request.request_id}", request_info
+
+
+def _request_index(request: GenerationRequest) -> int:
+    return int(request.request_id.removeprefix("req_"))
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.asyncio
+@async_timeout(60.0)
+async def test_trace_replay_multiprocess_from_trace_file(tmp_path: Path):
+    """Trace replay timing under multiprocessing with dataset-sourced settings.
+
+    ### WRITTEN BY AI ###
+    """
+    # Unsorted rows; deserializer sorts by timestamp (t0=2.0 -> EXPECTED_RELATIVE).
+    trace = _write_trace(
+        tmp_path / "trace.jsonl",
+        [
+            '{"timestamp": 9.0, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 2.0, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 5.5, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 2.0, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 4.0, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 2.1, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 2.0, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 3.5, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 2.1, "input_length": 10, "output_length": 5}',
+            '{"timestamp": 4.0, "input_length": 10, "output_length": 5}',
+        ],
+    )
+
+    requests, relative_timestamps = _requests_from_trace(trace)
+    assert relative_timestamps == pytest.approx(EXPECTED_RELATIVE, abs=1e-9)
+    assert len(requests) == NUM_REQUESTS
+
+    strategy = TraceReplayStrategy(time_scale=TIME_SCALE)
+    group = WorkerProcessGroup(
+        backend=FastMockBackend(resolve_delay=RESOLVE_DELAY),
+        requests=requests,
+        strategy=strategy,
+        max_number=MaxNumberConstraint(max_num=NUM_REQUESTS),
+    )
+
+    settings_by_index: dict[int, RequestSettings] = {}
+    targeted_start_by_index: dict[int, float] = {}
+    worker_nodes: set[int] = set()
+    completed = 0
+
+    try:
+        await group.create_processes()
+        assert group.processes is not None
+        assert len(group.processes) >= 2
+
+        start_time = time.time() + 0.05
+        await group.start(start_time)
+
+        async for (
+            response,
+            request,
+            request_info,
+            _state,
+        ) in group.request_updates():
+            index = _request_index(request)
+
+            if request_info.settings.relative_timestamp is not None:
+                settings_by_index[index] = request_info.settings
+
+            if request_info.timings.targeted_start is not None:
+                targeted_start_by_index[index] = request_info.timings.targeted_start
+
+            if request_info.status == "completed":
+                assert response == f"ok_req_{index}"
+                worker_nodes.add(request_info.scheduler_node_id)
+                completed += 1
+                if completed == NUM_REQUESTS:
+                    break
+    finally:
+        exceptions = await group.shutdown()
+        assert exceptions == []
+
+    assert len(settings_by_index) == NUM_REQUESTS
+    assert len(targeted_start_by_index) == NUM_REQUESTS
+    assert len(worker_nodes) >= 2
+
+    for index, relative_timestamp in enumerate(EXPECTED_RELATIVE):
+        assert settings_by_index[index].relative_timestamp == pytest.approx(
+            relative_timestamp,
+            abs=1e-9,
+        )
+        expected_target = start_time + TIME_SCALE * relative_timestamp
+        assert targeted_start_by_index[index] == pytest.approx(
+            expected_target,
+            abs=0.05,
+        )

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -81,11 +81,11 @@ class TestReplayProfile:
             ([2.0], 2.0),
         ],
     )
-    def test_profile_create_resolves_timestamps_and_time_scale(
+    def test_profile_create_resolves_time_scale_and_default_max_requests(
         self, tmp_path: Path, rate, expected_scale
     ):
         """
-        Profile.create loads sorted relative timestamps and time scale from data.
+        Profile.create resolves time scale and default max_requests from trace data.
 
         ## WRITTEN BY AI ##
         """
@@ -107,7 +107,6 @@ class TestReplayProfile:
         profile = _replay_profile(**payload)
 
         assert isinstance(profile, ReplayProfile)
-        assert profile.relative_timestamps == pytest.approx([0.0, 3.0, 6.0], abs=1e-9)
         assert profile.args.time_scale == expected_scale
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
             type_="max_number", max_num=3, current_index=0
@@ -151,7 +150,6 @@ class TestReplayProfile:
             data=[TraceSyntheticDataArgs(path=trace, timestamp_column="ts")],
         )
 
-        assert profile.relative_timestamps == pytest.approx([0.0, 3.0, 6.0], abs=1e-9)
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
             type_="max_number", max_num=3, current_index=0
         )
@@ -236,7 +234,6 @@ class TestReplayProfile:
 
         profile = _replay_profile(data=[TraceSyntheticDataArgs(path=trace)])
 
-        assert profile.relative_timestamps == pytest.approx(timestamps, abs=1e-9)
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
             type_="max_number", max_num=27, current_index=0
         )
@@ -303,7 +300,6 @@ class TestReplayProfile:
             constraints={"max_requests": 10, "max_seconds": 0.25},
         )
 
-        assert profile.relative_timestamps == pytest.approx([0.0, 1.0, 4.0], abs=1e-9)
         assert profile.constraints == {"max_requests": 10, "max_seconds": 0.25}
 
     @pytest.mark.smoke
@@ -329,7 +325,6 @@ class TestReplayProfile:
             data_samples=data_samples,
         )
 
-        assert profile.relative_timestamps == pytest.approx([0.0, 1.0], abs=1e-9)
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
             type_="max_number", max_num=2, current_index=0
         )
@@ -367,7 +362,6 @@ class TestReplayProfile:
         )
 
         assert isinstance(profile, ReplayProfile)
-        assert profile.relative_timestamps == pytest.approx([0.0, 3.0], abs=1e-9)
         assert profile.args.time_scale == 2.0
         assert profile.constraints["max_requests"] == 2
 
@@ -390,6 +384,5 @@ class TestReplayProfile:
         strategy = profile.next_strategy(None, None)
         assert profile.strategy_types == ["trace"]
         assert isinstance(strategy, TraceReplayStrategy)
-        assert strategy.relative_timestamps == [0.0]
         assert strategy.time_scale == 2.0
         assert profile.next_strategy(strategy, None) is None

--- a/tests/unit/data/deserializers/test_trace_synthetic.py
+++ b/tests/unit/data/deserializers/test_trace_synthetic.py
@@ -76,6 +76,29 @@ class TestTraceSyntheticDatasetDeserializer:
             assert len(_mock_processor().encode(prompt)) == token_count
 
     @pytest.mark.smoke
+    def test_emits_relative_timestamp_column_sorted_from_trace(
+        self, tmp_path: Path, deserializer
+    ):
+        """Each row gets offset seconds from the earliest sorted timestamp.
+
+        ### WRITTEN BY AI ###
+        """
+        trace = _write_trace(
+            tmp_path,
+            '{"timestamp": 5.0, "input_length": 1, "output_length": 10}\n'
+            '{"timestamp": 2.0, "input_length": 2, "output_length": 20}\n'
+            '{"timestamp": 8.0, "input_length": 3, "output_length": 30}\n'
+            '{"timestamp": 2.0, "input_length": 4, "output_length": 40}\n'
+            '{"timestamp": 5.0, "input_length": 5, "output_length": 50}\n',
+        )
+
+        ds = self._deserialize(deserializer, trace)
+
+        assert ds["relative_timestamp"] == pytest.approx(
+            [0.0, 0.0, 3.0, 3.0, 6.0], abs=1e-9
+        )
+
+    @pytest.mark.smoke
     def test_honors_custom_column_names(self, tmp_path: Path, deserializer):
         trace = _write_trace(
             tmp_path,

--- a/tests/unit/data/test_finalizers.py
+++ b/tests/unit/data/test_finalizers.py
@@ -13,7 +13,7 @@ from guidellm.data.finalizers import (
     GenerativeRequestFinalizer,
 )
 from guidellm.data.finalizers.generative import GenerativeRequestFinalizerConfig
-from guidellm.schemas import GenerationRequest
+from guidellm.schemas import GenerationRequest, RequestSettings
 
 
 class TestGenerativeRequestFinalizerTokenAggregation:
@@ -374,3 +374,36 @@ class TestFinalizerExpectsToolCall:
         ]
         results = finalizer(items)
         assert results[0].expects_tool_call is True
+
+
+class TestGenerativeRequestFinalizerRequestSettings:
+    """Verify relative_timestamp_column maps to GenerationRequest.settings.
+
+    ### WRITTEN BY AI ###
+    """
+
+    @pytest.fixture
+    def finalizer(self):
+        """### WRITTEN BY AI ###"""
+        return GenerativeRequestFinalizer(GenerativeRequestFinalizerConfig())
+
+    @pytest.mark.smoke
+    def test_relative_timestamp_column_sets_settings(self, finalizer):
+        """### WRITTEN BY AI ###"""
+        result = finalizer.finalize_turn({"relative_timestamp_column": [2.5]})
+
+        assert result.settings == RequestSettings(relative_timestamp=2.5)
+
+    @pytest.mark.smoke
+    def test_missing_relative_timestamp_column_uses_empty_settings(self, finalizer):
+        """### WRITTEN BY AI ###"""
+        result = finalizer.finalize_turn({"text_column": ["hello"]})
+
+        assert result.settings == RequestSettings()
+
+    @pytest.mark.smoke
+    def test_none_relative_timestamp_column_uses_empty_settings(self, finalizer):
+        """### WRITTEN BY AI ###"""
+        result = finalizer.finalize_turn({"relative_timestamp_column": [None]})
+
+        assert result.settings == RequestSettings()

--- a/tests/unit/scheduler/test_trace_replay.py
+++ b/tests/unit/scheduler/test_trace_replay.py
@@ -8,7 +8,7 @@ import pytest
 from datasets.exceptions import DatasetGenerationError
 
 from guidellm.scheduler import SchedulingStrategy, TraceReplayStrategy
-from guidellm.schemas import RequestInfo
+from guidellm.schemas import RequestInfo, RequestSettings
 from guidellm.utils.trace_io import load_relative_timestamps
 
 
@@ -92,88 +92,120 @@ class TestLoadRelativeTimestamps:
             load_relative_timestamps(trace)
 
 
+TRACE_TIMESTAMPS = [0.0, 0.0, 0.0, 0.1, 0.1, 1.5, 2.0, 2.0, 3.5, 7.0]
+
+
 class TestTraceReplayStrategy:
     @pytest.mark.smoke
     def test_initialization_and_serialization(self):
-        strategy = TraceReplayStrategy(
-            relative_timestamps=[0.0, 0.5, 1.0],
-            time_scale=2.0,
-        )
+        strategy = TraceReplayStrategy(time_scale=2.0)
 
         assert strategy.type_ == "trace"
         assert str(strategy) == "trace@2.00"
-        assert strategy.processes_limit == 1
+        assert strategy.processes_limit is None
         assert strategy.requests_limit is None
         restored = SchedulingStrategy.model_validate(strategy.model_dump())
         assert isinstance(restored, TraceReplayStrategy)
-        assert restored.relative_timestamps == [0.0, 0.5, 1.0]
         assert restored.time_scale == 2.0
 
     @pytest.mark.smoke
-    def test_next_request_time_scales_timestamps(self):
-        strategy = TraceReplayStrategy(
-            relative_timestamps=[0.0, 0.5, 1.0],
-            time_scale=2.0,
-        )
+    def test_resolve_dequeued_target_start_applies_trace_offset(self):
+        """Dequeue resolution uses per-request settings, not provisional slot time.
+
+        ### WRITTEN BY AI ###
+        """
+        strategy = TraceReplayStrategy(time_scale=2.0)
         strategy.init_processes_timings(
-            worker_count=1,
+            worker_count=2,
             max_concurrency=10,
             mp_context=get_context(),
         )
         strategy.init_processes_start(1000.0)
 
         async def run():
-            return [await strategy.next_request_time(0) for _ in range(3)]
+            settings = RequestSettings(relative_timestamp=1.5)
+            provisional = 9999.0
+            resolved = await strategy.resolve_dequeued_target_start(
+                1,
+                provisional,
+                settings,
+            )
+            return resolved, provisional
 
-        assert asyncio.run(run()) == pytest.approx([1000.0, 1001.0, 1002.0], abs=1e-6)
+        resolved, provisional = asyncio.run(run())
+        assert resolved == pytest.approx(1000.0 + 2.0 * 1.5, abs=1e-6)
+        assert resolved != pytest.approx(provisional, abs=1e-6)
 
     @pytest.mark.smoke
-    def test_next_request_time_parks_when_trace_exhausted(self):
-        strategy = TraceReplayStrategy(
-            relative_timestamps=[0.0, 0.5],
-            time_scale=1.0,
-        )
+    def test_next_request_time_returns_start_time(self):
+        """Verify next_request_time schedules immediate dequeue at benchmark start.
+
+        ### WRITTEN BY AI ###
+        """
+        strategy = TraceReplayStrategy(time_scale=2.0)
         strategy.init_processes_timings(
             worker_count=1,
             max_concurrency=10,
             mp_context=get_context(),
         )
         strategy.init_processes_start(1000.0)
-
-        async def run():
-            # Consume the 2 valid slots
-            await strategy.next_request_time(0)
-            await strategy.next_request_time(0)
-            # The 3rd call parks; should raise CancelledError when cancelled
-            task = asyncio.create_task(strategy.next_request_time(0))
-            await asyncio.sleep(0.05)
-            assert not task.done(), "expected to be parked, not resolved"
-            task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await task
-
-        asyncio.run(run())
-
-    @pytest.mark.smoke
-    def test_empty_trace_has_no_request_limit_and_uses_start_time(self):
-        strategy = TraceReplayStrategy(relative_timestamps=[], time_scale=1.0)
-        strategy.init_processes_timings(
-            worker_count=1,
-            max_concurrency=10,
-            mp_context=get_context(),
-        )
-        strategy.init_processes_start(123.0)
-
-        assert strategy.requests_limit is None
 
         async def run():
             return await strategy.next_request_time(0)
 
-        assert asyncio.run(run()) == pytest.approx(123.0)
+        assert asyncio.run(run()) == pytest.approx(1000.0, abs=1e-6)
+
+    @pytest.mark.smoke
+    def test_resolve_dequeued_target_start_scales_timestamps(self):
+        strategy = TraceReplayStrategy(time_scale=2.0)
+        strategy.init_processes_timings(
+            worker_count=1,
+            max_concurrency=10,
+            mp_context=get_context(),
+        )
+        strategy.init_processes_start(1000.0)
+
+        async def run():
+            return [
+                await strategy.resolve_dequeued_target_start(
+                    0,
+                    1000.0,
+                    RequestSettings(relative_timestamp=ts),
+                )
+                for ts in TRACE_TIMESTAMPS
+            ]
+
+        assert asyncio.run(run()) == pytest.approx(
+            [1000.0 + 2.0 * ts for ts in TRACE_TIMESTAMPS],
+            abs=1e-6,
+        )
+
+    @pytest.mark.smoke
+    def test_resolve_dequeued_target_start_without_relative_timestamp(self):
+        """Missing offset schedules at benchmark start, not the provisional slot.
+
+        ### WRITTEN BY AI ###
+        """
+        strategy = TraceReplayStrategy(time_scale=2.0)
+        strategy.init_processes_timings(
+            worker_count=1,
+            max_concurrency=10,
+            mp_context=get_context(),
+        )
+        strategy.init_processes_start(1000.0)
+
+        async def run():
+            return await strategy.resolve_dequeued_target_start(
+                0,
+                9999.0,
+                RequestSettings(),
+            )
+
+        assert asyncio.run(run()) == pytest.approx(1000.0, abs=1e-6)
 
     @pytest.mark.smoke
     def test_request_completed_no_op(self):
-        strategy = TraceReplayStrategy(relative_timestamps=[0.0], time_scale=1.0)
+        strategy = TraceReplayStrategy(time_scale=1.0)
         info = RequestInfo(
             request_id="x",
             status="completed",


### PR DESCRIPTION
## Summary:

Trace replay previously forced single-process execution because timestamps were assigned at dequeue time via a shared `next_request_index()` counter, causing ordering races under multiprocessing (#620). This PR sources per-request trace offsets from the dataset pipeline via `RequestSettings.relative_timestamp`, following the
design in #735.


## Details
- `trace_synthetic` deserializer emits a `relative_timestamp` column (offset from
  the earliest sorted trace event)
- `GenerativeColumnMapper` maps it to `relative_timestamp_column`
- `GenerativeRequestFinalizer` attaches `RequestSettings` on `GenerationRequest`
- `WorkerGroupState` copies `request.settings` into `RequestInfo` at enqueue
- Add `resolve_dequeued_target_start()` on `SchedulingStrategy`; trace replay
  applies `start_time + time_scale * relative_timestamp` at dequeue
- `TraceReplayStrategy.next_request_time` returns benchmark start (immediate dequeue)
- Remove `processes_limit = 1` on trace replay
- `ReplayProfile` keeps `time_scale` only; default `max_requests` derived from trace row count


## Test Plan:

- [x] Unit tests pass
- [x] Manual trace replay benchmark with `--processes > 1` and verify inter-arrival timing matches the trace

## Related Issues

 #735

## 

- [x]  I used an AI coding assistant while working on this PR

<!-- begin:squash-data -->

---

# git log

commit 25484a64d8afc95d7467074b2ac235c448c35f10
Author: Vincent Gimenes <vincent.gimenes@gmail.com>
Date:   Fri Jun 5 11:16:54 2026 +0200

    Enable multiprocess trace replay via per-request RequestSettings
    Move trace replay timing from ReplayProfile/TraceReplayStrategy into the
    dataset pipeline so each request carries its own scheduling metadata:
    - trace_synthetic deserializer emits a relative_timestamp column (offset
      from the earliest sorted trace event)
    - GenerativeColumnMapper maps it to relative_timestamp_column
    - GenerativeRequestFinalizer attaches RequestSettings on GenerationRequest
    - WorkerGroupState copies request.settings into RequestInfo at enqueue
    TraceReplayStrategy no longer holds a global relative_timestamps list.
    next_request_time schedules dequeue at benchmark start; resolve_dequeued_target_start
    applies start_time + time_scale * relative_timestamp per request at dequeue.
    This removes the single-process constraint and enables correct multiprocess
    trace replay timing.
    ReplayProfile keeps only time_scale (from rate) and default max_requests
    when data_samples truncates the dataset.
    Add integration test exercising the full trace_synthetic → mapper →
    finalizer → TraceReplayStrategy multiprocess path, plus unit test updates.
    
    Signed-off-by: Vincent Gimenes <vincent.gimenes@gmail.com>

---------

Signed-off-by: Vincent Gimenes <vincent.gimenes@gmail.com>
