### PR TITLE
Time to first output token and related fixes

### DIFF
--- a/docs/guides/multiturn.md
+++ b/docs/guides/multiturn.md
@@ -412,6 +412,53 @@ guidellm benchmark run \
 > [!WARNING]\
 > In the current CLI design, setting `--data-preprocessors` overrides **all** preprocessors, *except for the column mapper*, so take care to specify any preprocessor required for your use-case.
 
+## Reasoning in History
+
+Reasoning models emit chain-of-thought tokens before their final answer. By default, these are discarded from conversation history on follow-up turns. Enable `multiturn_reasoning` via `--backend-kwargs` to include them:
+
+- `false` (default) — reasoning not included in history
+- `true` — wraps in `<think>...</think>` tags (equivalent to `"<think>{reasoning}</think>"`)
+- A format string containing `{reasoning}` — custom wrapping
+
+### Think Tags (most models)
+
+```bash
+--backend-kwargs '{"multiturn_reasoning": true}'
+```
+
+Results in the following being sent for the turn in the conversation history:
+
+```json
+{"role": "assistant", "content": "<think>step-by-step reasoning...</think>Final answer."}
+```
+
+### Granite Format
+
+```bash
+--backend-kwargs '{"multiturn_reasoning": "Here is my thought process:{reasoning}Here is my response:"}'
+```
+
+### Raw (no delimiters)
+
+```bash
+--backend-kwargs '{"multiturn_reasoning": "{reasoning}"}'
+```
+
+### Common Model Pairings
+
+| Model Family                                                       | Recommended Value                                              |
+| ------------------------------------------------------------------ | -------------------------------------------------------------- |
+| DeepSeek R1, QwQ, Qwen3, Gemma 4, GLM-4.5, Holo2, Cohere Command A | `true`                                                         |
+| IBM Granite 3.2                                                    | `"Here is my thought process:{reasoning}Here is my response:"` |
+| OpenAI o-series (o1, o3)                                           | `false` (reasoning not replayable via API)                     |
+| Custom / no delimiters                                             | `"{reasoning}"`                                                |
+
+### Other notes regarding reasoning:
+
+Reasoning is only recognized if "reasoning" chunks are sent to the client. This is typically only done if a reasoning parser is included. Otherwise, GuideLLM will interpret them as non-reasoning tokens. Regarding KVCache, reasoning parsers reformat the reasoning, which has a side effect of making it so that despite sending back reasoning tokens, kvcache likely won't match exactly, causing a partial cache miss. Settings to evict reasoning from vLLM's cache are in review as of the time of this writing.
+
+It is recommended that you research the design of the model you're using and the model server to ensure reasoning history is set up correctly.
+
 ## Limitations and Considerations
 
 ### Supported Request Formats

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -147,13 +147,27 @@ class OpenAIHTTPBackendArgs(BackendArgs):
             "cancel remaining turns)."
         ),
     )
-    multiturn_reasoning: bool = Field(
+    multiturn_reasoning: bool | str = Field(
         default=False,
         description=(
             "Include reasoning/chain-of-thought text in multi-turn "
-            "conversation history. Disabled by default."
+            "conversation history. False disables (default). True wraps "
+            "reasoning in <think>...</think> tags (equivalent to the string "
+            "'<think>{reasoning}</think>'). A string value is used as a "
+            "format template and must contain '{reasoning}'."
         ),
     )
+
+    @field_validator("multiturn_reasoning", mode="after")
+    @classmethod
+    def validate_multiturn_reasoning(cls, value: bool | str) -> bool | str:
+        """Reject non-empty strings that don't contain the {reasoning} placeholder."""
+        if isinstance(value, str) and "{reasoning}" not in value:
+            raise ValueError(
+                "multiturn_reasoning string must contain '{reasoning}' "
+                f"placeholder, got: {value!r}"
+            )
+        return value
 
     @field_validator("target", mode="after")
     @classmethod

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -147,7 +147,7 @@ class OpenAIHTTPBackendArgs(BackendArgs):
             "cancel remaining turns)."
         ),
     )
-    include_reasoning_in_history: bool = Field(
+    multiturn_reasoning: bool = Field(
         default=False,
         description=(
             "Include reasoning/chain-of-thought text in multi-turn "
@@ -405,7 +405,7 @@ class OpenAIHTTPBackend(Backend):
             extras=self._args.extras,
             max_tokens=self._args.max_tokens,
             server_history=self._args.server_history,
-            include_reasoning_in_history=(self._args.include_reasoning_in_history),
+            multiturn_reasoning=self._args.multiturn_reasoning,
         )
 
         request_url = f"{self._args.target}/{request_path}"

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -147,6 +147,13 @@ class OpenAIHTTPBackendArgs(BackendArgs):
             "cancel remaining turns)."
         ),
     )
+    include_reasoning_in_history: bool = Field(
+        default=False,
+        description=(
+            "Include reasoning/chain-of-thought text in multi-turn "
+            "conversation history. Disabled by default to save context."
+        ),
+    )
 
     @field_validator("target", mode="after")
     @classmethod
@@ -398,6 +405,9 @@ class OpenAIHTTPBackend(Backend):
             extras=self._args.extras,
             max_tokens=self._args.max_tokens,
             server_history=self._args.server_history,
+            include_reasoning_in_history=(
+                self._args.include_reasoning_in_history
+            ),
         )
 
         request_url = f"{self._args.target}/{request_path}"
@@ -508,6 +518,15 @@ class OpenAIHTTPBackend(Backend):
                         request_info.timings.first_token_iteration = iter_time
                         request_info.timings.token_iterations = 0
                         yield None, request_info
+
+                    # TTFOT: record the first content (non-reasoning) token.
+                    # For non-reasoning models this fires on the same iteration
+                    # as first_token_iteration, making TTFOT == TTFT.
+                    if (
+                        request_info.timings.first_output_token_iteration is None
+                        and request_handler.last_iteration_had_content
+                    ):
+                        request_info.timings.first_output_token_iteration = iter_time
 
                     request_info.timings.last_token_iteration = iter_time
                     request_info.timings.token_iterations += iterations

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -151,7 +151,7 @@ class OpenAIHTTPBackendArgs(BackendArgs):
         default=False,
         description=(
             "Include reasoning/chain-of-thought text in multi-turn "
-            "conversation history. Disabled by default to save context."
+            "conversation history. Disabled by default."
         ),
     )
 
@@ -405,9 +405,7 @@ class OpenAIHTTPBackend(Backend):
             extras=self._args.extras,
             max_tokens=self._args.max_tokens,
             server_history=self._args.server_history,
-            include_reasoning_in_history=(
-                self._args.include_reasoning_in_history
-            ),
+            include_reasoning_in_history=(self._args.include_reasoning_in_history),
         )
 
         request_url = f"{self._args.target}/{request_path}"

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -83,12 +83,14 @@ class OpenAIRequestHandler(Protocol):
     @property
     def last_iteration_had_content(self) -> bool:
         """
-        Whether the last streaming iteration produced content (not reasoning-only).
+        Whether the last chunk carried output (text/tool-call) tokens,
+        not solely reasoning tokens.
 
-        Used by the HTTP streaming loop to distinguish the first content token
-        from the first reasoning token for TTFOT measurement.
+        Used by the HTTP streaming loop to detect the first output token
+        for TTFOT measurement.
 
-        :return: True if the last iteration had content, False if reasoning-only
+        :return: True if the last chunk carried output tokens, not solely
+            reasoning tokens.
         """
         ...
 
@@ -529,8 +531,8 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
     @property
     def last_iteration_had_content(self) -> bool:
         """
-        :return: True if the last streaming iteration produced content
-            (not reasoning-only)
+        :return: True if the last chunk carried output (text/tool-call) tokens,
+            not solely reasoning tokens.
         """
         return self._last_iteration_had_content
 
@@ -767,12 +769,12 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         # For tool call responses, include the assistant's tool_calls and
         # synthetic tool result messages so the model sees the full
         # multi-turn exchange.  For plain text responses, just add content.
-        # When include_reasoning_in_history is enabled, prepend reasoning
+        # When multiturn_reasoning is enabled, prepend reasoning
         # text to the assistant content so the model sees its own CoT.
-        include_reasoning = kwargs.get("include_reasoning_in_history", False)
+        multiturn_reasoning = kwargs.get("multiturn_reasoning", False)
         if response and response.tool_calls:
             assistant_content = response.text
-            if include_reasoning and response.reasoning_text:
+            if multiturn_reasoning and response.reasoning_text:
                 assistant_content = response.reasoning_text + (assistant_content or "")
             arguments.body["messages"].append(
                 {
@@ -788,10 +790,10 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
                 )
             )
         elif response and (
-            response.text or (include_reasoning and response.reasoning_text)
+            response.text or (multiturn_reasoning and response.reasoning_text)
         ):
             content = response.text or ""
-            if include_reasoning and response.reasoning_text:
+            if multiturn_reasoning and response.reasoning_text:
                 content = response.reasoning_text + content
             arguments.body["messages"].append({"role": "assistant", "content": content})
 
@@ -1094,8 +1096,8 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
     @property
     def last_iteration_had_content(self) -> bool:
         """
-        :return: True if the last streaming iteration produced content
-            (not reasoning-only)
+        :return: True if the last chunk carried output (text/tool-call) tokens,
+            not solely reasoning tokens.
         """
         return self._last_iteration_had_content
 
@@ -1151,7 +1153,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         response: GenerationResponse | None,
         prev_requests: list[GenerationRequestArguments],
         *,
-        include_reasoning: bool = False,
+        multiturn_reasoning: bool = False,
     ) -> list[dict[str, Any]]:
         """Build the ``input`` array for the Responses API.
 
@@ -1159,7 +1161,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         dicts (with nested content parts like ``input_text``, ``input_image``)
         instead of chat completions' ``messages`` array.
 
-        :param include_reasoning: When True, prepend reasoning text to
+        :param multiturn_reasoning: When True, prepend reasoning text to
             assistant content in the conversation history.
         """
         input_items: list[dict[str, Any]] = []
@@ -1204,10 +1206,10 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                     }
                 )
         elif response and (
-            response.text or (include_reasoning and response.reasoning_text)
+            response.text or (multiturn_reasoning and response.reasoning_text)
         ):
             content = response.text or ""
-            if include_reasoning and response.reasoning_text:
+            if multiturn_reasoning and response.reasoning_text:
                 content = response.reasoning_text + content
             input_items.append({"role": "assistant", "content": content})
 
@@ -1311,7 +1313,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             data,
             response,
             prev_requests,
-            include_reasoning=kwargs.get("include_reasoning_in_history", False),
+            multiturn_reasoning=kwargs.get("multiturn_reasoning", False),
         )
 
         # Server-side history: reference the previous response by ID and

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -176,6 +176,24 @@ def _apply_tool_call_metrics(
         output_metrics.mixed_content_tool_tokens = output_metrics.text_tokens
 
 
+_DEFAULT_REASONING_TEMPLATE = "<think>{reasoning}</think>"
+
+
+def _wrap_reasoning(reasoning_text: str | None, mode: bool | str) -> str | None:
+    """Apply the configured reasoning format to reasoning text.
+
+    :param reasoning_text: Raw reasoning text from the model response.
+    :param mode: Wrapping mode — False disables, True uses the default
+        ``<think>...</think>`` template, a string is used as a format
+        template containing ``{reasoning}``.
+    :return: Formatted reasoning string, or None when disabled or no text.
+    """
+    if not mode or not reasoning_text:
+        return None
+    template = _DEFAULT_REASONING_TEMPLATE if mode is True else mode
+    return template.format(reasoning=reasoning_text)
+
+
 def _compile_streaming_response(
     request: GenerationRequest,
     arguments: GenerationRequestArguments,
@@ -769,13 +787,16 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         # For tool call responses, include the assistant's tool_calls and
         # synthetic tool result messages so the model sees the full
         # multi-turn exchange.  For plain text responses, just add content.
-        # When multiturn_reasoning is enabled, prepend reasoning
+        # When multiturn_reasoning is enabled, prepend wrapped reasoning
         # text to the assistant content so the model sees its own CoT.
         multiturn_reasoning = kwargs.get("multiturn_reasoning", False)
+        wrapped_reasoning = _wrap_reasoning(
+            response.reasoning_text if response else None, multiturn_reasoning
+        )
         if response and response.tool_calls:
             assistant_content = response.text
-            if multiturn_reasoning and response.reasoning_text:
-                assistant_content = response.reasoning_text + (assistant_content or "")
+            if wrapped_reasoning:
+                assistant_content = wrapped_reasoning + (assistant_content or "")
             arguments.body["messages"].append(
                 {
                     "role": "assistant",
@@ -789,12 +810,10 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
                     response.tool_calls, tool_response_columns
                 )
             )
-        elif response and (
-            response.text or (multiturn_reasoning and response.reasoning_text)
-        ):
+        elif response and (response.text or wrapped_reasoning):
             content = response.text or ""
-            if multiturn_reasoning and response.reasoning_text:
-                content = response.reasoning_text + content
+            if wrapped_reasoning:
+                content = wrapped_reasoning + content
             arguments.body["messages"].append({"role": "assistant", "content": content})
 
         # Inject tool definitions and apply tool-call-specific overrides.
@@ -1153,7 +1172,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         response: GenerationResponse | None,
         prev_requests: list[GenerationRequestArguments],
         *,
-        multiturn_reasoning: bool = False,
+        multiturn_reasoning: bool | str = False,
     ) -> list[dict[str, Any]]:
         """Build the ``input`` array for the Responses API.
 
@@ -1161,8 +1180,8 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         dicts (with nested content parts like ``input_text``, ``input_image``)
         instead of chat completions' ``messages`` array.
 
-        :param multiturn_reasoning: When True, prepend reasoning text to
-            assistant content in the conversation history.
+        :param multiturn_reasoning: When truthy, prepend wrapped reasoning text
+            to assistant content in the conversation history.
         """
         input_items: list[dict[str, Any]] = []
 
@@ -1183,6 +1202,9 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         # Replay the prior assistant response. For tool call responses,
         # include the function_call items and synthetic function_call_output
         # items so the model sees the full multi-turn exchange.
+        wrapped_reasoning = _wrap_reasoning(
+            response.reasoning_text if response else None, multiturn_reasoning
+        )
         if response and response.tool_calls:
             for tc in response.tool_calls:
                 input_items.append(self._tool_call_to_responses_item(tc))
@@ -1205,12 +1227,10 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                         "output": output_content,
                     }
                 )
-        elif response and (
-            response.text or (multiturn_reasoning and response.reasoning_text)
-        ):
+        elif response and (response.text or wrapped_reasoning):
             content = response.text or ""
-            if multiturn_reasoning and response.reasoning_text:
-                content = response.reasoning_text + content
+            if wrapped_reasoning:
+                content = wrapped_reasoning + content
             input_items.append({"role": "assistant", "content": content})
 
         return input_items

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -80,6 +80,18 @@ class OpenAIRequestHandler(Protocol):
         """
         ...
 
+    @property
+    def last_iteration_had_content(self) -> bool:
+        """
+        Whether the last streaming iteration produced content (not reasoning-only).
+
+        Used by the HTTP streaming loop to distinguish the first content token
+        from the first reasoning token for TTFOT measurement.
+
+        :return: True if the last iteration had content, False if reasoning-only
+        """
+        ...
+
     def add_streaming_line(self, line: str) -> int | None:
         """
         Process a single line from a streaming response.
@@ -173,6 +185,7 @@ def _compile_streaming_response(
         [dict[str, int | dict[str, int]] | None, str | None],
         tuple[UsageMetrics, UsageMetrics],
     ],
+    streaming_reasoning_texts: list[str] | None = None,
 ) -> GenerationResponse:
     """Compile accumulated streaming state into a final response.
 
@@ -187,9 +200,13 @@ def _compile_streaming_response(
     :param streaming_usage: Usage dict from the final streaming event.
     :param streaming_response_id: Server-assigned response ID, if any.
     :param extract_metrics: Handler-specific metric extraction callable.
+    :param streaming_reasoning_texts: Reasoning text chunks, if any.
     :return: Standardized GenerationResponse with extracted metrics.
     """
     text = "".join(streaming_texts) or None
+    reasoning_text = (
+        "".join(streaming_reasoning_texts) if streaming_reasoning_texts else None
+    ) or None
     tool_calls: list[ToolCall] | None = (
         [streaming_tool_calls[i] for i in sorted(streaming_tool_calls)]
         if streaming_tool_calls
@@ -205,6 +222,7 @@ def _compile_streaming_response(
         request_args=arguments.model_dump_json(),
         response_id=streaming_response_id,
         text=text,
+        reasoning_text=reasoning_text,
         tool_calls=tool_calls,
         input_metrics=input_metrics,
         output_metrics=output_metrics,
@@ -239,6 +257,19 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         self.streaming_texts: list[str] = []
         self.streaming_usage: dict[str, int | dict[str, int]] | None = None
         self.streaming_response_id: str | None = None
+
+    @property
+    def last_iteration_had_content(self) -> bool:
+        """
+        Text completions (``/v1/completions``) have no reasoning concept, so
+        every token is content. ChatCompletionsRequestHandler and
+        ResponsesRequestHandler override this with a tracked flag that starts
+        ``False`` and only becomes ``True`` when a content or tool call delta
+        arrives.
+
+        :return: Always True for the text completions base class
+        """
+        return True
 
     def format(  # noqa: C901
         self,
@@ -492,6 +523,16 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         # keyed by the delta ``index`` field.  Needed for multi-turn tool
         # calling so the response carries the id/name/arguments of each call.
         self.streaming_tool_calls: dict[int, ToolCall] = {}
+        self.streaming_reasoning_texts: list[str] = []
+        self._last_iteration_had_content: bool = False
+
+    @property
+    def last_iteration_had_content(self) -> bool:
+        """
+        :return: True if the last streaming iteration produced content
+            (not reasoning-only)
+        """
+        return self._last_iteration_had_content
 
     @staticmethod
     def _ensure_tool_format(tool: dict[str, Any]) -> dict[str, Any]:
@@ -726,11 +767,19 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         # For tool call responses, include the assistant's tool_calls and
         # synthetic tool result messages so the model sees the full
         # multi-turn exchange.  For plain text responses, just add content.
+        # When include_reasoning_in_history is enabled, prepend reasoning
+        # text to the assistant content so the model sees its own CoT.
+        include_reasoning = kwargs.get("include_reasoning_in_history", False)
         if response and response.tool_calls:
+            assistant_content = response.text
+            if include_reasoning and response.reasoning_text:
+                assistant_content = (
+                    response.reasoning_text + (assistant_content or "")
+                )
             arguments.body["messages"].append(
                 {
                     "role": "assistant",
-                    "content": response.text,
+                    "content": assistant_content,
                     "tool_calls": [tc.model_dump() for tc in response.tool_calls],
                 }
             )
@@ -741,8 +790,11 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
                 )
             )
         elif response and response.text:
+            content = response.text
+            if include_reasoning and response.reasoning_text:
+                content = response.reasoning_text + content
             arguments.body["messages"].append(
-                {"role": "assistant", "content": response.text}
+                {"role": "assistant", "content": content}
             )
 
         # Inject tool definitions and apply tool-call-specific overrides.
@@ -771,6 +823,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
         text = message.get("content")
+        reasoning_text = message.get("reasoning") or None
         raw_tool_calls = message.get("tool_calls")
         if text is None and not raw_tool_calls:
             text = ""  # Edge case: null content and no tools
@@ -788,6 +841,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),  # use vLLM ID if available
             text=text,
+            reasoning_text=reasoning_text,
             tool_calls=tool_calls,
             input_metrics=input_metrics,
             output_metrics=output_metrics,
@@ -811,15 +865,22 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.streaming_response_id = data["id"]
 
         updated = False
+        # Tracks whether this iteration produced user-visible content (not
+        # reasoning-only). Used by the HTTP layer to set TTFOT timing.
+        had_content = False
         choices, usage = self.extract_choices_and_usage(data)
         choice: dict[str, dict] = choices[0] if choices else {}
         delta = choice.get("delta", {}) if choices else {}
 
-        if delta.get("reasoning"):
+        # Reasoning tokens trigger TTFT (updated=True) but are not
+        # considered "content" for the TTFOT metric.
+        if reasoning := delta.get("reasoning"):
+            self.streaming_reasoning_texts.append(reasoning)
             updated = True
         if content := delta.get("content"):
             self.streaming_texts.append(content)
             updated = True
+            had_content = True
 
         # Accumulate streamed tool_calls deltas.  Each tool call may be split
         # across multiple chunks; we reassemble by ``index``.
@@ -828,10 +889,15 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         for tc_delta in delta.get("tool_calls") or []:
             self._accumulate_tool_call_delta(tc_delta)
             updated = True
+            had_content = True
 
         if usage:
             self.streaming_usage = usage
 
+        # Only update the flag when we processed a token-bearing iteration;
+        # non-updating lines should not reset the flag.
+        if updated:
+            self._last_iteration_had_content = had_content
         return 1 if updated else 0
 
     def _accumulate_tool_call_delta(self, tc_delta: dict[str, Any]) -> None:
@@ -879,6 +945,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
             self.streaming_usage,
             self.streaming_response_id,
             self.extract_metrics,
+            streaming_reasoning_texts=self.streaming_reasoning_texts,
         )
 
 
@@ -1023,6 +1090,16 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         # Accumulated function_call items keyed by output_index, used to
         # reconstruct tool_calls on GenerationResponse after streaming.
         self.streaming_tool_calls: dict[int, ToolCall] = {}
+        self.streaming_reasoning_texts: list[str] = []
+        self._last_iteration_had_content: bool = False
+
+    @property
+    def last_iteration_had_content(self) -> bool:
+        """
+        :return: True if the last streaming iteration produced content
+            (not reasoning-only)
+        """
+        return self._last_iteration_had_content
 
     @staticmethod
     def _ensure_tool_format(tool: dict[str, Any]) -> dict[str, Any]:
@@ -1075,12 +1152,17 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         data: GenerationRequest,
         response: GenerationResponse | None,
         prev_requests: list[GenerationRequestArguments],
+        *,
+        include_reasoning: bool = False,
     ) -> list[dict[str, Any]]:
         """Build the ``input`` array for the Responses API.
 
         The Responses API uses a flat ``input`` list of role-tagged message
         dicts (with nested content parts like ``input_text``, ``input_image``)
         instead of chat completions' ``messages`` array.
+
+        :param include_reasoning: When True, prepend reasoning text to
+            assistant content in the conversation history.
         """
         input_items: list[dict[str, Any]] = []
 
@@ -1124,7 +1206,10 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                     }
                 )
         elif response and response.text:
-            input_items.append({"role": "assistant", "content": response.text})
+            content = response.text
+            if include_reasoning and response.reasoning_text:
+                content = response.reasoning_text + content
+            input_items.append({"role": "assistant", "content": content})
 
         return input_items
 
@@ -1222,7 +1307,12 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         if prefix:
             arguments.body["instructions"] = prefix
 
-        arguments.body["input"] = self._build_input_items(data, response, prev_requests)
+        arguments.body["input"] = self._build_input_items(
+            data,
+            response,
+            prev_requests,
+            include_reasoning=kwargs.get("include_reasoning_in_history", False),
+        )
 
         # Server-side history: reference the previous response by ID and
         # include any tool outputs the server cannot know (tool execution
@@ -1236,6 +1326,25 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
 
         return arguments
 
+    @staticmethod
+    def _extract_reasoning_text(response: dict) -> str | None:
+        """Extract reasoning summary text from Responses API output items.
+
+        Reasoning items have ``type: "reasoning"`` with a list of ``summary``
+        objects, each containing a ``text`` field.
+
+        :param response: Full Responses API response dict.
+        :return: Concatenated reasoning text, or None if absent.
+        """
+        parts: list[str] = []
+        for item in response.get("output", []):
+            if item.get("type") != "reasoning":
+                continue
+            for summary in item.get("summary", []):
+                if txt := summary.get("text"):
+                    parts.append(txt)
+        return "".join(parts) or None
+
     def compile_non_streaming(
         self,
         request: GenerationRequest,
@@ -1243,6 +1352,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         response: dict,
     ) -> GenerationResponse:
         text = self._extract_output_text(response)
+        reasoning_text = self._extract_reasoning_text(response)
         raw_items = [
             item
             for item in response.get("output", [])
@@ -1266,6 +1376,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             request_args=arguments.model_dump_json(),
             response_id=response.get("id"),
             text=text,
+            reasoning_text=reasoning_text,
             tool_calls=tool_calls,
             input_metrics=input_metrics,
             output_metrics=output_metrics,
@@ -1282,6 +1393,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             self.streaming_usage,
             self.streaming_response_id,
             self.extract_metrics,
+            streaming_reasoning_texts=self.streaming_reasoning_texts,
         )
 
     def extract_line_data(self, line: str) -> dict[str, Any] | None:
@@ -1461,6 +1573,33 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         # Not a function-call event; let the caller handle it.
         return None
 
+    def _handle_streaming_text_delta(
+        self, event_type: str, data: dict[str, Any]
+    ) -> int | None:
+        """
+        Handle reasoning and output text delta events, updating
+        ``_last_iteration_had_content`` accordingly.
+
+        :return: 0 or 1 if handled, None if not a text delta event.
+        """
+        if event_type == "response.reasoning_summary_text.delta":
+            delta = data.get("delta", "")
+            if delta:
+                self.streaming_reasoning_texts.append(delta)
+                self._last_iteration_had_content = False
+                return 1
+            return 0
+
+        if event_type == "response.output_text.delta":
+            delta = data.get("delta", "")
+            if delta:
+                self.streaming_texts.append(delta)
+                self._last_iteration_had_content = True
+                return 1
+            return 0
+
+        return None
+
     def add_streaming_line(self, line: str) -> int | None:
         if not (data := self.extract_line_data(line)):
             return None if data is None else 0
@@ -1474,15 +1613,14 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             if isinstance(resp, dict) and "id" in resp:
                 self.streaming_response_id = resp["id"]
 
-        if event_type == "response.output_text.delta":
-            delta = data.get("delta", "")
-            if delta:
-                self.streaming_texts.append(delta)
-                return 1
-            return 0
+        text_result = self._handle_streaming_text_delta(event_type, data)
+        if text_result is not None:
+            return text_result
 
+        # Function call deltas are always treated as content for TTFOT
         fc_result = self._handle_streaming_function_call(event_type, data)
         if fc_result is not None:
+            self._last_iteration_had_content = True
             return fc_result
 
         if event_type in (

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -773,9 +773,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         if response and response.tool_calls:
             assistant_content = response.text
             if include_reasoning and response.reasoning_text:
-                assistant_content = (
-                    response.reasoning_text + (assistant_content or "")
-                )
+                assistant_content = response.reasoning_text + (assistant_content or "")
             arguments.body["messages"].append(
                 {
                     "role": "assistant",
@@ -789,13 +787,13 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
                     response.tool_calls, tool_response_columns
                 )
             )
-        elif response and response.text:
-            content = response.text
+        elif response and (
+            response.text or (include_reasoning and response.reasoning_text)
+        ):
+            content = response.text or ""
             if include_reasoning and response.reasoning_text:
                 content = response.reasoning_text + content
-            arguments.body["messages"].append(
-                {"role": "assistant", "content": content}
-            )
+            arguments.body["messages"].append({"role": "assistant", "content": content})
 
         # Inject tool definitions and apply tool-call-specific overrides.
         self._apply_tool_call_overrides(arguments.body, data)
@@ -1205,8 +1203,10 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                         "output": output_content,
                     }
                 )
-        elif response and response.text:
-            content = response.text
+        elif response and (
+            response.text or (include_reasoning and response.reasoning_text)
+        ):
+            content = response.text or ""
             if include_reasoning and response.reasoning_text:
                 content = response.reasoning_text + content
             input_items.append({"role": "assistant", "content": content})

--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -452,6 +452,11 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
                 name="ms",
             )
             columns.add_stats(
+                benchmark.metrics.time_to_first_output_token_ms,
+                group="TTFOT",
+                name="ms",
+            )
+            columns.add_stats(
                 benchmark.metrics.inter_token_latency_ms,
                 group="ITL",
                 name="ms",

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -419,6 +419,13 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
         self._add_stats_for_metric(
             headers,
             values,
+            benchmark.metrics.time_to_first_output_token_ms,
+            "Time to First Output Token",
+            "ms",
+        )
+        self._add_stats_for_metric(
+            headers,
+            values,
             benchmark.metrics.time_per_output_token_ms,
             "Time per Output Token",
             "ms",

--- a/src/guidellm/benchmark/schemas/generative/accumulator.py
+++ b/src/guidellm/benchmark/schemas/generative/accumulator.py
@@ -700,6 +700,7 @@ class GenerativeRequestsAccumulator(StandardBaseModel):
             stats.request_args = None
         if self.clear_nonsampled_outputs:
             stats.output = None
+            stats.reasoning_output = None
             stats.tool_calls = None
 
     @classmethod

--- a/src/guidellm/benchmark/schemas/generative/accumulator.py
+++ b/src/guidellm/benchmark/schemas/generative/accumulator.py
@@ -495,6 +495,10 @@ class GenerativeMetricsAccumulator(StandardBaseModel):
         default_factory=RunningMetricStats,
         description="Accumulated time to first token statistics in milliseconds",
     )
+    time_to_first_output_token_ms: RunningMetricStats = Field(
+        default_factory=RunningMetricStats,
+        description="Accumulated time to first content token stats in ms",
+    )
     time_per_output_token_ms: RunningMetricStats = Field(
         default_factory=RunningMetricStats,
         description="Accumulated time per output token statistics in milliseconds",
@@ -534,6 +538,9 @@ class GenerativeMetricsAccumulator(StandardBaseModel):
         self.request_latency.update_estimate(stats.request_latency, duration=duration)
         self.time_to_first_token_ms.update_estimate(
             stats.time_to_first_token_ms, duration=duration
+        )
+        self.time_to_first_output_token_ms.update_estimate(
+            stats.time_to_first_output_token_ms, duration=duration
         )
         self.time_per_output_token_ms.update_estimate(
             stats.time_per_output_token_ms,

--- a/src/guidellm/benchmark/schemas/generative/metrics.py
+++ b/src/guidellm/benchmark/schemas/generative/metrics.py
@@ -802,6 +802,12 @@ class GenerativeMetrics(StandardBaseDict):
     time_to_first_token_ms: StatusDistributionSummary = Field(
         description="Distribution of first token latencies in milliseconds"
     )
+    time_to_first_output_token_ms: StatusDistributionSummary = Field(
+        description=(
+            "Distribution of first content (non-reasoning) token latencies "
+            "in milliseconds"
+        )
+    )
     time_per_output_token_ms: StatusDistributionSummary = Field(
         description="Distribution of average time per output token in milliseconds"
     )
@@ -928,6 +934,12 @@ class GenerativeMetrics(StandardBaseDict):
             ),
             time_to_first_token_ms=StatusDistributionSummary.from_values_function(
                 function=lambda req: req.time_to_first_token_ms or 0.0,
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+            time_to_first_output_token_ms=StatusDistributionSummary.from_values_function(
+                function=lambda req: req.time_to_first_output_token_ms or 0.0,
                 successful=successful,
                 incomplete=incomplete,
                 errored=errored,

--- a/src/guidellm/schemas/info.py
+++ b/src/guidellm/schemas/info.py
@@ -59,6 +59,13 @@ class RequestTimings(StandardBaseDict):
     first_token_iteration: float | None = Field(
         default=None,
     )
+    first_output_token_iteration: float | None = Field(
+        default=None,
+        description=(
+            "Unix timestamp of the first non-reasoning content token. "
+            "Equals first_token_iteration when no reasoning tokens are emitted."
+        ),
+    )
     last_token_iteration: float | None = Field(
         default=None,
     )

--- a/src/guidellm/schemas/request_stats.py
+++ b/src/guidellm/schemas/request_stats.py
@@ -54,6 +54,10 @@ class GenerativeRequestStats(StandardBaseDict):
     output: str | None = Field(
         default=None, description="Generated text output from the request"
     )
+    reasoning_output: str | None = Field(
+        default=None,
+        description="Reasoning/chain-of-thought text emitted before content",
+    )
     tool_calls: list[ToolCall] | None = Field(
         default=None,
         description="Raw tool call payloads from the model response in OpenAI format",

--- a/src/guidellm/schemas/request_stats.py
+++ b/src/guidellm/schemas/request_stats.py
@@ -224,6 +224,23 @@ class GenerativeRequestStats(StandardBaseDict):
 
     @computed_field  # type: ignore[misc]
     @property
+    def time_to_first_output_token_ms(self) -> float | None:
+        """
+        Time to first content (non-reasoning) token in milliseconds.
+
+        When no reasoning tokens are emitted this equals TTFT.
+
+        :return: Milliseconds from request start to first content token,
+            or None if unavailable
+        """
+        first_output = self.info.timings.first_output_token_iteration
+        start = self.info.timings.request_start
+        if first_output is None or start is None:
+            return None
+        return 1000 * (first_output - start)
+
+    @computed_field  # type: ignore[misc]
+    @property
     def iter_tokens_per_iteration(self) -> float | None:
         """
         :return: Average tokens per iteration excluding first token, or None if

--- a/src/guidellm/schemas/response.py
+++ b/src/guidellm/schemas/response.py
@@ -57,6 +57,13 @@ class GenerationResponse(StandardBaseModel):
         default=None,
         description="The generated response text.",
     )
+    reasoning_text: str | None = Field(
+        default=None,
+        description=(
+            "Reasoning/chain-of-thought text emitted before the content. "
+            "Not included in multi-turn history unless explicitly enabled."
+        ),
+    )
     tool_calls: list[ToolCall] | None = Field(
         default=None,
         description=(

--- a/src/guidellm/schemas/response.py
+++ b/src/guidellm/schemas/response.py
@@ -148,6 +148,7 @@ class GenerationResponse(StandardBaseModel):
             response_id=self.response_id,
             request_args=self.request_args,
             output=self.text,
+            reasoning_output=self.reasoning_text,
             tool_calls=self.tool_calls,
             info=info,
             input_metrics=UsageMetrics(**input_metrics_dict),

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -1090,7 +1090,7 @@ class TestChatCompletionsRequestHandler:
     @pytest.mark.sanity
     def test_format_excludes_reasoning_from_history_by_default(self, valid_instances):
         """
-        By default (include_reasoning_in_history=False), reasoning_text
+        By default (multiturn_reasoning=False), reasoning_text
         should not appear in the assistant message content.
 
         ## WRITTEN BY AI ##
@@ -1126,7 +1126,7 @@ class TestChatCompletionsRequestHandler:
     @pytest.mark.sanity
     def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
-        When include_reasoning_in_history=True, reasoning_text should
+        When multiturn_reasoning=True, reasoning_text should
         be prepended to the assistant message content.
 
         ## WRITTEN BY AI ##
@@ -1149,7 +1149,7 @@ class TestChatCompletionsRequestHandler:
         result = instance.format(
             data,
             history=[(prev_request, prev_response)],
-            include_reasoning_in_history=True,
+            multiturn_reasoning=True,
         )
 
         assistant_msgs = [
@@ -1161,7 +1161,7 @@ class TestChatCompletionsRequestHandler:
     @pytest.mark.sanity
     def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
         """
-        When include_reasoning_in_history=True and the prior response has
+        When multiturn_reasoning=True and the prior response has
         reasoning_text but no regular text content, an assistant message
         should still be injected containing the reasoning.
 
@@ -1185,7 +1185,7 @@ class TestChatCompletionsRequestHandler:
         result = instance.format(
             data,
             history=[(prev_request, prev_response)],
-            include_reasoning_in_history=True,
+            multiturn_reasoning=True,
         )
 
         assistant_msgs = [
@@ -1199,7 +1199,7 @@ class TestChatCompletionsRequestHandler:
         self, valid_instances
     ):
         """
-        When include_reasoning_in_history=False (default) and the prior
+        When multiturn_reasoning=False (default) and the prior
         response has reasoning_text but no regular text content, no
         assistant message should be injected.
 
@@ -3069,7 +3069,7 @@ class TestResponsesRequestHandler:
     @pytest.mark.sanity
     def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
-        When include_reasoning_in_history=True, reasoning_text should be
+        When multiturn_reasoning=True, reasoning_text should be
         prepended to the assistant input item content.
 
         ## WRITTEN BY AI ##
@@ -3089,7 +3089,7 @@ class TestResponsesRequestHandler:
         result = instance.format(
             data,
             history=[(prev_request, prev_response)],
-            include_reasoning_in_history=True,
+            multiturn_reasoning=True,
         )
 
         assistant_items = [
@@ -3101,7 +3101,7 @@ class TestResponsesRequestHandler:
     @pytest.mark.sanity
     def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
         """
-        When include_reasoning_in_history=True and the prior response has
+        When multiturn_reasoning=True and the prior response has
         reasoning_text but no regular text content, an assistant input item
         should still be injected containing the reasoning.
 
@@ -3122,7 +3122,7 @@ class TestResponsesRequestHandler:
         result = instance.format(
             data,
             history=[(prev_request, prev_response)],
-            include_reasoning_in_history=True,
+            multiturn_reasoning=True,
         )
 
         assistant_items = [
@@ -3136,7 +3136,7 @@ class TestResponsesRequestHandler:
         self, valid_instances
     ):
         """
-        When include_reasoning_in_history=False (default) and the prior
+        When multiturn_reasoning=False (default) and the prior
         response has reasoning_text but no regular text content, no
         assistant input item should be injected.
 

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -1127,7 +1127,7 @@ class TestChatCompletionsRequestHandler:
     def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
         When multiturn_reasoning=True, reasoning_text should
-        be prepended to the assistant message content.
+        be wrapped in <think> tags and prepended to the assistant message content.
 
         ## WRITTEN BY AI ##
         """
@@ -1156,7 +1156,7 @@ class TestChatCompletionsRequestHandler:
             m for m in result.body["messages"] if m.get("role") == "assistant"
         ]
         assert len(assistant_msgs) == 1
-        assert assistant_msgs[0]["content"] == "Let me add 2 and 2.4"
+        assert assistant_msgs[0]["content"] == "<think>Let me add 2 and 2.</think>4"
 
     @pytest.mark.sanity
     def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
@@ -1192,7 +1192,10 @@ class TestChatCompletionsRequestHandler:
             m for m in result.body["messages"] if m.get("role") == "assistant"
         ]
         assert len(assistant_msgs) == 1
-        assert assistant_msgs[0]["content"] == "Let me think about this carefully."
+        assert (
+            assistant_msgs[0]["content"]
+            == "<think>Let me think about this carefully.</think>"
+        )
 
     @pytest.mark.sanity
     def test_format_drops_reasoning_only_response_from_history_by_default(
@@ -1229,6 +1232,78 @@ class TestChatCompletionsRequestHandler:
             m for m in result.body["messages"] if m.get("role") == "assistant"
         ]
         assert len(assistant_msgs) == 0
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_with_custom_template(self, valid_instances):
+        """
+        When multiturn_reasoning is a custom format string, reasoning_text
+        should be wrapped using that template.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="4",
+            reasoning_text="Let me add 2 and 2.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        template = "Here is my thought process:{reasoning}Here is my response:"
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            multiturn_reasoning=template,
+        )
+
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 1
+        expected = "Here is my thought process:Let me add 2 and 2.Here is my response:4"
+        assert assistant_msgs[0]["content"] == expected
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_raw_template(self, valid_instances):
+        """
+        When multiturn_reasoning='{reasoning}', reasoning_text should be
+        prepended with no extra delimiters (raw mode).
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="4",
+            reasoning_text="Let me add 2 and 2.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            multiturn_reasoning="{reasoning}",
+        )
+
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == "Let me add 2 and 2.4"
 
     @pytest.mark.sanity
     def test_last_iteration_had_content_reasoning_then_content(
@@ -3070,7 +3145,7 @@ class TestResponsesRequestHandler:
     def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
         When multiturn_reasoning=True, reasoning_text should be
-        prepended to the assistant input item content.
+        wrapped in <think> tags and prepended to the assistant input item content.
 
         ## WRITTEN BY AI ##
         """
@@ -3096,7 +3171,9 @@ class TestResponsesRequestHandler:
             item for item in result.body["input"] if item.get("role") == "assistant"
         ]
         assert len(assistant_items) == 1
-        assert assistant_items[0]["content"] == "Think about greeting.World"
+        assert (
+            assistant_items[0]["content"] == "<think>Think about greeting.</think>World"
+        )
 
     @pytest.mark.sanity
     def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
@@ -3129,7 +3206,7 @@ class TestResponsesRequestHandler:
             item for item in result.body["input"] if item.get("role") == "assistant"
         ]
         assert len(assistant_items) == 1
-        assert assistant_items[0]["content"] == "Think about greeting."
+        assert assistant_items[0]["content"] == "<think>Think about greeting.</think>"
 
     @pytest.mark.sanity
     def test_format_drops_reasoning_only_response_from_history_by_default(
@@ -3163,6 +3240,74 @@ class TestResponsesRequestHandler:
             item for item in result.body["input"] if item.get("role") == "assistant"
         ]
         assert len(assistant_items) == 0
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_with_custom_template(self, valid_instances):
+        """
+        When multiturn_reasoning is a custom format string, reasoning_text
+        should be wrapped using that template in the Responses API input.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="World",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        template = "Here is my thought process:{reasoning}Here is my response:"
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            multiturn_reasoning=template,
+        )
+
+        assistant_items = [
+            item for item in result.body["input"] if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 1
+        expected = (
+            "Here is my thought process:Think about greeting.Here is my response:World"
+        )
+        assert assistant_items[0]["content"] == expected
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_raw_template(self, valid_instances):
+        """
+        When multiturn_reasoning='{reasoning}', reasoning_text should be
+        prepended with no extra delimiters (raw mode) in the Responses API input.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="World",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            multiturn_reasoning="{reasoning}",
+        )
+
+        assistant_items = [
+            item for item in result.body["input"] if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 1
+        assert assistant_items[0]["content"] == "Think about greeting.World"
 
     @pytest.mark.sanity
     def test_format_with_history(self, valid_instances):
@@ -4585,6 +4730,7 @@ class TestChatCompletionsToolResponseColumn:
             )
         ]
         prior_response.text = None
+        prior_response.reasoning_text = None
 
         current_request = GenerationRequest(
             columns={"text_column": ["now respond"]},
@@ -4631,6 +4777,7 @@ class TestChatCompletionsToolResponseColumn:
             )
         ]
         prior_response.text = None
+        prior_response.reasoning_text = None
 
         current_request = GenerationRequest(
             columns={"text_column": ["now respond"]},
@@ -4677,6 +4824,7 @@ class TestChatCompletionsToolResponseColumn:
             )
         ]
         prior_response.text = None
