### PR TITLE
Implement a Squash Commit PR Workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,3 +37,7 @@ Link any relevant issues that this PR addresses.
 - [ ] Includes tests generated or substantially modified by an AI agent
 
 > NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
+
+<!-- Do not edit bellow this line -->
+
+<!-- begin:squash-data -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,6 @@ Link any relevant issues that this PR addresses.
 
 > NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
 
-<!-- Do not edit bellow this line -->
+<!-- Do not edit below this line -->
 
 <!-- begin:squash-data -->

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,34 +1,24 @@
 queue_rules:
   - name: default
-    update_method: rebase
-    merge_method: merge
-    batch_size: 1
-pull_request_rules:
-  - name: comment-pre-commit-failure
-    description: Comment on PR when pre-commit check fails
-    conditions:
-      - status-failure = precommit-checks
-      - -closed
+    queue_conditions:
+      - "#approved-reviews-by >= 1"
+      - "#changes-requested-reviews-by = 0"
+      - check-success = DCO
+      - check-success = update-description
       - -draft
-    actions:
-      comment:
-        message: |
-          Hi @{{author}}, the pre-commit checks have failed. Please run:
+      - -closed
+    merge_method: squash
+    branch_protection_injection_mode: merge
+    batch_size: 1
+    commit_message_format:
+      title: pr-title
+      body: pr-body
 
-          ```bash
-          uv pip install pre-commit
-          pre-commit install
-          pre-commit run --all-files
-          ```
-
-          Then, commit the changes and push to your branch.
-
-          For future commits, `pre-commit` will run automatically on changed files before each commit.
-
+pull_request_rules:
   - name: comment-dco-failure
     description: Comment on PR when DCO check fails
     conditions:
-      - status-failure = dco
+      - check-failure = DCO
       - -closed
       - -draft
     actions:
@@ -36,48 +26,17 @@ pull_request_rules:
         message: |
           Hi @{{author}}, the DCO check has failed. Please click on DCO in the Checks section for instructions on how to resolve this.
 
-  - name: ping author on conflicts and add 'needs-rebase' label
+  - name: dismiss-reviews-on-push
+    description: Dismiss approvals when new commits are pushed to dequeue updated PRs
     conditions:
-      - conflict
       - -closed
     actions:
-      label:
-        add:
-          - needs-rebase
-      comment:
-        message: |
-          This pull request has merge conflicts that must be resolved before it can be
-          merged. Please rebase the PR, @{{author}}.
+      dismiss_reviews:
+        approved: true
+        when: synchronize
 
-          https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
-
-  - name: block PRs containing merge commits
-    conditions:
-      - -linear-history
-      - -closed
-    actions:
-      label:
-        add:
-          - needs-rebase
-      comment:
-        message: |
-          @{{author}}, this project requires a linear history on feature branches.
-          Your PR contains merge commits. Please rebase your branch against `main`
-          and remove them.
-
-          You can do this by running:
-          `git pull --rebase upstream main`
-
-  - name: remove 'needs-rebase' label when blockers are resolved
-    conditions:
-      - linear-history
-      - -conflict
-      - -closed
-    actions:
-      label:
-        remove:
-          - needs-rebase
 merge_protections_settings:
   reporting_method: check-runs
-merge_queue:
-  max_parallel_checks: 1
+  auto_merge_conditions:
+    - "#approved-reviews-by >= 2"
+    - "#changes-requested-reviews-by = 0"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -26,15 +26,6 @@ pull_request_rules:
         message: |
           Hi @{{author}}, the DCO check has failed. Please click on DCO in the Checks section for instructions on how to resolve this.
 
-  - name: dismiss-reviews-on-push
-    description: Dismiss approvals when new commits are pushed to dequeue updated PRs
-    conditions:
-      - -closed
-    actions:
-      dismiss_reviews:
-        approved: true
-        when: synchronize
-
 merge_protections_settings:
   reporting_method: check-runs
   auto_merge_conditions:

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,46 @@
+name: PR Description
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-description-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Update PR description
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CURRENT_BODY="$(gh pr view "$PR_NUMBER" --json body -q .body)"
+
+          NEW_BODY_FILE="$(mktemp)"
+          printf '%s' "$CURRENT_BODY" \
+            | ./scripts/format_pr.sh "origin/$PR_BASE_REF" "$PR_HEAD_SHA" \
+            > "$NEW_BODY_FILE"
+          NEW_BODY="$(cat "$NEW_BODY_FILE")"
+
+          if [ "$CURRENT_BODY" = "$NEW_BODY" ]; then
+            echo "PR body is already up to date, skipping update."
+            rm -f "$NEW_BODY_FILE"
+            exit 0
+          fi
+
+          gh pr edit "$PR_NUMBER" --body-file "$NEW_BODY_FILE"
+          rm -f "$NEW_BODY_FILE"

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update-description:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -3,22 +3,17 @@ name: PR Styling
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-  # This is a hack to ensure this workflow is available as a merge blocker.
-  # All the jobs need a condition to ensure they only run on PRs.
-  push:
-    branches: [main]
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: pr-description-${{ github.event.pull_request.number || github.sha }}
+  group: pr-description-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   update-description:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -1,19 +1,24 @@
-name: PR Description
+name: PR Styling
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  # This is a hack to ensure this workflow is available as a merge blocker.
+  # All the jobs need a condition to ensure they only run on PRs.
+  push:
+    branches: [main]
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: pr-description-${{ github.event.pull_request.number }}
+  group: pr-description-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
   update-description:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -1,7 +1,9 @@
 name: PR Styling
 
 on:
