### PR TITLE
fix: fix docs deploy trigger and minor doc issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check docs changes
         id: docs-changed
         run: |
-          if git diff-tree --no-commit-id --name-only -r HEAD \
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} \
             | grep -qE '^(docs/|mkdocs\.yml|DEVELOPING\.md|CONTRIBUTING\.md|CODE_OF_CONDUCT\.md)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -282,7 +282,7 @@ npm run build
 
 ##### Tagging Tests
 
-Reference [https://www.npmjs.com/package/jest-runner-groups](jest-runner-groups) Add @group with the tag in a docblock at the top of the test file to indicate which types of tests are contained within. Can't distinguish between different types of tests in the same file.
+Reference [jest-runner-groups](https://www.npmjs.com/package/jest-runner-groups). Add @group with the tag in a docblock at the top of the test file to indicate which types of tests are contained within. Can't distinguish between different types of tests in the same file.
 
 ```
 /**

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/neuralmagic/guidellm/main/docs/assets/guidellm-logo-light.png">
-    <img alt="GuideLLM Logo" src="https://raw.githubusercontent.com/neuralmagic/guidellm/main/docs/assets/guidellm-logo-dark.png" width=55%>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/guidellm/main/docs/assets/guidellm-logo-light.png">
+    <img alt="GuideLLM Logo" src="https://raw.githubusercontent.com/vllm-project/guidellm/main/docs/assets/guidellm-logo-dark.png" width=55%>
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary

The docs deployment workflow added in #747 uses `git diff-tree HEAD` to detect docs changes, which only checks the last commit and misses changes in merge commits. This prevents the first deployment from triggering after merge. Also fix a broken markdown link and stale logo URLs.

## Details

- [x] Use `git diff --name-only ${{ github.event.before }} ${{ github.sha }}` instead of `git diff-tree HEAD` so docs changes across the entire push are detected
- [x] Fix swapped markdown link syntax in DEVELOPING.md (`[jest-runner-groups](url)` instead of `[url](text)`)
- [x] Update `neuralmagic` -> `vllm-project` in docs/index.md logo image URLs

## Test Plan

- After merge, the Main workflow should detect the DEVELOPING.md and docs/index.md changes and run the docs-deploy job
- Verify https://vllm-project.github.io/guidellm/main/ shows the updated content

## Related Issues

- Follow-up to #747

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent