### PR TITLE
Run a useful set of tox environments by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-env_list = py3{10,11,12,13}
+env_list = {lint,type}-check,test-{unit,integration,e2e}
 
 
 [testenv:tests]


### PR DESCRIPTION
## Summary

Simple QoL change to make `tox run` default to the set of tox jobs used in CI.

## Test Plan

- `tox run`

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