-  pull_request:
+  # This has to be pull_request_target since its editing but
+  # that means the the version from main runs not the PR's
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -32,11 +32,11 @@ MARKER="<!-- begin:squash-data -->"
 BASE_REF="${1:?$(usage >&2; echo "error: missing <base-ref>")}"
 HEAD_SHA="${2:?$(usage >&2; echo "error: missing <head-sha>")}"
 
-CURRENT_BODY="$(cat)"
+CURRENT_BODY="$(cat | tr -d '\r')"
 
-if printf '%s' "$CURRENT_BODY" | grep -qF "$MARKER"; then
-    USER_CONTENT="$(printf '%s' "$CURRENT_BODY" | awk -v marker="$MARKER" '$0 == marker {found=1} !found')"
-    # Strip trailing blank lines
+MARKER_LINE="$(printf '%s\n' "$CURRENT_BODY" | grep -nF "$MARKER" | head -1 | cut -d: -f1)"
+if [ -n "$MARKER_LINE" ]; then
+    USER_CONTENT="$(printf '%s\n' "$CURRENT_BODY" | head -n "$((MARKER_LINE - 1))")"
     USER_CONTENT="$(printf '%s' "$USER_CONTENT" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')"
 else
     USER_CONTENT="$CURRENT_BODY"

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -85,7 +85,7 @@ fi
 {
     printf '%s\n\n%s\n' "$USER_CONTENT" "$MARKER"
     printf '\n---\n'
-    printf '\n# Log\n\n'
+    printf '\n# git log\n\n'
     printf '%s\n' "$COMMITS_SECTION"
     if [ -n "$UNIQUE_TRAILERS" ]; then
         printf '\n---------\n\n'

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -34,7 +34,7 @@ HEAD_SHA="${2:?$(usage >&2; echo "error: missing <head-sha>")}"
 
 CURRENT_BODY="$(cat | tr -d '\r')"
 
-MARKER_LINE="$(printf '%s\n' "$CURRENT_BODY" | grep -nF "$MARKER" | head -1 | cut -d: -f1)"
+MARKER_LINE="$(printf '%s\n' "$CURRENT_BODY" | grep -nF "$MARKER" | head -1 | cut -d: -f1)" || true
 if [ -n "$MARKER_LINE" ]; then
     USER_CONTENT="$(printf '%s\n' "$CURRENT_BODY" | head -n "$((MARKER_LINE - 1))")"
     USER_CONTENT="$(printf '%s' "$USER_CONTENT" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')"
@@ -51,28 +51,17 @@ if [ -z "$COMMIT_SHAS" ]; then
     exit 0
 fi
 
-COMMITS_SECTION=""
+COMMITS_SECTION="$(git log --reverse --first-parent --no-merges --format=medium --no-decorate "$MERGE_BASE".."$HEAD_SHA")"
+
 ALL_TRAILERS=""
-
 while IFS= read -r sha; do
-    short_sha="${sha:0:7}"
-    message="$(git log --format="%B" -1 "$sha")"
-    # Trim trailing newline from git log output
-    message="$(printf '%s' "$message" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')"
-
-    trailers="$(printf '%s' "$message" | git interpret-trailers --parse 2>/dev/null)" || true
+    trailers="$(git log --format="%B" -1 "$sha" | git interpret-trailers --parse 2>/dev/null)" || true
     if [ -n "$trailers" ]; then
         if [ -n "$ALL_TRAILERS" ]; then
             ALL_TRAILERS="$(printf '%s\n%s' "$ALL_TRAILERS" "$trailers")"
         else
             ALL_TRAILERS="$trailers"
         fi
-    fi
-
-    if [ -n "$COMMITS_SECTION" ]; then
-        COMMITS_SECTION="$(printf '%s\n\n## %s\n\n%s' "$COMMITS_SECTION" "$short_sha" "$message")"
-    else
-        COMMITS_SECTION="$(printf '## %s\n\n%s' "$short_sha" "$message")"
     fi
 done <<< "$COMMIT_SHAS"
 
@@ -96,7 +85,7 @@ fi
 {
     printf '%s\n\n%s\n' "$USER_CONTENT" "$MARKER"
     printf '\n---\n'
-    printf '\n# Commits\n\n'
+    printf '\n# Log\n\n'
     printf '%s\n' "$COMMITS_SECTION"
     if [ -n "$UNIQUE_TRAILERS" ]; then
         printf '\n---------\n\n'

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -5,7 +5,7 @@ usage() {
     cat <<EOF
 Usage: $0 <base-ref> <head-sha>
 
-Format a PR description by appending a commits summary section.
+Format a PR description by appending a summary of commits.
 
 The current PR body is read from stdin. The output (written to stdout)
 preserves everything above the marker comment and replaces everything

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $0 <base-ref> <head-sha>
+
+Format a PR description by appending a commits summary section.
+
+The current PR body is read from stdin. The output (written to stdout)
+preserves everything above the marker comment and replaces everything
+below it with a generated commits section and de-duplicated trailers.
+
+Arguments:
+  base-ref    Git ref for the PR base branch (e.g. origin/main)
+  head-sha    Commit SHA of the PR head
+
+Example:
+  gh pr view 42 --json body -q .body \\
+    | $0 origin/main abc1234 \\
+    | gh pr edit 42 --body-file -
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+MARKER="<!-- begin:squash-data -->"
+
+BASE_REF="${1:?$(usage >&2; echo "error: missing <base-ref>")}"
+HEAD_SHA="${2:?$(usage >&2; echo "error: missing <head-sha>")}"
+
+CURRENT_BODY="$(cat)"
+
+if printf '%s' "$CURRENT_BODY" | grep -qF "$MARKER"; then
+    USER_CONTENT="$(printf '%s' "$CURRENT_BODY" | awk -v marker="$MARKER" '$0 == marker {found=1} !found')"
+    # Strip trailing blank lines
+    USER_CONTENT="$(printf '%s' "$USER_CONTENT" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')"
+else
+    USER_CONTENT="$CURRENT_BODY"
+fi
+
+MERGE_BASE="$(git merge-base "$BASE_REF" "$HEAD_SHA")"
+
+COMMIT_SHAS="$(git log --reverse --first-parent --no-merges --format="%H" "$MERGE_BASE".."$HEAD_SHA")" || true
+
+if [ -z "$COMMIT_SHAS" ]; then
+    printf '%s\n\n%s\n' "$USER_CONTENT" "$MARKER"
+    exit 0
+fi
+
+COMMITS_SECTION=""
+ALL_TRAILERS=""
+
+while IFS= read -r sha; do
+    short_sha="${sha:0:7}"
+    message="$(git log --format="%B" -1 "$sha")"
+    # Trim trailing newline from git log output
+    message="$(printf '%s' "$message" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')"
+
+    trailers="$(printf '%s' "$message" | git interpret-trailers --parse 2>/dev/null)" || true
+    if [ -n "$trailers" ]; then
+        if [ -n "$ALL_TRAILERS" ]; then
+            ALL_TRAILERS="$(printf '%s\n%s' "$ALL_TRAILERS" "$trailers")"
+        else
+            ALL_TRAILERS="$trailers"
+        fi
+    fi
+
+    if [ -n "$COMMITS_SECTION" ]; then
+        COMMITS_SECTION="$(printf '%s\n\n## %s\n\n%s' "$COMMITS_SECTION" "$short_sha" "$message")"
+    else
+        COMMITS_SECTION="$(printf '## %s\n\n%s' "$short_sha" "$message")"
+    fi
+done <<< "$COMMIT_SHAS"
+
+UNIQUE_TRAILERS=""
+if [ -n "$ALL_TRAILERS" ]; then
+    UNIQUE_TRAILERS="$(printf '%s\n' "$ALL_TRAILERS" | sort -u)"
+fi
+
+{
+    printf '%s\n\n%s\n' "$USER_CONTENT" "$MARKER"
+    printf '\n---\n'
+    printf '\n# Commits\n\n'
+    printf '%s\n' "$COMMITS_SECTION"
+    if [ -n "$UNIQUE_TRAILERS" ]; then
+        printf '\n---\n\n'
+        printf '%s\n' "$UNIQUE_TRAILERS"
+    fi
+}

--- a/scripts/format_pr.sh
+++ b/scripts/format_pr.sh
@@ -76,9 +76,21 @@ while IFS= read -r sha; do
     fi
 done <<< "$COMMIT_SHAS"
 
-UNIQUE_TRAILERS=""
+SIGNOFF_TRAILERS=""
+OTHER_TRAILERS=""
 if [ -n "$ALL_TRAILERS" ]; then
-    UNIQUE_TRAILERS="$(printf '%s\n' "$ALL_TRAILERS" | sort -u)"
+    OTHER_TRAILERS="$(printf '%s\n' "$ALL_TRAILERS" | grep -v '^Signed-off-by:' | sort -u)" || true
+    # Preserve original order for sign-offs, just deduplicate
+    SIGNOFF_TRAILERS="$(printf '%s\n' "$ALL_TRAILERS" | grep '^Signed-off-by:' | awk '!seen[$0]++')" || true
+fi
+
+UNIQUE_TRAILERS=""
+if [ -n "$OTHER_TRAILERS" ] && [ -n "$SIGNOFF_TRAILERS" ]; then
+    UNIQUE_TRAILERS="$(printf '%s\n%s' "$OTHER_TRAILERS" "$SIGNOFF_TRAILERS")"
+elif [ -n "$OTHER_TRAILERS" ]; then
+    UNIQUE_TRAILERS="$OTHER_TRAILERS"
+elif [ -n "$SIGNOFF_TRAILERS" ]; then
+    UNIQUE_TRAILERS="$SIGNOFF_TRAILERS"
 fi
 
 {
@@ -87,7 +99,7 @@ fi
     printf '\n# Commits\n\n'
     printf '%s\n' "$COMMITS_SECTION"
     if [ -n "$UNIQUE_TRAILERS" ]; then
-        printf '\n---\n\n'
+        printf '\n---------\n\n'
         printf '%s\n' "$UNIQUE_TRAILERS"
     fi
 }


### PR DESCRIPTION
## Summary

Implements a Squash Commit PR workflow with queuing and custom commit messages.

## Details

Using a combination of GitHub workflows and Mergify this PR introduces a Merge Queue based workflow that retains commit history in squash messages and handles git-trailers correctly.

After this PR the review process will roughly follow this workflow:

1. User submits a PR
2. Normal review process
3. Maintainer approves the PR
4. One of the following:
    - If 2 maintainers approve, the PR is pended to the queued
    - If a maintainer comments `@mergifyio queue`, the PR is pended to the queue
5. If PR passed queue conditions (DCO, correct PR description, has approval, no changes requested) then the PR is queued
6. If the PR is first in queue and up-to-date with main, It is merged as soon as all checks pass
7. If the PR is first in queue and behind main, a second draft PR is created with the base PR squashed on top of main. If the checks pass on that PR then the base PR is merged
8. If the PR is not first in queue a draft PR is created with ever PR in the queue up until this PR squashed on top of main, If the checks pass on that PR then the base PR is merged once all previous PRs are merged
9. If any part of the queue fails checks, it is automatically bisected to find the failing PR and that PR is dequeued.

### Required GitHub Config Changes

A few changes to GitHub rulesets are also required after merge:

1. Add `update-description` to "Require status checks to pass"
2. Remove all conditions from "Require a pull request before merging" except "Dismiss stale pull request approvals when new commits are pushed"
3. Allow Mergify to always bypass "Require status checks to pass" (keep this in its own ruleset)
4. Add a new ruleset with "Restrict updates" on main and allow Mergify to bypass on pull requests
### Possible Follow-up Changes

#### Bump auto-queue approval requirement to 3

Currently I have it set where two approvals will trigger an auto queue (see (4) above) should this be 3? It should also be possible to accommodate maintainer submitter PRs with a custom condition check so we lower the requirement count for maintainers.

#### Larger batches

Currently the queue is configured with `batch_size: 1` which means that each PR gets its own draft PR in steps (7) or (8) above. If we increase this Mergify will wait up to `batch_max_wait_time` (default 30 seconds) before creating the draft PR and will batch multiple draft PRs together up to `batch_size`. This could save us compute time in running tests at the cost of slightly longer enqueue tine and longer bisections when something goes wrong.

#### Priority queuing

Items in a queue can be give priority based on labels. Might make sense although 

#### Check timeout and retries

Checks (tests/linting) are currently given unlimited time which can stall the queue if a check never finishes (PRs can be dequeued manually if needed). We can adjust the timeout and number of retry attempts for checks.

#### Disable  `update-description` check on Mergify branches

Having it run didn't cause problems in testing but probably an unnecessary waste of compute.


## Test Plan

Needs to be tested after merge on other PRs. You can review my [test repo](https://github.com/sjmonson/test-mergify/pulls?q=is%3Apr) to see everything in action.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.
