### PR TITLE
Fix update-description job

### DIFF
--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -30,6 +30,9 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Fetch the PR branch since we are on base repo
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+
           CURRENT_BODY="$(gh pr view "$PR_NUMBER" --json body -q .body)"
 
           NEW_BODY_FILE="$(mktemp)"


### PR DESCRIPTION
## Summary

If a PR is from a fork then update-description does not have the access to the commits from the fork without pulling them first.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3b19098d242bb59be2438640926f9fc33e23be53
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 3 15:28:36 2026 -0400

    Fix update-description job
    
    If a PR is from a fork then update-description does not have the access
    to the commits from the fork without pulling them first.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