+        prior_response.reasoning_text = None
 
         current_request = GenerationRequest(
             columns={"text_column": ["now respond"]},

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -1029,6 +1029,188 @@ class TestChatCompletionsRequestHandler:
         assert "Let me think..." not in response.text
         assert response.text == "Answer: 42"
 
+    @pytest.mark.sanity
+    def test_streaming_captures_reasoning_text(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify reasoning text is accumulated on response.reasoning_text
+        during streaming, separate from response.text.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            'data: {"choices": [{"delta": {"reasoning": "Step 1. "}}], "usage": {}}',
+            'data: {"choices": [{"delta": {"reasoning": "Step 2."}}], "usage": {}}',
+            'data: {"choices": [{"delta": {"content": "Final answer"}}], "usage": {}}',
+            "data: [DONE]",
+        ]
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+        assert response.text == "Final answer"
+        assert response.reasoning_text == "Step 1. Step 2."
+
+    @pytest.mark.sanity
+    def test_non_streaming_captures_reasoning_text(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify compile_non_streaming extracts reasoning from the message.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        api_response = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "reasoning": "Let me think step by step.",
+                        "content": "The answer is 42.",
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 15},
+        }
+        response = instance.compile_non_streaming(
+            generation_request, arguments, api_response
+        )
+        assert response.text == "The answer is 42."
+        assert response.reasoning_text == "Let me think step by step."
+
+    @pytest.mark.sanity
+    def test_format_excludes_reasoning_from_history_by_default(
+        self, valid_instances
+    ):
+        """
+        By default (include_reasoning_in_history=False), reasoning_text
+        should not appear in the assistant message content.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="4",
+            reasoning_text="Let me add 2 and 2.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+        )
+
+        # Find the assistant message in the history
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == "4"
+        assert "Let me add" not in assistant_msgs[0]["content"]
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_in_history_when_enabled(
+        self, valid_instances
+    ):
+        """
+        When include_reasoning_in_history=True, reasoning_text should
+        be prepended to the assistant message content.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="4",
+            reasoning_text="Let me add 2 and 2.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            include_reasoning_in_history=True,
+        )
+
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == "Let me add 2 and 2.4"
+
+    @pytest.mark.sanity
+    def test_last_iteration_had_content_reasoning_then_content(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify last_iteration_had_content tracks content vs reasoning deltas.
+
+        Reasoning-only iterations set the flag to False; content sets it True.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        instance.format(generation_request)
+
+        # Initial state before any streaming
+        assert instance.last_iteration_had_content is False
+
+        # Reasoning-only delta
+        instance.add_streaming_line(
+            'data: {"choices": [{"delta": {"reasoning": "thinking..."}}], "usage": {}}'
+        )
+        assert instance.last_iteration_had_content is False
+
+        # Content delta
+        instance.add_streaming_line(
+            'data: {"choices": [{"delta": {"content": "Hello"}}], "usage": {}}'
+        )
+        assert instance.last_iteration_had_content is True
+
+    @pytest.mark.sanity
+    def test_last_iteration_had_content_tool_call(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify tool call deltas set last_iteration_had_content to True.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        instance.format(generation_request)
+
+        tc_line = (
+            'data: {"choices": [{"delta": {"tool_calls": '
+            '[{"index": 0, "id": "call_1", "type": "function", '
+            '"function": {"name": "foo", "arguments": ""}}]}}], "usage": {}}'
+        )
+        instance.add_streaming_line(tc_line)
+        assert instance.last_iteration_had_content is True
+
     # Tool call response handling tests
 
     @pytest.mark.sanity
@@ -2661,6 +2843,202 @@ class TestResponsesRequestHandler:
         assert response.text == expected_text
         assert response.input_metrics.text_tokens == expected_input_tokens
         assert response.output_metrics.text_tokens == expected_output_tokens
+
+    @pytest.mark.sanity
+    def test_streaming_reasoning_triggers_ttft_not_content(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify Responses API reasoning events trigger TTFT (return 1)
+        but set last_iteration_had_content to False, matching Chat
+        Completions parity for TTFOT measurement.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        instance.format(generation_request)
+
+        assert instance.last_iteration_had_content is False
+
+        # Reasoning summary delta -- should return 1 (TTFT) but not content
+        result = instance.add_streaming_line(
+            'data: {"type": "response.reasoning_summary_text.delta", '
+            '"delta": "Let me think..."}'
+        )
+        assert result == 1
+        assert instance.last_iteration_had_content is False
+
+        # Output text delta -- now content flag flips to True
+        result = instance.add_streaming_line(
+            'data: {"type": "response.output_text.delta", "delta": "Hello"}'
+        )
+        assert result == 1
+        assert instance.last_iteration_had_content is True
+
+    @pytest.mark.sanity
+    def test_streaming_reasoning_only_leaves_content_false(
+        self, valid_instances, generation_request
+    ):
+        """
+        If a Responses API stream emits only reasoning before completing,
+        last_iteration_had_content stays False.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        instance.format(generation_request)
+
+        instance.add_streaming_line(
+            'data: {"type": "response.reasoning_summary_text.delta", '
+            '"delta": "thinking..."}'
+        )
+        instance.add_streaming_line(
+            'data: {"type": "response.reasoning_summary_text.delta", '
+            '"delta": " more thinking"}'
+        )
+        assert instance.last_iteration_had_content is False
+
+        # Stream completes
+        instance.add_streaming_line(
+            'data: {"type": "response.completed", "response": '
+            '{"id": "resp_1", "usage": {"input_tokens": 5, "output_tokens": 0}}}'
+        )
+        assert instance.last_iteration_had_content is False
+
+    @pytest.mark.sanity
+    def test_streaming_captures_reasoning_text(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify Responses API streaming accumulates reasoning_text on the
+        compiled response.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        lines = [
+            'data: {"type": "response.reasoning_summary_text.delta", '
+            '"delta": "First, "}',
+            'data: {"type": "response.reasoning_summary_text.delta", '
+            '"delta": "consider..."}',
+            'data: {"type": "response.output_text.delta", "delta": "Answer"}',
+            'data: {"type": "response.completed", "response": '
+            '{"id": "resp_1", "usage": {"input_tokens": 5, "output_tokens": 3}}}',
+        ]
+        for line in lines:
+            result = instance.add_streaming_line(line)
+            if result is None:
+                break
+
+        response = instance.compile_streaming(generation_request, arguments)
+        assert response.text == "Answer"
+        assert response.reasoning_text == "First, consider..."
+
+    @pytest.mark.sanity
+    def test_non_streaming_captures_reasoning_text(
+        self, valid_instances, generation_request
+    ):
+        """
+        Verify compile_non_streaming extracts reasoning from Responses API
+        output items with type 'reasoning'.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        arguments = instance.format(generation_request)
+
+        api_response = {
+            "id": "resp_1",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"text": "Step 1. "}, {"text": "Step 2."}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Final answer"}],
+                },
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        response = instance.compile_non_streaming(
+            generation_request, arguments, api_response
+        )
+        assert response.text == "Final answer"
+        assert response.reasoning_text == "Step 1. Step 2."
+
+    @pytest.mark.sanity
+    def test_format_excludes_reasoning_from_history_by_default(
+        self, valid_instances
+    ):
+        """
+        By default, reasoning_text should not appear in the assistant
+        input item content.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="World",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        result = instance.format(
+            data, history=[(prev_request, prev_response)]
+        )
+
+        assistant_items = [
+            item
+            for item in result.body["input"]
+            if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 1
+        assert assistant_items[0]["content"] == "World"
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_in_history_when_enabled(
+        self, valid_instances
+    ):
+        """
+        When include_reasoning_in_history=True, reasoning_text should be
+        prepended to the assistant input item content.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="World",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            include_reasoning_in_history=True,
+        )
+
+        assistant_items = [
+            item
+            for item in result.body["input"]
+            if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 1
+        assert assistant_items[0]["content"] == "Think about greeting.World"
 
     @pytest.mark.sanity
     def test_format_with_history(self, valid_instances):

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -1088,9 +1088,7 @@ class TestChatCompletionsRequestHandler:
         assert response.reasoning_text == "Let me think step by step."
 
     @pytest.mark.sanity
-    def test_format_excludes_reasoning_from_history_by_default(
-        self, valid_instances
-    ):
+    def test_format_excludes_reasoning_from_history_by_default(self, valid_instances):
         """
         By default (include_reasoning_in_history=False), reasoning_text
         should not appear in the assistant message content.
@@ -1126,9 +1124,7 @@ class TestChatCompletionsRequestHandler:
         assert "Let me add" not in assistant_msgs[0]["content"]
 
     @pytest.mark.sanity
-    def test_format_includes_reasoning_in_history_when_enabled(
-        self, valid_instances
-    ):
+    def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
         When include_reasoning_in_history=True, reasoning_text should
         be prepended to the assistant message content.
@@ -1161,6 +1157,78 @@ class TestChatCompletionsRequestHandler:
         ]
         assert len(assistant_msgs) == 1
         assert assistant_msgs[0]["content"] == "Let me add 2 and 2.4"
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
+        """
+        When include_reasoning_in_history=True and the prior response has
+        reasoning_text but no regular text content, an assistant message
+        should still be injected containing the reasoning.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="",
+            reasoning_text="Let me think about this carefully.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            include_reasoning_in_history=True,
+        )
+
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0]["content"] == "Let me think about this carefully."
+
+    @pytest.mark.sanity
+    def test_format_drops_reasoning_only_response_from_history_by_default(
+        self, valid_instances
+    ):
+        """
+        When include_reasoning_in_history=False (default) and the prior
+        response has reasoning_text but no regular text content, no
+        assistant message should be injected.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["What is 2+2?"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="",
+            reasoning_text="Let me think about this carefully.",
+        )
+
+        data = GenerationRequest(
+            columns={"text_column": ["What is 3+3?"]},
+        )
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+        )
+
+        assistant_msgs = [
+            m for m in result.body["messages"] if m.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) == 0
 
     @pytest.mark.sanity
     def test_last_iteration_had_content_reasoning_then_content(
@@ -2971,9 +3039,7 @@ class TestResponsesRequestHandler:
         assert response.reasoning_text == "Step 1. Step 2."
 
     @pytest.mark.sanity
-    def test_format_excludes_reasoning_from_history_by_default(
-        self, valid_instances
-    ):
+    def test_format_excludes_reasoning_from_history_by_default(self, valid_instances):
         """
         By default, reasoning_text should not appear in the assistant
         input item content.
@@ -2992,22 +3058,16 @@ class TestResponsesRequestHandler:
             reasoning_text="Think about greeting.",
         )
         data = GenerationRequest(columns={"text_column": ["Follow up"]})
-        result = instance.format(
-            data, history=[(prev_request, prev_response)]
-        )
+        result = instance.format(data, history=[(prev_request, prev_response)])
 
         assistant_items = [
-            item
-            for item in result.body["input"]
-            if item.get("role") == "assistant"
+            item for item in result.body["input"] if item.get("role") == "assistant"
         ]
         assert len(assistant_items) == 1
         assert assistant_items[0]["content"] == "World"
 
     @pytest.mark.sanity
-    def test_format_includes_reasoning_in_history_when_enabled(
-        self, valid_instances
-    ):
+    def test_format_includes_reasoning_in_history_when_enabled(self, valid_instances):
         """
         When include_reasoning_in_history=True, reasoning_text should be
         prepended to the assistant input item content.
@@ -3033,12 +3093,76 @@ class TestResponsesRequestHandler:
         )
 
         assistant_items = [
-            item
-            for item in result.body["input"]
-            if item.get("role") == "assistant"
+            item for item in result.body["input"] if item.get("role") == "assistant"
         ]
         assert len(assistant_items) == 1
         assert assistant_items[0]["content"] == "Think about greeting.World"
+
+    @pytest.mark.sanity
+    def test_format_includes_reasoning_only_response_in_history(self, valid_instances):
+        """
+        When include_reasoning_in_history=True and the prior response has
+        reasoning_text but no regular text content, an assistant input item
+        should still be injected containing the reasoning.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+            include_reasoning_in_history=True,
+        )
+
+        assistant_items = [
+            item for item in result.body["input"] if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 1
+        assert assistant_items[0]["content"] == "Think about greeting."
+
+    @pytest.mark.sanity
+    def test_format_drops_reasoning_only_response_from_history_by_default(
+        self, valid_instances
+    ):
+        """
+        When include_reasoning_in_history=False (default) and the prior
+        response has reasoning_text but no regular text content, no
+        assistant input item should be injected.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+
+        prev_request = GenerationRequest(
+            columns={"text_column": ["Hello"]},
+        )
+        prev_response = GenerationResponse(
+            request_id="prev",
+            request_args=None,
+            text="",
+            reasoning_text="Think about greeting.",
+        )
+        data = GenerationRequest(columns={"text_column": ["Follow up"]})
+        result = instance.format(
+            data,
+            history=[(prev_request, prev_response)],
+        )
+
+        assistant_items = [
+            item for item in result.body["input"] if item.get("role") == "assistant"
+        ]
+        assert len(assistant_items) == 0
 
     @pytest.mark.sanity
     def test_format_with_history(self, valid_instances):

--- a/tests/unit/benchmark/schemas/generative/test_accumulator.py
+++ b/tests/unit/benchmark/schemas/generative/test_accumulator.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+from guidellm.benchmark.schemas.generative.accumulator import (
+    GenerativeRequestsAccumulator,
+)
+from guidellm.schemas import GenerativeRequestStats, RequestInfo, UsageMetrics
+
+
+def _make_stats(
+    request_id: str = "req-1",
+    output: str | None = "some output",
+    reasoning_output: str | None = None,
+    request_args: str | None = "args",
+) -> GenerativeRequestStats:
+    """Build a minimal GenerativeRequestStats for testing."""
+    info = RequestInfo(request_id=request_id, status="completed")
+    info.timings.request_start = 0.0
+    info.timings.request_end = 1.0
+    info.timings.resolve_end = 1.0
+    return GenerativeRequestStats(
+        request_id=request_id,
+        request_args=request_args,
+        output=output,
+        reasoning_output=reasoning_output,
+        info=info,
+        input_metrics=UsageMetrics(text_tokens=5),
+        output_metrics=UsageMetrics(text_tokens=10),
+    )
+
+
+class TestClearStatsData:
+    """
+    Tests for GenerativeRequestsAccumulator.clear_stats_data.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.smoke
+    def test_clears_output_and_reasoning_output(self):
+        """
+        clear_stats_data clears output, reasoning_output, and tool_calls
+        when clear_nonsampled_outputs is True.
+
+        ## WRITTEN BY AI ##
+        """
+        acc = GenerativeRequestsAccumulator(
+            clear_nonsampled_outputs=True,
+            clear_nonsampled_request_args=False,
+        )
+        stats = _make_stats(
+            output="answer",
+            reasoning_output="thinking...",
+            request_args="args",
+        )
+
+        acc.clear_stats_data(stats)
+
+        assert stats.output is None
+        assert stats.reasoning_output is None
+        assert stats.tool_calls is None
+        assert stats.request_args == "args"
+
+    @pytest.mark.smoke
+    def test_clears_request_args(self):
+        """
+        clear_stats_data clears request_args when
+        clear_nonsampled_request_args is True.
+
+        ## WRITTEN BY AI ##
+        """
+        acc = GenerativeRequestsAccumulator(
+            clear_nonsampled_outputs=False,
+            clear_nonsampled_request_args=True,
+        )
+        stats = _make_stats(
+            output="answer",
+            reasoning_output="thinking...",
+            request_args="args",
+        )
+
+        acc.clear_stats_data(stats)
+
+        assert stats.request_args is None
+        assert stats.output == "answer"
+        assert stats.reasoning_output == "thinking..."
+
+    @pytest.mark.smoke
+    def test_clears_both(self):
+        """
+        clear_stats_data clears all fields when both flags are True.
+
+        ## WRITTEN BY AI ##
+        """
+        acc = GenerativeRequestsAccumulator(
+            clear_nonsampled_outputs=True,
+            clear_nonsampled_request_args=True,
+        )
+        stats = _make_stats(
+            output="answer",
+            reasoning_output="thinking...",
+            request_args="args",
+        )
+
+        acc.clear_stats_data(stats)
+
+        assert stats.request_args is None
+        assert stats.output is None
+        assert stats.reasoning_output is None
+        assert stats.tool_calls is None
+
+    @pytest.mark.smoke
+    def test_clears_by_index(self):
+        """
+        clear_stats_data accepts an integer index to look up the stats
+        in requests_stats.
+
+        ## WRITTEN BY AI ##
+        """
+        acc = GenerativeRequestsAccumulator(
+            clear_nonsampled_outputs=True,
+            clear_nonsampled_request_args=True,
+        )
+        stats = _make_stats(reasoning_output="step 1")
+        acc.requests_stats.append(stats)
+
+        acc.clear_stats_data(0)
+
+        assert stats.output is None
+        assert stats.reasoning_output is None
+        assert stats.request_args is None
+
+    @pytest.mark.smoke
+    def test_preserves_when_both_flags_false(self):
+        """
+        clear_stats_data preserves all fields when both flags are False.
+
+        ## WRITTEN BY AI ##
+        """
+        acc = GenerativeRequestsAccumulator(
+            clear_nonsampled_outputs=False,
+            clear_nonsampled_request_args=False,
+        )
+        stats = _make_stats(
+            output="answer",
+            reasoning_output="thinking...",
+            request_args="args",
+        )
+
+        acc.clear_stats_data(stats)
+
+        assert stats.request_args == "args"
+        assert stats.output == "answer"
+        assert stats.reasoning_output == "thinking..."

--- a/tests/unit/schemas/test_request_stats.py
+++ b/tests/unit/schemas/test_request_stats.py
@@ -647,6 +647,82 @@ class TestGenerativeRequestStats:
         assert stats.output_tokens_per_second is None
 
     @pytest.mark.sanity
+    def test_time_to_first_output_token_ms_with_reasoning(self):
+        """
+        TTFOT should use first_output_token_iteration, which differs
+        from first_token_iteration when reasoning precedes content.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="ttfot", status="completed")
+        info.timings.request_start = 100.0
+        info.timings.first_token_iteration = 100.2  # reasoning at +200ms
+        info.timings.first_output_token_iteration = 100.5  # content at +500ms
+        info.timings.last_token_iteration = 101.0
+        info.timings.request_end = 101.0
+        info.timings.resolve_end = 101.0
+
+        stats = GenerativeRequestStats(
+            request_id="ttfot",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=10),
+            output_metrics=UsageMetrics(text_tokens=20),
+        )
+
+        # TTFT is from request_start to first_token_iteration
+        assert stats.time_to_first_token_ms == pytest.approx(200.0, abs=0.1)
+        # TTFOT is from request_start to first_output_token_iteration
+        assert stats.time_to_first_output_token_ms == pytest.approx(500.0, abs=0.1)
+
+    @pytest.mark.sanity
+    def test_time_to_first_output_token_ms_no_reasoning(self):
+        """
+        When no reasoning tokens are emitted, first_output_token_iteration
+        equals first_token_iteration and TTFOT == TTFT.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="ttfot-noreason", status="completed")
+        info.timings.request_start = 0.0
+        info.timings.first_token_iteration = 0.15
+        info.timings.first_output_token_iteration = 0.15
+        info.timings.last_token_iteration = 1.0
+        info.timings.request_end = 1.0
+        info.timings.resolve_end = 1.0
+
+        stats = GenerativeRequestStats(
+            request_id="ttfot-noreason",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=5),
+            output_metrics=UsageMetrics(text_tokens=10),
+        )
+
+        assert stats.time_to_first_output_token_ms == pytest.approx(
+            stats.time_to_first_token_ms, abs=0.01
+        )
+
+    @pytest.mark.smoke
+    def test_time_to_first_output_token_ms_none(self):
+        """
+        TTFOT is None when first_output_token_iteration is not set.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="ttfot-none", status="completed")
+        info.timings.request_start = 0.0
+        info.timings.request_end = 1.0
+        info.timings.resolve_end = 1.0
+
+        stats = GenerativeRequestStats(
+            request_id="ttfot-none",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=5),
+            output_metrics=UsageMetrics(text_tokens=10),
+        )
+
+        assert stats.time_to_first_output_token_ms is None
+
+    @pytest.mark.sanity
     @pytest.mark.asyncio
     @async_timeout(0.2)  # ensure no accidental indefinite waits if expanded later
     async def test_async_context_usage(self, valid_instances):

--- a/tests/unit/schemas/test_response.py
+++ b/tests/unit/schemas/test_response.py
@@ -328,6 +328,46 @@ class TestGenerationResponse:
         stats = response.compile_stats(request, info)
         assert stats.tool_calls is None
 
+    @pytest.mark.smoke
+    def test_compile_stats_persists_reasoning_text(self):
+        """
+        compile_stats carries reasoning_text to reasoning_output on stats.
+
+        ## WRITTEN BY AI ##
+        """
+        response = GenerationResponse(
+            request_id="test-reason",
+            request_args=None,
+            text="Answer is 42",
+            reasoning_text="Let me think step by step.",
+        )
+        request = GenerationRequest(request_id="test-reason")
+        info = RequestInfo(request_id="test-reason", status="completed")
+
+        stats = response.compile_stats(request, info)
+        assert stats.output == "Answer is 42"
+        assert stats.reasoning_output == "Let me think step by step."
+
+    @pytest.mark.smoke
+    def test_compile_stats_reasoning_output_none_when_absent(self):
+        """
+        compile_stats leaves reasoning_output as None when no reasoning
+        was emitted.
+
+        ## WRITTEN BY AI ##
+        """
+        response = GenerationResponse(
+            request_id="test-no-reason",
+            request_args=None,
+            text="Plain answer",
+        )
+        request = GenerationRequest(request_id="test-no-reason")
+        info = RequestInfo(request_id="test-no-reason", status="completed")
+
+        stats = response.compile_stats(request, info)
+        assert stats.output == "Plain answer"
+        assert stats.reasoning_output is None
+
     @pytest.mark.sanity
     def test_compile_stats_mismatched_request_id(self):
         """Test compile_stats with mismatched request IDs."""


### PR DESCRIPTION
## Summary

Adds time to first output token (TTFOT), and fixes TTFT when reasoning is included for the responses API.

## Details

- Uses TTFOT as that's industry standard. I can see arguments for and against that terminology.
- Updates the logic used in the responses API to properly track TTFT for the responses API.
- Adds a setting to include the reasoning in the history. I have not verified that its design is perfect for that. I don't expect perfect KVCache hits with that setting because it's returning output that was already processed by a reasoning parser, changing it. This setting is off by default.
- Note that if a reasoning parser isn't set in vLLM, it won't send chunks labeled as reasoning, and will instead just send raw thinking tokens, which will be processed as normal content.

## Test Plan

- Run a model with reasoning only
- Run a model with a zero token reasoning limit, as well as a non-zero reasoning limit. Observe how the TTFOT compares to the TTFT.
- Test reasoning on both chat completions and responses API.

## Related Issues

Related to #742 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- begin:squash-data -->

---

# git log

commit 14a0cbf8b204a67e10ac332661603d9ccfab0fb0
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Fri May 29 18:47:58 2026 -0400

    Add TTFOT and store reasoning tokens.
    
    Generated-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 54719febb3f27c63c2afb63c8676a21ab0c20f66
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Fri May 29 19:27:04 2026 -0400

    Fixed output behavior for reasoning tokens
    
    Also added tests
    
    Generated-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit a9bd3443cbd7e4d416171354edb786c1c7a20ba9
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Tue Jun 2 15:26:11 2026 -0400

    Address review comments
    
    Assisted-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit dd1918db44645145212fb7f58f16020fa558afd1
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Jun 3 00:31:02 2026 -0400

    Switch to template system to allow wrapping reasoning tokens
    
    Assisted-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Assisted-by: Cursor AI Claude Opus 4.6
Generated-by: Cursor AI Claude Opus 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
