### PR TITLE
feat: add automated docs deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "DEVELOPING.md"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
 
 jobs:
   tests:
@@ -22,3 +28,28 @@ jobs:
     uses: ./.github/workflows/quality.yml
     with:
       python: ${{ matrix.python }}
+
+  docs-deploy:
+    needs: [tests, quality]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Setup Python with UV
+        uses: ./.github/actions/python-uv
+        with:
+          python-version: "3.10"
+      - name: Install mkdocs dependencies
+        run: |
+          uv pip install --system mkdocs mkdocs-material mike \
+            mkdocs-gen-files mkdocs-nav-weight mkdocs-section-index \
+            mkdocs-minify-plugin "mkdocstrings[python]" mkdocs-api-autonav
+      - name: Deploy docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mike deploy main --push --update-aliases

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "DEVELOPING.md"
-      - "CONTRIBUTING.md"
-      - "CODE_OF_CONDUCT.md"
 
 jobs:
   tests:
@@ -39,16 +33,28 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Check docs changes
+        id: docs-changed
+        run: |
+          if git diff-tree --no-commit-id --name-only -r HEAD \
+            | grep -qE '^(docs/|mkdocs\.yml|DEVELOPING\.md|CONTRIBUTING\.md|CODE_OF_CONDUCT\.md)'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
       - name: Setup Python with UV
+        if: steps.docs-changed.outputs.changed == 'true'
         uses: ./.github/actions/python-uv
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install mkdocs dependencies
+        if: steps.docs-changed.outputs.changed == 'true'
         run: |
           uv pip install --system mkdocs mkdocs-material mike \
             mkdocs-gen-files mkdocs-nav-weight mkdocs-section-index \
             mkdocs-minify-plugin "mkdocstrings[python]" mkdocs-api-autonav
       - name: Deploy docs
+        if: steps.docs-changed.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Python with UV
         uses: ./.github/actions/python-uv
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install mkdocs dependencies
         run: |
           uv pip install --system mkdocs mkdocs-material mike \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,33 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+  docs-deploy:
+    needs: extract-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Setup Python with UV
+        uses: ./.github/actions/python-uv
+        with:
+          python-version: "3.10"
+      - name: Install mkdocs dependencies
+        run: |
+          uv pip install --system mkdocs mkdocs-material mike \
+            mkdocs-gen-files mkdocs-nav-weight mkdocs-section-index \
+            mkdocs-minify-plugin "mkdocstrings[python]" mkdocs-api-autonav
+      - name: Deploy docs
+        run: |
+          VERSION="${{ needs.extract-version.outputs.version }}"
+          VERSION="${VERSION#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          mike deploy $VERSION stable --push --update-aliases
+
   build-and-push-container:
     needs: extract-version
     permissions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: GuideLLM Docs
 site_description: Documentation for GuideLLM focused on evaluating the deployability of an LLM for real-world inference
-site_url: https://neuralmagic.github.io/guidellm
-repo_url: https://github.com/neuralmagic/guidellm
-edit_uri: https://github.com/neuralmagic/guidellm/tree/main/docs
+site_url: https://vllm-project.github.io/guidellm
+repo_url: https://github.com/vllm-project/guidellm
+edit_uri: https://github.com/vllm-project/guidellm/tree/main/docs
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

Add automated CI workflows to deploy documentation to GitHub Pages via mike. Currently docs are only deployable manually, and the live site has not been updated since mid-April, causing stale and incorrect content (e.g. the developing page still reads "Developing for Speculators" instead of "Developing for GuideLLM").

## Details

- [x] Add `docs-deploy` job to `main.yml`, triggered on push to `main` when docs-related files change (`docs/**`, `mkdocs.yml`, `DEVELOPING.md`, etc.), deploying as the `main` version
- [x] Add `docs-deploy` job to `release.yml`, triggered on `v*.*.*` tags, deploying the version tag and updating the `stable` alias
- [x] Fix `site_url`, `repo_url`, and `edit_uri` in `mkdocs.yml` from `neuralmagic` to `vllm-project`

## Test Plan

- After merge, verify the `docs-deploy` job succeeds in the Main workflow
- Confirm a new commit from `github-actions[bot]` appears on the `gh-pages` branch
- Visit `https://vllm-project.github.io/guidellm/main/developer/developing/` and verify content matches the current `DEVELOPING.md`

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent