### PR TITLE
Make synthetic_text output_tokens optional and improve CLI errors

### DIFF
--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -408,11 +408,13 @@ def run(**kwargs):  # noqa: C901
             scenario=kwargs.pop("scenario", None), **kwargs
         )
     except ValidationError as err:
-        # Translate pydantic valdation error to click argument error
+        # Translate pydantic validation error to click argument error
         errs = err.errors(include_url=False, include_context=True, include_input=True)
-        param_name = "--" + str(errs[0]["loc"][0]).replace("_", "-")
+        first_loc = errs[0]["loc"]
+        top_field = str(first_loc[0]) if first_loc else ""
+        param_name = "--" + top_field.replace("_", "-")
         raise click.BadParameter(
-            errs[0]["msg"], ctx=ctx, param_hint=param_name
+            cli_tools.format_validation_errors(errs), ctx=ctx, param_hint=param_name
         ) from err
 
     asyncio.run(

--- a/src/guidellm/data/deserializers/synthetic.py
+++ b/src/guidellm/data/deserializers/synthetic.py
@@ -89,9 +89,15 @@ class SyntheticTextDataArgs(DataArgs):
         gt=0,
         default=None,
     )
-    output_tokens: int = Field(
-        description="The average number of text tokens generated for outputs.",
+    output_tokens: int | None = Field(
+        description=(
+            "The average number of text tokens generated for outputs. "
+            "When omitted, output tokens are not sampled and ``max_tokens`` is left "
+            "to the backend default. Useful for endpoints that do not produce "
+            "output tokens (e.g. embeddings)."
+        ),
         gt=0,
+        default=None,
     )
     output_tokens_stdev: int | None = Field(
         description="The standard deviation of the tokens generated for outputs.",

--- a/src/guidellm/utils/cli.py
+++ b/src/guidellm/utils/cli.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import click
 import yaml
+from pydantic_core import ErrorDetails
 
 from guidellm.utils import arg_string
 
@@ -11,6 +12,8 @@ __all__ = [
     "Union",
     "decode_escaped_str",
     "format_list_arg",
+    "format_validation_error",
+    "format_validation_errors",
     "parse_json",
     "parse_list",
     "parse_list_floats",
@@ -67,6 +70,45 @@ def parse_list_floats(ctx, param, value):
             f"Input '{value}' is not a valid comma-separated list "
             f"of floats/ints. Failed on {item} Error: {err}"
         ) from err
+
+
+def format_validation_error(err: ErrorDetails) -> str:
+    """
+    Format a single pydantic validation error into a human-readable message.
+
+    Includes the full location path, such as
+    ``data[0].synthetic_text.output_tokens``, so callers can identify which
+    nested subfield failed rather than only the top-level CLI option.
+
+    :param err: A pydantic error dict as returned by ``ValidationError.errors()``
+    :return: Formatted error string including the failing field path
+    """
+    loc = err.get("loc", ())
+    msg = err.get("msg", "validation error")
+    if not loc:
+        return msg
+
+    path = str(loc[0])
+    for component in loc[1:]:
+        if isinstance(component, int):
+            path += f"[{component}]"
+        else:
+            path += f".{component}"
+
+    return f"{msg} (at '{path}')"
+
+
+def format_validation_errors(errs: list[ErrorDetails]) -> str:
+    """
+    Combine one or more pydantic error dicts into a single click-friendly message.
+
+    :param errs: Pydantic error dicts as returned by ``ValidationError.errors()``
+    :return: Single error message; multiple errors are rendered as a bullet list
+    """
+    formatted = [format_validation_error(e) for e in errs]
+    if len(formatted) == 1:
+        return formatted[0]
+    return "\n  - " + "\n  - ".join(formatted)
 
 
 def parse_json(ctx, param, value):  # noqa: ARG001, C901, PLR0911

--- a/tests/unit/cli/benchmark/test_run.py
+++ b/tests/unit/cli/benchmark/test_run.py
@@ -1,0 +1,65 @@
+"""Tests for ``guidellm benchmark run`` CLI error translation."""
+
+import pytest
+from click.testing import CliRunner
+
+from guidellm.__main__ import cli
+
+
+@pytest.mark.regression
+def test_run_reports_nested_field_path_on_missing_subfield():
+    """
+    A missing nested data subfield should surface its full location path
+    instead of only the top-level CLI option name.
+
+    Regression test for the misleading ``Invalid value for --data: Field required``
+    message produced when a synthetic data sub-argument was omitted.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "benchmark",
+            "run",
+            "--target",
+            "http://localhost:9",
+            "--data",
+            "kind=synthetic_text",
+            "--max-requests",
+            "1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--data" in result.output
+    assert "data[0].synthetic_text.prompt_tokens" in result.output
+
+
+@pytest.mark.regression
+def test_run_allows_synthetic_text_without_output_tokens():
+    """
+    ``output_tokens`` is optional so synthetic_text data can be used against
+    endpoints that don't produce output tokens (e.g. embeddings) without forcing
+    users to supply a meaningless value.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "benchmark",
+            "run",
+            "--target",
+            "http://localhost:9",
+            "--data",
+            "kind=synthetic_text,prompt_tokens=128",
+            "--max-requests",
+            "1",
+        ],
+    )
+
+    assert "Invalid value for --data" not in result.output
+    assert "output_tokens" not in result.output

--- a/tests/unit/utils/test_cli.py
+++ b/tests/unit/utils/test_cli.py
@@ -1,0 +1,38 @@
+"""Tests for CLI utility helpers."""
+
+import pytest
+
+from guidellm.utils.cli import format_validation_error
+
+
+@pytest.mark.sanity
+def test_format_validation_error_includes_indices_and_field_path():
+    """
+    ``format_validation_error`` should render integer loc components as ``[i]``
+    and string components as ``.name`` so nested errors are unambiguous.
+
+    ## WRITTEN BY AI ##
+    """
+    formatted = format_validation_error(
+        {
+            "loc": ("data", 0, "synthetic_text", "output_tokens"),
+            "msg": "Field required",
+        }
+    )
+
+    assert formatted == "Field required (at 'data[0].synthetic_text.output_tokens')"
+
+
+@pytest.mark.sanity
+def test_format_validation_error_handles_top_level_only_path():
+    """
+    A single-element loc should still produce a readable message without
+    appending a trailing separator.
+
+    ## WRITTEN BY AI ##
+    """
+    formatted = format_validation_error(
+        {"loc": ("rate",), "msg": "Input should be a valid number"}
+    )
+
+    assert formatted == "Input should be a valid number (at 'rate')"


### PR DESCRIPTION
## Summary

Synthetic data generation already handled output_tokens being absent (samplers, features, and downstream max_tokens fallback all gated on None), but the schema declared it required. This forced users benchmarking endpoints with no output tokens (e.g. /v1/embeddings) to pass a meaningless value. Make the field default to None.

Also fix the misleading "Invalid value for --data: Field required" CLI error: the pydantic-to-click translation in `benchmark run` was dropping the nested field location and only reporting the top-level CLI option. Errors now include the full path (e.g. data[0].synthetic_text.prompt_tokens) and aggregate multiple validation errors into a single message.

Assisted-by: Cursor AI Claude Opus 4.7

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
