### PR TITLE
Mask SecretStr api_key in model_dump so reports serialize

### DIFF
--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -16,7 +16,14 @@ from collections.abc import AsyncIterator
 from typing import Any, Literal
 
 import httpx
-from pydantic import AliasChoices, Field, SecretStr, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    Field,
+    SecretStr,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from guidellm.backends.backend import Backend, BackendArgs
 from guidellm.backends.openai.request_handlers import (
@@ -147,6 +154,27 @@ class OpenAIHTTPBackendArgs(BackendArgs):
             "cancel remaining turns)."
         ),
     )
+
+    @field_serializer("api_key", when_used="always")
+    def serialize_api_key(self, value: SecretStr | None) -> str | None:
+        """
+        Serialize ``api_key`` to a JSON-safe masked string in every dump mode.
+
+        A bare ``SecretStr`` is not JSON-serializable under python-mode
+        ``model_dump()``. Because ``OpenAIHTTPBackend.info`` returns
+        ``model_dump()`` and that dict is embedded in each benchmark's
+        ``config.backend`` (which the CSV/HTML writers pass to ``json.dumps``),
+        an unmasked ``SecretStr`` raises ``TypeError`` and no report is written.
+        Masking, rather than exposing ``get_secret_value()``, matches Pydantic's
+        json-mode default and keeps real keys out of persisted reports. Runtime
+        auth is unaffected: it reads the live ``SecretStr`` via
+        ``get_secret_value()``, and workers receive the backend object by pickle,
+        not by ``model_dump()``.
+
+        :param value: The configured API key, or ``None`` when unset.
+        :return: The masked key string, or ``None`` when no key is configured.
+        """
+        return str(value) if value is not None else None
 
     @field_validator("target", mode="after")
     @classmethod

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -1041,3 +1041,37 @@ class TestCheckToolCallExpectations:
         # Verify token counts
         assert final_info.timings.token_iterations > 0
         assert final_response.output_metrics.text_tokens == 10
+
+
+@pytest.mark.sanity
+def test_api_key_json_serializable_and_masked():
+    """
+    Backend args with an api_key must dump to JSON without raising and must mask
+    the secret.
+
+    Regression guard for the SecretStr serialization crash: ``info()`` returns
+    ``model_dump()`` and that dict is ``json.dumps``-ed by the CSV/HTML writers,
+    so an unmasked ``SecretStr`` produced empty reports for any run with an
+    api_key set.
+
+    ### WRITTEN BY AI ###
+    """
+    args = OpenAIHTTPBackendArgs(target="http://test", api_key="super-secret")
+
+    dumped = args.model_dump()
+    json.dumps(dumped)  # must not raise
+    assert dumped["api_key"] == "**********"
+    assert "super-secret" not in args.model_dump_json()
+    assert args.api_key.get_secret_value() == "super-secret"
+
+
+@pytest.mark.sanity
+def test_api_key_none_serializes_to_null():
+    """
+    An unset api_key must serialize to ``null`` without crashing.
+
+    ### WRITTEN BY AI ###
+    """
+    dumped = OpenAIHTTPBackendArgs(target="http://test").model_dump()
+    json.dumps(dumped)  # must not raise
+    assert dumped["api_key"] is None


### PR DESCRIPTION
## Summary

Backend args with an `api_key` (`SecretStr`) crash report serialization. `OpenAIHTTPBackend.info` returns `self._args.model_dump()` (python mode), leaving `api_key` as a raw `SecretStr` in `benchmark.config.backend`; the CSV/HTML writers `json.dumps` that dict and raise `TypeError: Object of type SecretStr is not JSON serializable`, so any run with an `api_key` set produces no reports. This adds a `field_serializer` on `OpenAIHTTPBackendArgs` that masks the key in every dump mode.

## Details

- [x] Add `field_serializer("api_key", when_used="always")` to `OpenAIHTTPBackendArgs`, masking the key (`**********`) in all dump modes.
- [x] Add unit tests asserting `model_dump()` / `model_dump_json()` are JSON-safe and masked, and that `get_secret_value()` (runtime auth) is unchanged.

## Test Plan

- `tox -e tests -- tests/unit/backends/openai/test_http.py`
- `tox -e lint-check && tox -e type-check`
- Manual: run a benchmark with `--api-key` set and `--outputs "benchmark.json,report.csv"`; confirm files are written and the key shows as `**********` (not the real value).

## Related Issues

- Resolves #764

---

- [x] "I certify that all code in this PR is my own, except as noted below." (AI assistance noted via the commit trailer.)

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent
