### PR TITLE
Build ProfileArgs in BenchmarkGenerativeTextArgs

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -33,7 +33,6 @@ from guidellm.benchmark.schemas import (
 )
 from guidellm.benchmark.schemas.base import TransientPhaseConfig
 from guidellm.data import (
-    DataArgs,
     DataLoader,
     create_data_loader,
 )
@@ -284,58 +283,8 @@ def resolve_constraints(constraints: MutableMapping[str, Any]) -> dict[str, Any]
     }
 
 
-def _build_profile_from_args(
-    profile: ProfileArgs | dict[str, Any],
-    random_seed: int,
-    rampup: float,
-    constraints: MutableMapping[str, ConstraintInitializer | Any],
-    rate: list[float] | None,
-    data: list[DataArgs] | None,
-    profile_kwargs: dict[str, Any],
-) -> Profile:
-    """
-    Build a Profile instance argument dictionary from the provided parameters.
-
-    :param profile: The profile configuration, which may be a ProfileArgs instance or a
-     dictionary.
-    :param random_seed: An integer seed for reproducible operations.
-    :param rampup: The ramp-up duration as a float (seconds).
-    :param constraints: Constraints for the profile, as a mapping from string to
-        constraint initializers or values.
-    :param rate: (Optional) The request rate for the benchmark.
-    :param data: (Optional) Data to include in the benchmark configuration.
-    :param profile_kwargs: Additional keyword arguments, may include "data_samples" and
-        other profile options.
-    :return: a Profile instance.
-    """
-    profile_args: dict[str, Any] = {
-        "rampup_duration": rampup,
-    }
-    if rate is not None:
-        profile_args["rate"] = rate
-    if data is not None:
-        profile_args["data"] = data
-    if "data_samples" in profile_kwargs:
-        profile_args["data_samples"] = profile_kwargs.get("data_samples")
-    profile_args.update(profile_kwargs)
-
-    if isinstance(profile, ProfileArgs):
-        profile_args.update(profile.model_dump())
-    elif isinstance(profile, dict):
-        profile_args.update(profile)
-    else:
-        raise ValueError(
-            "Profile arguments must be a string, dictionary, or ProfileArgs."
-        )
-    args = ProfileArgs.model_validate(profile_args)
-    return ProfileFactory.create(args, random_seed, resolve_constraints(constraints))
-
-
 async def resolve_profile(
-    profile: ProfileArgs | dict[str, Any] | Profile,
-    rate: list[float] | None,
-    random_seed: int,
-    rampup: float,
+    profile: ProfileArgs | Profile,
     constraints: MutableMapping[str, ConstraintInitializer | Any],
     max_seconds: int | float | None,
     max_requests: int | None,
@@ -344,7 +293,6 @@ async def resolve_profile(
     max_global_error_rate: float | None,
     over_saturation: dict[str, Any] | None = None,
     console: Console | None = None,
-    data: list[DataArgs] | None = None,
     **profile_kwargs: Any,
 ) -> Profile:
     """
@@ -355,10 +303,6 @@ async def resolve_profile(
     profile creation.
 
     :param profile: Profile type identifier or pre-configured Profile instance
-    :param rate: Request rate(s) for the benchmark execution
-    :param random_seed: Seed for reproducible random operations
-    :param warmup: Warm-up phase configuration for the benchmark execution
-        (used for ramp-up duration calculation)
     :param constraints: Dictionary of constraint initializers for benchmark limits
     :param max_seconds: Maximum duration in seconds for the benchmark
     :param max_requests: Maximum number of requests to process
@@ -367,8 +311,8 @@ async def resolve_profile(
     :param max_global_error_rate: Maximum global error rate threshold before stopping
     :param over_saturation: Over-saturation detection configuration (dict)
     :param console: Console instance for progress reporting, or None
-    :param data: Optional list of data sources.
     :param profile_kwargs: Additional profile-specific arguments.
+        data, data_samples, random_seed are used by some profiles & ignored by others.
     :return: Configured Profile instance ready for benchmarking
     :raises ValueError: If constraints are provided with a pre-configured Profile
     """
@@ -390,18 +334,11 @@ async def resolve_profile(
             constraints[key] = val
 
     if not isinstance(profile, Profile):
-        profile = _build_profile_from_args(
-            profile, random_seed, rampup, constraints, rate, data, profile_kwargs
-        )
+        profile = ProfileFactory.create(profile, constraints, **profile_kwargs)
     elif constraints:
         raise ValueError(
             "Constraints must be empty when providing a Profile instance. "
             f"Provided constraints: {constraints} ; provided profile: {profile}"
-        )
-    elif rampup > 0.0:
-        raise ValueError(
-            "Ramp-up duration must not be set when providing a Profile instance. "
-            f"Provided rampup: {rampup} ; provided profile: {profile}"
         )
 
     if console_step:
@@ -496,9 +433,6 @@ async def benchmark_generative_text(
 
     profile = await resolve_profile(
         profile=args.profile,
-        rate=args.rate,
-        random_seed=args.random_seed,
-        rampup=args.rampup,
         constraints=constraints,
         max_seconds=args.max_seconds,
         max_requests=args.max_requests,
@@ -507,6 +441,7 @@ async def benchmark_generative_text(
         max_global_error_rate=args.max_global_error_rate,
         over_saturation=args.over_saturation,
         console=console,
+        random_seed=args.random_seed,
         data=args.data,
         data_samples=request_loader.info.get("data_samples", -1),
     )

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -291,6 +291,7 @@ async def resolve_profile(
     max_errors: int | None,
     max_error_rate: float | None,
     max_global_error_rate: float | None,
+    random_seed: int = 42,
     over_saturation: dict[str, Any] | None = None,
     console: Console | None = None,
     **profile_kwargs: Any,
@@ -311,8 +312,9 @@ async def resolve_profile(
     :param max_global_error_rate: Maximum global error rate threshold before stopping
     :param over_saturation: Over-saturation detection configuration (dict)
     :param console: Console instance for progress reporting, or None
-    :param profile_kwargs: Additional profile-specific arguments.
-        data, data_samples, random_seed are used by some profiles & ignored by others.
+    :param random_seed: Seed for reproducible random operations in profile strategies
+    :param profile_kwargs: Additional profile-specific arguments such as data and
+        data_samples, used by some profiles and ignored by others.
     :return: Configured Profile instance ready for benchmarking
     :raises ValueError: If constraints are provided with a pre-configured Profile
     """
@@ -334,7 +336,9 @@ async def resolve_profile(
             constraints[key] = val
 
     if not isinstance(profile, Profile):
-        profile = ProfileFactory.create(profile, constraints, **profile_kwargs)
+        profile = ProfileFactory.create(
+            profile, random_seed, constraints, **profile_kwargs
+        )
     elif constraints:
         raise ValueError(
             "Constraints must be empty when providing a Profile instance. "

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, PositiveFloat, PositiveInt, field_validator
@@ -9,6 +10,7 @@ from pydantic import Field, PositiveFloat, PositiveInt, field_validator
 from guidellm.scheduler import (
     AsyncConstantStrategy,
     AsyncPoissonStrategy,
+    ConstraintInitializer,
     SchedulingStrategy,
 )
 
@@ -69,15 +71,16 @@ class AsyncProfile(Profile):
     def __init__(
         self,
         args: AsyncProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
         if args.kind in ("async", "constant"):
             self._strategy_type: Literal["constant", "poisson"] = "constant"
         elif args.kind == "poisson":
             self._strategy_type = "poisson"
+            self.random_seed = kwargs.get("random_seed", 42)
         else:
             raise ValueError(f"Invalid profile kind: {args.kind}")
 

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -71,16 +71,16 @@ class AsyncProfile(Profile):
     def __init__(
         self,
         args: AsyncProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
         if args.kind in ("async", "constant"):
             self._strategy_type: Literal["constant", "poisson"] = "constant"
         elif args.kind == "poisson":
             self._strategy_type = "poisson"
-            self.random_seed = kwargs.get("random_seed", 42)
         else:
             raise ValueError(f"Invalid profile kind: {args.kind}")
 

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -35,19 +35,8 @@ class ConcurrentProfileArgs(ProfileArgs):
     @model_validator(mode="before")
     @classmethod
     def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Remove a duplicate rate
-
-        This profile aliases "rate" to "streams"; but if the user types
-
-            "--profile kind=concurrent,streams=2.0 --rate 3"
-
-        Pydantic won't alias the "rate" because it's already seen "streams", and
-        we'll get a validation error. In this case, the global "--rate" should be
-        ignored, so we remove the "rate" key.
-        """
-        if isinstance(data, dict) and all(key in data for key in ("rate", "streams")):
-            data.pop("rate")
-        return data
+        """Check for duplicate rate"""
+        return cls._fail_on_duplicate_rate(data, "streams")
 
     @field_validator("streams", mode="before")
     @classmethod

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -82,10 +82,11 @@ class ConcurrentProfile(Profile):
     def __init__(
         self,
         args: ConcurrentProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, Field, PositiveInt, field_validator
+from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
 
 from guidellm.scheduler import (
     ConcurrentStrategy,
+    ConstraintInitializer,
     SchedulingStrategy,
 )
 
@@ -29,6 +31,23 @@ class ConcurrentProfileArgs(ProfileArgs):
         validation_alias=AliasChoices("streams", "rate"),
         description="Concurrent stream counts to execute",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
+        """Remove a duplicate rate
+
+        This profile aliases "rate" to "streams"; but if the user types
+
+            "--profile kind=concurrent,streams=2.0 --rate 3"
+
+        Pydantic won't alias the "rate" because it's already seen "streams", and
+        we'll get a validation error. In this case, the global "--rate" should be
+        ignored, so we remove the "rate" key.
+        """
+        if isinstance(data, dict) and all(key in data for key in ("rate", "streams")):
+            data.pop("rate")
+        return data
 
     @field_validator("streams", mode="before")
     @classmethod
@@ -63,10 +82,10 @@ class ConcurrentProfile(Profile):
     def __init__(
         self,
         args: ConcurrentProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -76,6 +76,7 @@ class ProfileFactory(RegistryMixin["type[Profile]"]):
     def create(
         cls,
         args: ProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None = None,
         **kwargs: Any,
     ) -> Profile:
@@ -83,6 +84,10 @@ class ProfileFactory(RegistryMixin["type[Profile]"]):
         Create profile instances from validated profile arguments.
 
         :param args: Validated profile argument model for the target profile type
+        :param random_seed: Seed for reproducible random operations in profile
+            strategies.
+        :param constraints: Constraints for the profile strategies.
+        :param kwargs: Additional profile-specific configuration parameters
         :return: Configured profile instance for the specified type
         :raises ValueError: If the profile kind is not registered
         """
@@ -96,7 +101,7 @@ class ProfileFactory(RegistryMixin["type[Profile]"]):
                 f"Available types: {list(cls.registry.keys()) if cls.registry else []}"
             )
 
-        return profile_class(args, constraints, **kwargs)
+        return profile_class(args, random_seed, constraints, **kwargs)
 
     @classmethod
     def registered_names(cls) -> tuple[str, ...]:
@@ -129,6 +134,7 @@ class Profile(ABC):
     def __init__(
         self,
         args: ProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
@@ -136,10 +142,15 @@ class Profile(ABC):
         Initialize a profile instance.
 
         :param args: Validated profile argument model for this profile type
+        :param random_seed: Seed for reproducible random operations in profile
+            strategies.
+        :param constraints: Constraints for the profile strategies.
+        :param kwargs: Additional profile-specific configuration parameters
         """
         _ = kwargs  # unused
         self.kind = args.kind
         self.args = args
+        self.random_seed = random_seed
         self.constraints = dict(constraints or {})
         self.completed_strategies: list[SchedulingStrategy] = []
 

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -60,6 +60,28 @@ class ProfileArgs(PydanticClassRegistryMixin["ProfileArgs"], ABC):
 
         return ProfileArgs
 
+    @classmethod
+    def _fail_on_duplicate_rate(cls, data: Any, key: str) -> Any:
+        """Fail if both "rate" and <key> are specified.
+
+        Some profile alias "rate" and a more specific key; if the user enters
+        both, either directly or via the global "--rate" option, we should fail.
+
+        for example:
+
+            "--profile kind=concurrent,streams=2.0 --rate 3"
+            "--profile kind=concurrent,streams=2,rate=3"
+
+        Pydantic won't resolve all cases consistently, so we need to fail explicitly.
+
+        :param data: The data to validate
+        :param key: The key to check for duplicate rate
+        :return: The data
+        """
+        if isinstance(data, dict) and all(key in data for key in ("rate", key)):
+            raise ValueError(f"Both 'rate' and '{key}' cannot be specified.")
+        return data
+
     kind: str = Field(
         description="Profile type discriminator for polymorphic serialization",
     )

--- a/src/guidellm/benchmark/profiles/profile.py
+++ b/src/guidellm/benchmark/profiles/profile.py
@@ -5,18 +5,18 @@ Profile base class for multi-strategy benchmark execution.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator
+from collections.abc import Generator, MutableMapping
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import (
     ConfigDict,
     Field,
     NonNegativeFloat,
-    model_validator,
 )
 
 from guidellm.scheduler import (
     Constraint,
+    ConstraintInitializer,
     ConstraintsInitializerFactory,
     SchedulingStrategy,
 )
@@ -35,17 +35,6 @@ class ProfileArgs(PydanticClassRegistryMixin["ProfileArgs"], ABC):
     of profile instances. It inherits from PydanticClassRegistryMixin to enable
     automatic registration of subclasses, allowing for flexible and extensible
     profile configurations.
-
-    NOTES:
-
-    - Several fields are always passed by the CLI but are not relevant to some
-      profiles. In order to "forbid" unknown parameters, we have to handle these
-      here. There are two separate strategies:
-      - a "before" model validator removes the replay specific parameters (data and
-        data_samples), and this validator is overriden by the replay profile.
-      - random_seed is allowed as a "global" even though it's not used by most
-        profiles. Since random_seed is a CLI option used outside of profiles, this
-        seems less "hacky" than the temporary solution for replay.
 
     :cvar schema_discriminator: Field name for polymorphic deserialization
     """
@@ -81,28 +70,14 @@ class ProfileArgs(PydanticClassRegistryMixin["ProfileArgs"], ABC):
         ),
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _remove_replay_params(cls, data: Any) -> Any:
-        """Remove replay specific parameters from the data.
-
-        TODO: This is a temporary solution to remove replay specific parameters from the
-        data so we can use Pydantic to validate the parameters. This is overriden by the
-        replay profile, and will be removed when we have a better solution.
-        """
-        if isinstance(data, dict):
-            data.pop("data", None)
-            data.pop("data_samples", None)
-        return data
-
 
 class ProfileFactory(RegistryMixin["type[Profile]"]):
     @classmethod
     def create(
         cls,
         args: ProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None = None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None = None,
+        **kwargs: Any,
     ) -> Profile:
         """
         Create profile instances from validated profile arguments.
@@ -121,7 +96,7 @@ class ProfileFactory(RegistryMixin["type[Profile]"]):
                 f"Available types: {list(cls.registry.keys()) if cls.registry else []}"
             )
 
-        return profile_class(args, random_seed, constraints)
+        return profile_class(args, constraints, **kwargs)
 
     @classmethod
     def registered_names(cls) -> tuple[str, ...]:
@@ -154,18 +129,18 @@ class Profile(ABC):
     def __init__(
         self,
         args: ProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
         """
         Initialize a profile instance.
 
         :param args: Validated profile argument model for this profile type
         """
+        _ = kwargs  # unused
         self.kind = args.kind
         self.args = args
-        self.random_seed = random_seed
-        self.constraints = constraints
+        self.constraints = dict(constraints or {})
         self.completed_strategies: list[SchedulingStrategy] = []
 
     @property

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -107,21 +107,8 @@ class ReplayProfileArgs(ProfileArgs):
     @model_validator(mode="before")
     @classmethod
     def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Remove a duplicate rate
-
-        This profile aliases "rate" to "time_scale"; but if the user types
-
-            "--profile kind=replay,time_scale=2.0 --rate 3"
-
-        Pydantic won't alias the "rate" because it's already seen "time_scale", and
-        we'll get a validation error. In this case, the global "--rate" should be
-        ignored, so we remove the "rate" key.
-        """
-        if isinstance(data, dict) and all(
-            key in data for key in ("rate", "time_scale")
-        ):
-            data.pop("rate")
-        return data
+        """Check for duplicate rate"""
+        return cls._fail_on_duplicate_rate(data, "time_scale")
 
     @field_validator("time_scale", mode="before")
     @classmethod

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -162,10 +162,11 @@ class ReplayProfile(Profile):
     def __init__(
         self,
         args: ReplayProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
         data = kwargs.get("data", [])

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -10,6 +11,7 @@ from pydantic import AliasChoices, Field, field_validator, model_validator
 from guidellm.data import DataArgs
 from guidellm.data.deserializers import TraceSyntheticDataArgs
 from guidellm.scheduler import (
+    ConstraintInitializer,
     ConstraintsInitializerFactory,
     SchedulingStrategy,
     TraceReplayStrategy,
@@ -95,18 +97,31 @@ class ReplayProfileArgs(ProfileArgs):
         default="replay",
         description="Profile type discriminator for polymorphic serialization",
     )
-    data: list[DataArgs] = Field(description="Data source for replay profile")
-    data_samples: int = Field(
-        default=-1,
-        ge=-1,
-        description="Number of data samples to use for replay profile",
-    )
     time_scale: float = Field(
         validation_alias=AliasChoices("time_scale", "rate"),
         default=1.0,
         gt=0,
         description="Scale factor applied to relative timestamps",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
+        """Remove a duplicate rate
+
+        This profile aliases "rate" to "time_scale"; but if the user types
+
+            "--profile kind=replay,time_scale=2.0 --rate 3"
+
+        Pydantic won't alias the "rate" because it's already seen "time_scale", and
+        we'll get a validation error. In this case, the global "--rate" should be
+        ignored, so we remove the "rate" key.
+        """
+        if isinstance(data, dict) and all(
+            key in data for key in ("rate", "time_scale")
+        ):
+            data.pop("rate")
+        return data
 
     @field_validator("time_scale", mode="before")
     @classmethod
@@ -126,14 +141,6 @@ class ReplayProfileArgs(ProfileArgs):
             "time_scale (rate) must be an integer or a list of numeric values, "
             f"got {type(value).__name__}"
         )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _remove_replay_params(cls, data: Any) -> Any:
-        """
-        Override the ProfileArgs validator that removes replay specific parameters.
-        """
-        return data
 
 
 @ProfileFactory.register("replay")
@@ -155,13 +162,15 @@ class ReplayProfile(Profile):
     def __init__(
         self,
         args: ReplayProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
-        relative_timestamps = _resolve_relative_timestamps(args.data, args.data_samples)
 
+        data = kwargs.get("data", [])
+        data_samples = kwargs.get("data_samples", -1)
+        relative_timestamps = _resolve_relative_timestamps(data, data_samples)
         new_constraints = dict(constraints or {})
         if not any(key in new_constraints for key in _MAX_REQUEST_CONSTRAINT_KEYS):
             new_constraints.update(

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -100,13 +100,12 @@ class SweepProfile(Profile):
     def __init__(
         self,
         args: SweepProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
-        if self.args.strategy_type == "poisson":
-            self.random_seed = kwargs.get("random_seed", 42)
         self.synchronous_rate = -1.0
         self.throughput_rate = -1.0
         self.async_rates: list[float] = []

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from pydantic import AliasChoices, Field, PositiveInt, field_validator
+from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
 
 from guidellm.scheduler import (
     AsyncConstantStrategy,
     AsyncPoissonStrategy,
+    ConstraintInitializer,
     SchedulingStrategy,
     SynchronousStrategy,
     ThroughputStrategy,
@@ -40,6 +42,25 @@ class SweepProfileArgs(ProfileArgs):
         default=None,
         description="Maximum concurrent requests to schedule",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
+        """Remove a duplicate rate
+
+        This profile aliases "rate" to "sweep_size"; but if the user types
+
+            "--profile kind=sweep,sweep_size=6 --rate 10"
+
+        Pydantic won't alias the "rate" because it's already seen "sweep_size", and
+        we'll get a validation error. In this case, the global "--rate" should be
+        ignored, so we remove the "rate" key.
+        """
+        if isinstance(data, dict) and all(
+            key in data for key in ("rate", "sweep_size")
+        ):
+            data.pop("rate")
+        return data
 
     @field_validator("sweep_size", mode="before")
     @classmethod
@@ -79,11 +100,13 @@ class SweepProfile(Profile):
     def __init__(
         self,
         args: SweepProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
+        if self.args.strategy_type == "poisson":
+            self.random_seed = kwargs.get("random_seed", 42)
         self.synchronous_rate = -1.0
         self.throughput_rate = -1.0
         self.async_rates: list[float] = []

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -46,21 +46,8 @@ class SweepProfileArgs(ProfileArgs):
     @model_validator(mode="before")
     @classmethod
     def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Remove a duplicate rate
-
-        This profile aliases "rate" to "sweep_size"; but if the user types
-
-            "--profile kind=sweep,sweep_size=6 --rate 10"
-
-        Pydantic won't alias the "rate" because it's already seen "sweep_size", and
-        we'll get a validation error. In this case, the global "--rate" should be
-        ignored, so we remove the "rate" key.
-        """
-        if isinstance(data, dict) and all(
-            key in data for key in ("rate", "sweep_size")
-        ):
-            data.pop("rate")
-        return data
+        """Check for duplicate rate"""
+        return cls._fail_on_duplicate_rate(data, "sweep_size")
 
     @field_validator("sweep_size", mode="before")
     @classmethod

--- a/src/guidellm/benchmark/profiles/synchronous.py
+++ b/src/guidellm/benchmark/profiles/synchronous.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, model_validator
 
 from guidellm.scheduler import (
+    ConstraintInitializer,
     SchedulingStrategy,
     SynchronousStrategy,
 )
@@ -49,10 +51,10 @@ class SynchronousProfile(Profile):
     def __init__(
         self,
         args: SynchronousProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/synchronous.py
+++ b/src/guidellm/benchmark/profiles/synchronous.py
@@ -51,10 +51,11 @@ class SynchronousProfile(Profile):
     def __init__(
         self,
         args: SynchronousProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -35,21 +35,8 @@ class ThroughputProfileArgs(ProfileArgs):
     @model_validator(mode="before")
     @classmethod
     def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Remove a duplicate rate
-
-        This profile aliases "rate" to "max_concurrency"; but if the user types
-
-            "--profile kind=throughput,max_concurrency=2.0 --rate 3"
-
-        Pydantic won't alias the "rate" because it's already seen "max_concurrency", and
-        we'll get a validation error. In this case, the global "--rate" should be
-        ignored, so we remove the "rate" key.
-        """
-        if isinstance(data, dict) and all(
-            key in data for key in ("rate", "max_concurrency")
-        ):
-            data.pop("rate")
-        return data
+        """Check for duplicate rate"""
+        return cls._fail_on_duplicate_rate(data, "max_concurrency")
 
     @field_validator("max_concurrency", mode="before")
     @classmethod

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -86,10 +86,11 @@ class ThroughputProfile(Profile):
     def __init__(
         self,
         args: ThroughputProfileArgs,
+        random_seed: int,
         constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
         **kwargs: Any,
     ):
-        super().__init__(args, constraints, **kwargs)
+        super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, Field, PositiveInt, field_validator
+from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
 
 from guidellm.scheduler import (
+    ConstraintInitializer,
     SchedulingStrategy,
     ThroughputStrategy,
 )
@@ -29,6 +31,25 @@ class ThroughputProfileArgs(ProfileArgs):
         validation_alias=AliasChoices("max_concurrency", "rate"),
         description="Maximum concurrent requests to schedule",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
+        """Remove a duplicate rate
+
+        This profile aliases "rate" to "max_concurrency"; but if the user types
+
+            "--profile kind=throughput,max_concurrency=2.0 --rate 3"
+
+        Pydantic won't alias the "rate" because it's already seen "max_concurrency", and
+        we'll get a validation error. In this case, the global "--rate" shoulde be
+        ignored, so we remove the "rate" key.
+        """
+        if isinstance(data, dict) and all(
+            key in data for key in ("rate", "max_concurrency")
+        ):
+            data.pop("rate")
+        return data
 
     @field_validator("max_concurrency", mode="before")
     @classmethod
@@ -65,10 +86,10 @@ class ThroughputProfile(Profile):
     def __init__(
         self,
         args: ThroughputProfileArgs,
-        random_seed: int,
-        constraints: dict[str, Any] | None,
+        constraints: MutableMapping[str, ConstraintInitializer | Any] | None,
+        **kwargs: Any,
     ):
-        super().__init__(args, random_seed, constraints)
+        super().__init__(args, constraints, **kwargs)
         self.args = args
 
     @property

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -42,7 +42,7 @@ class ThroughputProfileArgs(ProfileArgs):
             "--profile kind=throughput,max_concurrency=2.0 --rate 3"
 
         Pydantic won't alias the "rate" because it's already seen "max_concurrency", and
-        we'll get a validation error. In this case, the global "--rate" shoulde be
+        we'll get a validation error. In this case, the global "--rate" should be
         ignored, so we remove the "rate" key.
         """
         if isinstance(data, dict) and all(

--- a/src/guidellm/benchmark/schemas/generative/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/generative/entrypoints.py
@@ -30,7 +30,7 @@ from pydantic import (
 )
 
 from guidellm.backends import BackendArgs
-from guidellm.benchmark.profiles import Profile
+from guidellm.benchmark.profiles import Profile, ProfileArgs
 from guidellm.benchmark.scenarios import get_builtin_scenarios
 from guidellm.benchmark.schemas.base import TransientPhaseConfig
 from guidellm.data import (
@@ -174,8 +174,7 @@ class BenchmarkGenerativeTextArgs(StandardBaseModel):
         min_length=1,
     )
     # Benchmark configuration
-    profile: dict[str, Any] = Field(
-        default={"kind": "sweep"},
+    profile: ProfileArgs = Field(
         description="Benchmark profile configuration arguments",
     )
     rate: list[float] | None = Field(

--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -320,7 +320,7 @@ __all__ = ["run"]
     flag_value='{"enabled": true}',
     help="Enable over-saturation detection with default settings.",
 )
-def run(**kwargs):  # noqa: C901, PLR0915
+def run(**kwargs):  # noqa: C901, PLR0915, PLR0912
     ctx = click.get_current_context()
     # Only set CLI args that differ from click defaults
     kwargs = cli_tools.set_if_not_default(ctx, **kwargs)
@@ -371,7 +371,15 @@ def run(**kwargs):  # noqa: C901, PLR0915
         with contextlib.suppress(KeyError):
             backend_kwargs[alias] = kwargs.pop(alias)
 
+    # Map top-level CLI options to profile
     kwargs["backend_kwargs"] = backend_kwargs
+    profile = kwargs.pop("profile", {"kind": "sweep"})
+    rate = kwargs.pop("rate", None)
+    profile["rate"] = rate
+    rampup = kwargs.pop("rampup", None)
+    if rampup is not None and "rampup_duration" not in profile:
+        profile["rampup_duration"] = rampup
+    kwargs["profile"] = profile
 
     # Handle console options
     disable_console = kwargs.pop("disable_console", False)

--- a/src/guidellm/cli/benchmark/run.py
+++ b/src/guidellm/cli/benchmark/run.py
@@ -374,8 +374,12 @@ def run(**kwargs):  # noqa: C901, PLR0915, PLR0912
     # Map top-level CLI options to profile
     kwargs["backend_kwargs"] = backend_kwargs
     profile = kwargs.pop("profile", {"kind": "sweep"})
-    rate = kwargs.pop("rate", None)
-    profile["rate"] = rate
+    if rate := kwargs.pop("rate", None):
+        if "rate" in profile:
+            raise click.BadParameter(
+                "Both --rate and --profile rate cannot be specified together."
+            )
+        profile["rate"] = rate
     rampup = kwargs.pop("rampup", None)
     if rampup is not None and "rampup_duration" not in profile:
         profile["rampup_duration"] = rampup

--- a/tests/unit/benchmark/schemas/generative/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/generative/test_entrypoints.py
@@ -33,6 +33,7 @@ _PIPELINE_DEFAULTS = {
     "data_preprocessors": [],
     "data_finalizer": {"kind": "generative"},
     "data_loader": {"kind": "pytorch"},
+    "profile": {"kind": "sweep", "rate": [10.0]},
 }
 
 

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -27,21 +27,29 @@ def _replay_args(**kwargs) -> ReplayProfileArgs:
 def _replay_profile(
     constraints: dict[str, Any] | None = None, random_seed: int = 42, **kwargs
 ) -> ReplayProfile:
-    return ProfileFactory.create(
-        _replay_args(**kwargs), random_seed=random_seed, constraints=constraints
-    )
+    data = kwargs.pop("data", None)
+    data_samples = kwargs.pop("data_samples", -1)
+    args = _replay_args(**kwargs)
+    profile_kwargs: dict[str, Any] = {
+        "random_seed": random_seed,
+        "data_samples": data_samples,
+    }
+    if data is not None:
+        profile_kwargs["data"] = data
+    return ProfileFactory.create(args, constraints=constraints, **profile_kwargs)
 
 
 class TestReplayProfile:
     @pytest.mark.smoke
     def test_requires_data(self):
         """
-        Replay profile args require a trace data source.
+        Replay profile requires a trace data source.
 
         ## WRITTEN BY AI ##
         """
-        with pytest.raises(ValidationError):
-            _replay_args()
+        args = _replay_args()
+        with pytest.raises(ValueError, match="exactly one data source"):
+            ProfileFactory.create(args)
 
     @pytest.mark.smoke
     def test_rejects_multiple_data_sources(self, tmp_path: Path):
@@ -50,8 +58,10 @@ class TestReplayProfile:
 
         ## WRITTEN BY AI ##
         """
+        args = _replay_args()
         with pytest.raises(ValueError, match="exactly one data source"):
-            _replay_profile(
+            ProfileFactory.create(
+                args,
                 data=[
                     TraceSyntheticDataArgs(path=tmp_path / "trace-a.jsonl"),
                     TraceSyntheticDataArgs(path=tmp_path / "trace-b.jsonl"),
@@ -66,12 +76,13 @@ class TestReplayProfile:
         ## WRITTEN BY AI ##
         """
         missing = tmp_path / "missing.jsonl"
+        args = _replay_args()
         with pytest.raises(ValueError, match="not found"):
-            _replay_profile(data=[TraceSyntheticDataArgs(path=missing)])
+            ProfileFactory.create(args, data=[TraceSyntheticDataArgs(path=missing)])
 
         empty = _trace_path(tmp_path)
         with pytest.raises(ValueError, match="empty|No timestamps"):
-            _replay_profile(data=[TraceSyntheticDataArgs(path=empty)])
+            ProfileFactory.create(args, data=[TraceSyntheticDataArgs(path=empty)])
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(
@@ -347,16 +358,14 @@ class TestReplayProfile:
         )
 
         profile = await resolve_profile(
-            profile={"kind": "replay"},
-            rate=[2.0],
-            random_seed=42,
-            rampup=0.0,
+            profile=ReplayProfileArgs.model_validate({"kind": "replay", "rate": [2.0]}),
             constraints={},
             max_seconds=None,
             max_requests=2,
             max_errors=None,
             max_error_rate=None,
             max_global_error_rate=None,
+            random_seed=42,
             data=[TraceSyntheticDataArgs(path=trace, timestamp_column="ts")],
             data_samples=2,
         )

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -30,13 +30,12 @@ def _replay_profile(
     data = kwargs.pop("data", None)
     data_samples = kwargs.pop("data_samples", -1)
     args = _replay_args(**kwargs)
-    profile_kwargs: dict[str, Any] = {
-        "random_seed": random_seed,
-        "data_samples": data_samples,
-    }
+    profile_kwargs: dict[str, Any] = {"data_samples": data_samples}
     if data is not None:
         profile_kwargs["data"] = data
-    return ProfileFactory.create(args, constraints=constraints, **profile_kwargs)
+    return ProfileFactory.create(
+        args, random_seed, constraints=constraints, **profile_kwargs
+    )
 
 
 class TestReplayProfile:
@@ -49,7 +48,7 @@ class TestReplayProfile:
         """
         args = _replay_args()
         with pytest.raises(ValueError, match="exactly one data source"):
-            ProfileFactory.create(args)
+            ProfileFactory.create(args, 42)
 
     @pytest.mark.smoke
     def test_rejects_multiple_data_sources(self, tmp_path: Path):
@@ -62,6 +61,7 @@ class TestReplayProfile:
         with pytest.raises(ValueError, match="exactly one data source"):
             ProfileFactory.create(
                 args,
+                42,
                 data=[
                     TraceSyntheticDataArgs(path=tmp_path / "trace-a.jsonl"),
                     TraceSyntheticDataArgs(path=tmp_path / "trace-b.jsonl"),
@@ -78,11 +78,11 @@ class TestReplayProfile:
         missing = tmp_path / "missing.jsonl"
         args = _replay_args()
         with pytest.raises(ValueError, match="not found"):
-            ProfileFactory.create(args, data=[TraceSyntheticDataArgs(path=missing)])
+            ProfileFactory.create(args, 42, data=[TraceSyntheticDataArgs(path=missing)])
 
         empty = _trace_path(tmp_path)
         with pytest.raises(ValueError, match="empty|No timestamps"):
-            ProfileFactory.create(args, data=[TraceSyntheticDataArgs(path=empty)])
+            ProfileFactory.create(args, 42, data=[TraceSyntheticDataArgs(path=empty)])
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -52,6 +52,7 @@ def file_path_report(tmp_path: Path) -> GenerativeBenchmarksReport:
                 "target": "http://localhost:8000/v1",
                 "model": "test-model",
             },
+            "profile": {"kind": "sweep"},
             "data": [
                 {
                     "kind": "json_file",

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -27,6 +27,7 @@ def minimal_report() -> GenerativeBenchmarksReport:
                 "model": "test-model",
             },
             "data": [{"kind": "huggingface", "source": "test_data.jsonl"}],
+            "profile": {"kind": "sweep", "rate": [10.0]},
             "tokenizer": {"kind": "huggingface_auto", "model": "test-model"},
             "data_column_mapper": {"kind": "generative_column_mapper"},
             "data_preprocessors": [],

--- a/tests/unit/benchmark/test_sweep_profile.py
+++ b/tests/unit/benchmark/test_sweep_profile.py
@@ -52,16 +52,16 @@ class TestSweepProfileArgs:
         ## WRITTEN BY AI ##
         """
         profile = await resolve_profile(
-            profile={"kind": "sweep"},
-            rate=[7.0],
-            random_seed=42,
-            rampup=0.0,
+            profile=SweepProfileArgs.model_validate(
+                {"kind": "sweep", "rate": [7.0, 8.0]}
+            ),
             constraints={},
             max_seconds=None,
             max_requests=None,
             max_errors=None,
             max_error_rate=None,
             max_global_error_rate=None,
+            random_seed=42,
         )
         assert isinstance(profile, SweepProfile)
         assert profile.args.sweep_size == 7

--- a/tests/unit/benchmark/test_sweep_profile.py
+++ b/tests/unit/benchmark/test_sweep_profile.py
@@ -38,7 +38,9 @@ class TestSweepProfileArgs:
         ## WRITTEN BY AI ##
         """
         profile = ProfileFactory.create(
-            SweepProfileArgs.model_validate({"kind": "sweep", "rate": [6.0]}), {}
+            SweepProfileArgs.model_validate({"kind": "sweep", "rate": [6.0]}),
+            42,
+            {},
         )
         assert isinstance(profile, SweepProfile)
         assert profile.args.sweep_size == 6


### PR DESCRIPTION
## Summary

Let `BenchmarkGenerativeTextArgs` build the `ProfileArgs` embedded object.

## Details

This is a refactoring that follows up on a discussion during review of #753.

The key was to shuffle data/data_samples from ReplayProfileArgs to ReplayProfile so that we can rely on a built loader by the time we need it. Now we can fully build ProfileArgs up front.

## Test Plan

Ensure proper parsing of profile parameters, particularly,

- [x] merging of global rate & rampup into `ProfileArgs` dict
- [x] proper handling of global `--rate` with aliased `ProfileArgs` parameters

E.g.:

- uv run guidellm benchmark --target http://<vllm> --max-seconds 10 --profile kind=replay,time_scale=0.3 --data kind=trace_synthetic,path=${HOME}/replay.jsonl --rate 5
- uv run guidellm benchmark --target http://<vllm> --max-seconds 10 --data "kind=synthetic_text,prompt_tokens=256,output_tokens=128" --rate 5 --profile kind=async

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3e27713126784bc63c5109ef7027f7ad805b0008
Author: David Butenhof <dbutenho@redhat.com>
Date:   Fri Jun 5 02:03:41 2026 -0400

    Build ProfileArgs in BenchmarkGenerativeTextArgs
    
    This follows up on a discussion in #753.
    
    Shuffle data/data_samples from ReplayProfileArgs to ReplayProfile so that we
    can rely on built loader. Now we can fully build ProfileArgs up front.
    
    Assisted-by: Cursor
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit 66d9025add7f46e9dd7f280db4cafe49d1d4d4ab
Author: David Butenhof <dbutenho@redhat.com>
Date:   Fri Jun 5 15:04:53 2026 -0400

    Pull random_seed back out of kwargs
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit c3cf2d0865080ddfbbde4baa7b1143b9d4b242e8
Author: David Butenhof <dbutenho@redhat.com>
Date:   Fri Jun 5 20:12:36 2026 -0400

    Fix a typo
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit a11f2dd0ad2ee448807e14ef04d9d834019a869d
Author: David Butenhof <dbutenho@redhat.com>
Date:   Mon Jun 8 08:45:01 2026 -0400

    Complain about duplicate rates
    
    More consistent behavior than ignoring one.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit f240157a121895d7bfb3d085c6687244215d1eb4
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jun 9 16:21:31 2026 -0400

    Fix merge queue test breakage
    
    (Yeah, that's why we *have* a merge queue!)
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Assisted-by: Cursor
Signed-off-by: David Butenhof <dbutenho@redhat.com>
