### PR TITLE
Fix TypeError when streaming delta has tool_calls=null

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -726,7 +726,9 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         # Accumulate streamed tool_calls deltas.  Each tool call may be split
         # across multiple chunks; we reassemble by ``index``.
-        for tc_delta in delta.get("tool_calls", []):
+        # ``tool_calls`` could be either missing or ``null`` in the delta
+        # (some OpenAI-compatible servers emit this), handle both cases
+        for tc_delta in delta.get("tool_calls") or []:
             self._accumulate_tool_call_delta(tc_delta)
             updated = True
 


### PR DESCRIPTION
## Summary

Some OpenAI-compatible servers emit ``"tool_calls": null`` inside streaming chat completion deltas. ``dict.get("tool_calls", [])`` only returns the default when the key is missing, so for an explicit ``null`` the iteration was attempted on ``None``, raising
``TypeError: 'NoneType' object is not iterable`` and erroring the request. Coerce ``None`` to an empty list before iterating.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
