### PR TITLE
Ensure system env vars don't taint tests

### DIFF
--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from guidellm.settings import (
@@ -14,7 +16,12 @@ BASE_URL = "https://vllm-project.github.io/guidellm/ui/"
 
 
 @pytest.mark.smoke
-def test_default_settings():
+def test_default_settings(mocker):
+    mocker.patch.dict(
+        "os.environ",
+        {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
+        clear=True,
+    )
     settings = Settings()
     assert settings.logging == LoggingSettings()
     assert settings.report_generation.source.startswith(BASE_URL)
@@ -55,7 +62,12 @@ def test_report_generation_settings():
 
 
 @pytest.mark.sanity
-def test_generate_env_file():
+def test_generate_env_file(mocker):
+    mocker.patch.dict(
+        "os.environ",
+        {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
+        clear=True,
+    )
     settings = Settings()
     env_file_content = settings.generate_env_file()
     assert "GUIDELLM__LOGGING__DISABLED" in env_file_content
@@ -106,7 +118,12 @@ def test_dataset_settings_defaults():
 
 
 @pytest.mark.sanity
-def test_table_properties_defaults():
+def test_table_properties_defaults(mocker):
+    mocker.patch.dict(
+        "os.environ",
+        {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
+        clear=True,
+    )
     settings = Settings()
     assert settings.table_border_char == "="
     assert settings.table_headers_border_char == "-"


### PR DESCRIPTION
## Summary

I've had problems where env vars I set are tainting tests.

## Details

- The env var I set was to set the console log level to DEBUG, because I want to see backend errors. But that breaks a test. I had `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL=DEBUG`
- I applied this to all tests that could theoretically break due to env vars being set. 

## Test Plan

- Running tests to ensure the standard case didn't break
- Run tests with env vars set to ensure it still works. 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
