### PR TITLE
Add Mooncake trace format support

### DIFF
--- a/src/guidellm/data/deserializers/__init__.py
+++ b/src/guidellm/data/deserializers/__init__.py
@@ -28,6 +28,7 @@ from .synthetic import (
     SyntheticTextDataset,
     SyntheticTextDatasetDeserializer,
 )
+from .trace_mooncake import TraceMooncakeDataArgs, TraceMooncakeDatasetDeserializer
 from .trace_synthetic import TraceSyntheticDataArgs, TraceSyntheticDatasetDeserializer
 
 __all__ = [
@@ -54,6 +55,8 @@ __all__ = [
     "SyntheticTextDatasetDeserializer",
     "TarFileDatasetDeserializer",
     "TextFileDatasetDeserializer",
+    "TraceMooncakeDataArgs",
+    "TraceMooncakeDatasetDeserializer",
     "TraceSyntheticDataArgs",
     "TraceSyntheticDatasetDeserializer",
 ]

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -9,6 +9,7 @@ benchmarks.
 
 import math
 from collections.abc import Callable
+from typing import Any
 
 from datasets import Dataset
 from faker import Faker
@@ -60,7 +61,7 @@ def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
         )
 
 
-def _is_in_table(hash_id_table: list[list[int]], hash_id: int) -> bool:
+def _is_in_table(hash_id_table: list[Any], hash_id: int) -> bool:
     return (
         hash_id < len(hash_id_table)
         and hash_id >= 0
@@ -68,7 +69,7 @@ def _is_in_table(hash_id_table: list[list[int]], hash_id: int) -> bool:
     )
 
 
-def _resize_to_hold_id(hash_id_table: list[list[int]], hash_id: int) -> None:
+def _resize_to_hold_id(hash_id_table: list[Any], hash_id: int) -> None:
     num_new_entries = hash_id - (len(hash_id_table) - 1)
     hash_id_table.extend(None for _ in range(num_new_entries))
 
@@ -176,8 +177,8 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
         processor = processor_factory()
         faker = Faker()
         faker.seed_instance(random_seed)
-        hash_id_table = []
-        sibling_token_blocks = {}
+        hash_id_table: list[Any] = []
+        sibling_token_blocks: dict[Any, list[list[int]]] = {}
         prompts = []
         for row in rows:
             _validate_row(row, config)

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -64,8 +64,9 @@ def _calculate_required_prompt_tokens(
     """Returns the number of prompt tokens needed to satisfy the row input length.
     This will be less than the block_size if the input length is not divisible by it
     and `hash_id` is the final ID for the row."""
-    if row[config.hash_ids_column][-1] == hash_id:
-        return row[config.prompt_tokens_column] % config.hash_id_block_size
+    remainder = row[config.prompt_tokens_column] % config.hash_id_block_size
+    if row[config.hash_ids_column][-1] == hash_id and remainder != 0:
+        return remainder
     return config.hash_id_block_size
 
 

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -81,7 +81,9 @@ def _generate_token_ids(
     faker: Faker,
 ) -> list[int]:
     """Generate `token_count` synthetic token ids for trace prompt construction."""
-    margin_of_safety = 2
+    # Ideally, `margin_of_safety` should be set to slighty more than
+    # the average number of characters used by tokenizers to form one token.
+    margin_of_safety = 8
     attempt = 0
     while True:
         attempt += 1

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -6,6 +6,7 @@ Reads a trace file (timestamp, input_length, output_length, hash_ids) and yields
 row per line with a synthetic prompt matching the requested input_length for replay
 benchmarks.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -14,11 +15,11 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any, Literal
 
+import numpy as np
 from datasets import Dataset, DatasetInfo, Features, IterableDataset, List, Value
 from datasets.exceptions import DatasetGenerationError
 from datasets.iterable_dataset import _BaseExamplesIterable
 from faker import Faker
-import numpy as np
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
 

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -6,6 +6,7 @@ Reads a trace file (timestamp, input_length, output_length, hash_ids) and yields
 row per line with a synthetic prompt matching the requested input_length for replay
 benchmarks.
 """
+from __future__ import annotations
 
 import dataclasses
 import math
@@ -17,6 +18,7 @@ from datasets import Dataset, DatasetInfo, Features, IterableDataset, List, Valu
 from datasets.exceptions import DatasetGenerationError
 from datasets.iterable_dataset import _BaseExamplesIterable
 from faker import Faker
+import numpy as np
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
 
@@ -266,6 +268,22 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
     @property
     def num_shards(self) -> int:
         return 1
+
+    def shuffle_data_sources(
+        self,
+        generator: np.random.Generator,  # noqa: ARG002
+    ) -> _TraceMooncakeExamplesIterable:
+        """Returns self as sharding is not implemented yet."""
+        return self
+
+    def shard_data_sources(
+        self,
+        num_shards: int,  # noqa: ARG002
+        index: int,  # noqa: ARG002
+        contiguous: bool = True,  # noqa: ARG002
+    ) -> _TraceMooncakeExamplesIterable:
+        """Returns self as sharding is not implemented yet."""
+        return self
 
     def load_state_dict(self, state_dict: dict) -> None:
         """Load the state from a state dict."""

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -235,15 +235,15 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                     )
                     sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
             prompt = _create_prompt_from_hash_ids(ids, hash_id_table, self.processor)
-            self.iteration_count += 1
             yield (
-                self.iteration_count - 1,
+                self.iteration_count,
                 {
                     "prompt_tokens_count": row[self.config.prompt_tokens_column],
                     "output_tokens_count": row[self.config.output_tokens_column],
                     "prompt": prompt,
                 },
             )
+            self.iteration_count += 1
 
     @property
     def is_typed(self) -> bool:

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -9,12 +9,13 @@ benchmarks.
 
 import dataclasses
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any, Literal
 
-from datasets import Dataset, List, Value
+from datasets import Dataset, DatasetInfo, Features, IterableDataset, List, Value
 from datasets.exceptions import DatasetGenerationError
+from datasets.iterable_dataset import _BaseExamplesIterable
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -107,7 +108,7 @@ def _create_distinct_token_block(
         if token_ids not in sibling_token_blocks:
             return token_ids
         attempt += 1
-    raise DataNotSupportedError(
+    raise ValueError(
         f"Failed to generate distinct synthetic token block after {attempt} attempts"
     )
 
@@ -180,6 +181,123 @@ def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
         )
 
 
+class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
+    """Custom examples iterable for synthetic prompt generation. Used to avoid
+    pre-generating a prompt for every row in the dataset on load."""
+
+    def __init__(
+        self,
+        config: TraceMooncakeDataArgs,
+        processor: PreTrainedTokenizerBase,
+        random_seed: int = 42,
+    ):
+        super().__init__()
+        self.config = config
+        self.processor = processor
+        self.faker = Faker()
+        self.faker.seed_instance(random_seed)
+        self.trace_rows = _load_formatted_trace_rows(
+            config.path,
+            Column(config.timestamp_column, Value("float")),
+            required_columns=[
+                Column(config.prompt_tokens_column, Value("int32")),
+                Column(config.output_tokens_column, Value("int32")),
+                Column(config.hash_ids_column, List(Value("int32"))),
+            ],
+        )
+        for row in self.trace_rows:
+            _validate_row(row, self.config)
+        self.iteration_count = 0
+
+    def __iter__(self) -> Iterable[tuple[int, dict[str, Any]]]:
+        hash_id_table: list[Any] = []
+        sibling_token_blocks: dict[Any, list[list[int]]] = {}
+        while True:
+            try:
+                row = self.trace_rows[self.iteration_count]
+            except IndexError:
+                break
+
+            ids = row[self.config.hash_ids_column]
+            for idx, hash_id in enumerate(ids):
+                if not _is_in_table(hash_id_table, hash_id):
+                    _resize_to_hold_id(hash_id_table, hash_id)
+                    prev_id = None if idx == 0 else ids[idx - 1]
+                    num_tokens = _calculate_required_prompt_tokens(
+                        row, self.config, hash_id
+                    )
+                    sibling_token_blocks.setdefault(prev_id, [])
+                    hash_id_table[hash_id] = _create_distinct_token_block(
+                        num_tokens,
+                        sibling_token_blocks[prev_id],
+                        self.processor,
+                        self.faker,
+                    )
+                    sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
+            prompt = _create_prompt_from_hash_ids(ids, hash_id_table, self.processor)
+            self.iteration_count += 1
+            yield (
+                self.iteration_count - 1,
+                {
+                    "prompt_tokens_count": row[self.config.prompt_tokens_column],
+                    "output_tokens_count": row[self.config.output_tokens_column],
+                    "prompt": prompt,
+                },
+            )
+
+    @property
+    def is_typed(self) -> bool:
+        return True
+
+    @property
+    def features(self) -> Features:
+        return Features(
+            {
+                "prompt": Value("string"),
+                "prompt_tokens_count": Value("int32"),
+                "output_tokens_count": Value("int32"),
+            }
+        )
+
+    @property
+    def num_shards(self) -> int:
+        return 1
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        """Load the state from a state dict."""
+        self.iteration_count = state_dict.get("iteration_count", 0)
+
+    def _init_state_dict(self):
+        """Initialize the state dict for the iterable."""
+        self._state_dict = {"iteration_count": self.iteration_count}
+        return self._state_dict
+
+
+class _TraceMooncakeDataset(IterableDataset):
+    def __init__(
+        self,
+        config: TraceMooncakeDataArgs,
+        processor: PreTrainedTokenizerBase,
+        random_seed: int = 42,
+    ):
+        self.config = config
+        self.processor = processor
+        self.random_seed = random_seed
+        ex_iterable = _TraceMooncakeExamplesIterable(config, processor, random_seed)
+        super().__init__(
+            ex_iterable=ex_iterable,
+            info=DatasetInfo(
+                description="Mooncake trace dataset generator",
+                features=ex_iterable.features,
+            ),
+        )
+
+    def set_epoch(self, epoch: int):
+        """Set the epoch for the dataset iteration."""
+        if isinstance(self._ex_iterable, _TraceMooncakeExamplesIterable):
+            self._ex_iterable.iteration_count = epoch
+
+
 @DatasetDeserializerFactory.register("mooncake")
 class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
     """Mooncake trace format requires a column for timestamps, prompt token counts,
@@ -199,48 +317,10 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
         config: TraceMooncakeDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> IterableDataset:
         if not config.path.is_file():
             raise DataNotSupportedError(
                 f"{type(self).__name__} expects a path to a trace file, "
                 f"got {config.path}"
             )
-        rows = _load_formatted_trace_rows(
-            config.path,
-            Column(config.timestamp_column, Value("float")),
-            required_columns=[
-                Column(config.prompt_tokens_column, Value("int64")),
-                Column(config.output_tokens_column, Value("int64")),
-                Column(config.hash_ids_column, List(Value("int64"))),
-            ],
-        )
-        processor = processor_factory()
-        faker = Faker()
-        faker.seed_instance(random_seed)
-        hash_id_table: list[Any] = []
-        sibling_token_blocks: dict[Any, list[list[int]]] = {}
-        prompts = []
-        for row in rows:
-            _validate_row(row, config)
-            ids = row[config.hash_ids_column]
-            for idx, hash_id in enumerate(ids):
-                if not _is_in_table(hash_id_table, hash_id):
-                    _resize_to_hold_id(hash_id_table, hash_id)
-                    prev_id = None if idx == 0 else ids[idx - 1]
-                    num_tokens = _calculate_required_prompt_tokens(row, config, hash_id)
-                    sibling_token_blocks.setdefault(prev_id, [])
-                    hash_id_table[hash_id] = _create_distinct_token_block(
-                        num_tokens, sibling_token_blocks[prev_id], processor, faker
-                    )
-                    sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
-            prompt = _create_prompt_from_hash_ids(ids, hash_id_table, processor)
-            prompts.append(prompt)
-
-        return Dataset.from_dict(
-            {
-                "prompt": prompts,
-                "prompt_tokens_count": rows[config.prompt_tokens_column],
-                "output_tokens_count": rows[config.output_tokens_column],
-            },
-            **config.load_kwargs,
-        )
+        return _TraceMooncakeDataset(config, processor_factory(), random_seed)

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -75,7 +75,7 @@ def _calculate_required_prompt_tokens(
 
 
 def _generate_token_ids(
-    amount: int, processor: PreTrainedTokenizerBase, faker: Faker, max_attempts: int = 8
+    token_count: int, processor: PreTrainedTokenizerBase, faker: Faker, max_attempts: int = 8
 ) -> list[int]:
     """Generate `amount` synthetic token ids for trace prompt construction."""
     margin_of_safety = 2
@@ -83,30 +83,30 @@ def _generate_token_ids(
     while attempt < max_attempts:
         attempt += 1
         # The Faker.text() can only generate text of at least 5 characters.
-        num_chars = max(amount * margin_of_safety * attempt, 5)
+        num_chars = max(token_count * margin_of_safety * attempt, 5)
         text = faker.text(max_nb_chars=num_chars)
         token_ids = processor.encode(text)
-        if len(token_ids) >= amount:
-            return token_ids[:amount]
+        if len(token_ids) >= token_count:
+            return token_ids[:token_count]
     raise DataNotSupportedError(
         "Failed to generate enough synthetic prompt tokens for "
-        f"{amount} tokens after {attempt} attempts"
+        f"{token_count} tokens after {attempt} attempts"
     )
 
 
 def _create_distinct_token_block(
     block_size: int,
-    exhausted_token_blocks: list[list[int]],
+    sibling_token_blocks: list[list[int]],
     processor: PreTrainedTokenizerBase,
     faker: Faker,
-    max_distinctness_attempts: int = 20,
+    max_attempts: int = 20,
 ) -> list[int]:
     """Constructs a new token block of `block_size` that does not appear in
     `sibling_nodes`."""
     attempt = 0
-    while attempt < max_distinctness_attempts:
+    while attempt < max_attempts:
         token_ids = _generate_token_ids(block_size, processor, faker)
-        if token_ids not in exhausted_token_blocks:
+        if token_ids not in sibling_token_blocks:
             return token_ids
         attempt += 1
     raise DataNotSupportedError(

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -31,7 +31,7 @@ from guidellm.utils.trace_io import load_trace_rows
 __all__ = ["TraceMooncakeDataArgs", "TraceMooncakeDatasetDeserializer"]
 
 
-@DataArgs.register("trace_mooncake")
+@DataArgs.register("mooncake")
 class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
     kind: Literal["trace_mooncake"] = Field(  # type: ignore[assignment]
         default="trace_mooncake",
@@ -75,9 +75,12 @@ def _calculate_required_prompt_tokens(
 
 
 def _generate_token_ids(
-    token_count: int, processor: PreTrainedTokenizerBase, faker: Faker, max_attempts: int = 8
+    token_count: int,
+    processor: PreTrainedTokenizerBase,
+    faker: Faker,
+    max_attempts: int = 8,
 ) -> list[int]:
-    """Generate `amount` synthetic token ids for trace prompt construction."""
+    """Generate `token_count` synthetic token ids for trace prompt construction."""
     margin_of_safety = 2
     attempt = 0
     while attempt < max_attempts:
@@ -102,7 +105,7 @@ def _create_distinct_token_block(
     max_attempts: int = 20,
 ) -> list[int]:
     """Constructs a new token block of `block_size` that does not appear in
-    `sibling_nodes`."""
+    `sibling_token_blocks`."""
     attempt = 0
     while attempt < max_attempts:
         token_ids = _generate_token_ids(block_size, processor, faker)
@@ -182,7 +185,7 @@ def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
         )
 
 
-@DatasetDeserializerFactory.register("trace_mooncake")
+@DatasetDeserializerFactory.register("mooncake")
 class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
     """Mooncake trace format requires a column for timestamps, prompt token counts,
     ouput token counts and lists of hash IDs.

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -7,9 +7,9 @@ row per line with a synthetic prompt matching the requested input_length for rep
 benchmarks.
 """
 
-from collections.abc import Callable
 import dataclasses
 import math
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -137,7 +137,7 @@ def _load_formatted_trace_rows(
     path: Path,
     timestamp_column: Column,
     required_columns: list[Column],
-) -> list[dict[str, Any]]:
+) -> Dataset:
     """Load a trace file and format the columns."""
     try:
         rows = load_trace_rows(
@@ -170,9 +170,7 @@ def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
         )
     for hash_id in row[config.hash_ids_column]:
         if hash_id < 0:
-            raise DataNotSupportedError(
-                f"Hash ID must be non-negative, got {hash_id}"
-            )
+            raise DataNotSupportedError(f"Hash ID must be non-negative, got {hash_id}")
     if math.ceil(n_in / config.hash_id_block_size) != n_blocks:
         raise DataNotSupportedError(
             f"Input token count of {n_in} split into blocks of size "
@@ -212,7 +210,7 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
                 Column(config.prompt_tokens_column, Value("int64")),
                 Column(config.output_tokens_column, Value("int64")),
                 Column(config.hash_ids_column, List(Value("int64"))),
-            ]
+            ],
         )
         processor = processor_factory()
         faker = Faker()
@@ -227,9 +225,7 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
                 if not _is_in_table(hash_id_table, hash_id):
                     _resize_to_hold_id(hash_id_table, hash_id)
                     prev_id = None if idx == 0 else ids[idx - 1]
-                    num_tokens = _calculate_required_prompt_tokens(
-                        row, config, hash_id
-                    )
+                    num_tokens = _calculate_required_prompt_tokens(row, config, hash_id)
                     sibling_token_blocks.setdefault(prev_id, [])
                     hash_id_table[hash_id] = _create_distinct_token_block(
                         num_tokens, sibling_token_blocks[prev_id], processor, faker

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -78,12 +78,11 @@ def _generate_token_ids(
     token_count: int,
     processor: PreTrainedTokenizerBase,
     faker: Faker,
-    max_attempts: int = 8,
 ) -> list[int]:
     """Generate `token_count` synthetic token ids for trace prompt construction."""
     margin_of_safety = 2
     attempt = 0
-    while attempt < max_attempts:
+    while True:
         attempt += 1
         # The Faker.text() can only generate text of at least 5 characters.
         num_chars = max(token_count * margin_of_safety * attempt, 5)
@@ -91,10 +90,6 @@ def _generate_token_ids(
         token_ids = processor.encode(text)
         if len(token_ids) >= token_count:
             return token_ids[:token_count]
-    raise DataNotSupportedError(
-        "Failed to generate enough synthetic prompt tokens for "
-        f"{token_count} tokens after {attempt} attempts"
-    )
 
 
 def _create_distinct_token_block(

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -34,8 +34,8 @@ __all__ = ["TraceMooncakeDataArgs", "TraceMooncakeDatasetDeserializer"]
 
 @DataArgs.register("mooncake")
 class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
-    kind: Literal["trace_mooncake"] = Field(  # type: ignore[assignment]
-        default="trace_mooncake",
+    kind: Literal["mooncake"] = Field(  # type: ignore[assignment]
+        default="mooncake",
         description="Type identifier for the trace Mooncake dataset deserializer.",
     )
     hash_ids_column: str = Field(

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -241,7 +241,6 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
                 "prompt": prompts,
                 "prompt_tokens_count": rows[config.prompt_tokens_column],
                 "output_tokens_count": rows[config.output_tokens_column],
-                "hash_ids": rows[config.hash_ids_column],
             },
             **config.load_kwargs,
         )

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -247,6 +247,7 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                     "prompt": prompt,
                 },
             )
+            row_idx += 1
 
     @property
     def is_typed(self) -> bool:

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -11,7 +11,7 @@ import dataclasses
 import math
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from datasets import Dataset, List, Value
 from datasets.exceptions import DatasetGenerationError
@@ -33,6 +33,10 @@ __all__ = ["TraceMooncakeDataArgs", "TraceMooncakeDatasetDeserializer"]
 
 @DataArgs.register("trace_mooncake")
 class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
+    kind: Literal["trace_mooncake"] = Field(  # type: ignore[assignment]
+        default="trace_mooncake",
+        description="Type identifier for the trace Mooncake dataset deserializer.",
+    )
     hash_ids_column: str = Field(
         default="hash_ids",
         description="Column name for lists of hash IDs in the trace file.",

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -210,11 +210,13 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
         self.iteration_count = 0
 
     def __iter__(self) -> Iterable[tuple[int, dict[str, Any]]]:
+        self.iteration_count += 1
+        row_idx = 0
         hash_id_table: list[Any] = []
         sibling_token_blocks: dict[Any, list[list[int]]] = {}
         while True:
             try:
-                row = self.trace_rows[self.iteration_count]
+                row = self.trace_rows[row_idx]
             except IndexError:
                 break
 
@@ -236,14 +238,13 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                     sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
             prompt = _create_prompt_from_hash_ids(ids, hash_id_table, self.processor)
             yield (
-                self.iteration_count,
+                row_idx,
                 {
                     "prompt_tokens_count": row[self.config.prompt_tokens_column],
                     "output_tokens_count": row[self.config.output_tokens_column],
                     "prompt": prompt,
                 },
             )
-            self.iteration_count += 1
 
     @property
     def is_typed(self) -> bool:

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -7,11 +7,14 @@ row per line with a synthetic prompt matching the requested input_length for rep
 benchmarks.
 """
 
-import math
 from collections.abc import Callable
+import dataclasses
+import math
+from pathlib import Path
 from typing import Any
 
-from datasets import Dataset
+from datasets import Dataset, List, Value
+from datasets.exceptions import DatasetGenerationError
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -42,25 +45,6 @@ class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
     )
 
 
-def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
-    n_in = row[config.prompt_tokens_column]
-    n_out = row[config.output_tokens_column]
-    n_blocks = len(row[config.hash_ids_column])
-    if n_in < 0 or n_out < 0:
-        raise DataNotSupportedError(
-            f"Trace token counts must be non-negative, got "
-            f"input_length={n_in}, output_length={n_out}"
-        )
-    for hash_id in row[config.hash_ids_column]:
-        if hash_id < 0:
-            raise ValueError(f"Hash ID must be non-negative, got {hash_id}.")
-    if math.ceil(n_in / config.hash_id_block_size) != n_blocks:
-        raise DataNotSupportedError(
-            f"Input token count of {n_in} split into blocks of size "
-            f"{config.hash_id_block_size} does not match expected {n_blocks} blocks."
-        )
-
-
 def _is_in_table(hash_id_table: list[Any], hash_id: int) -> bool:
     return (
         hash_id < len(hash_id_table)
@@ -74,13 +58,15 @@ def _resize_to_hold_id(hash_id_table: list[Any], hash_id: int) -> None:
     hash_id_table.extend(None for _ in range(num_new_entries))
 
 
-def _calculate_required_prompt_tokens(block_size: int, row: dict, hash_id: int) -> int:
+def _calculate_required_prompt_tokens(
+    row: dict, config: TraceMooncakeDataArgs, hash_id: int
+) -> int:
     """Returns the number of prompt tokens needed to satisfy the row input length.
-    This will be less than `block_size` if the input length is not divisible by it and
-    `hash_id` is the final ID for the row."""
-    if row["hash_ids"][-1] == hash_id:
-        return block_size - row["input_length"] % block_size
-    return block_size
+    This will be less than the block_size if the input length is not divisible by it
+    and `hash_id` is the final ID for the row."""
+    if row[config.hash_ids_column][-1] == hash_id:
+        return row[config.prompt_tokens_column] % config.hash_id_block_size
+    return config.hash_id_block_size
 
 
 def _generate_token_ids(
@@ -99,7 +85,7 @@ def _generate_token_ids(
             return token_ids[:amount]
     raise DataNotSupportedError(
         "Failed to generate enough synthetic prompt tokens for "
-        f"{amount} tokens after {attempt} attempts."
+        f"{amount} tokens after {attempt} attempts"
     )
 
 
@@ -119,7 +105,7 @@ def _create_distinct_token_block(
             return token_ids
         attempt += 1
     raise DataNotSupportedError(
-        f"Failed to generate distinct synthetic token block after {attempt} attempts."
+        f"Failed to generate distinct synthetic token block after {attempt} attempts"
     )
 
 
@@ -138,6 +124,59 @@ def _create_prompt_from_hash_ids(
     if isinstance(prompt, list):
         return prompt[0] if prompt else ""
     return prompt
+
+
+@dataclasses.dataclass
+class Column:
+    name: str
+    feature_type: Value
+
+
+def _load_formatted_trace_rows(
+    path: Path,
+    timestamp_column: Column,
+    required_columns: list[Column],
+) -> list[dict[str, Any]]:
+    """Load a trace file and format the columns."""
+    try:
+        rows = load_trace_rows(
+            path,
+            [col.name for col in required_columns],
+            timestamp_column.name,
+        )
+    except (DatasetGenerationError, KeyError, ValueError) as e:
+        raise DataNotSupportedError(str(e)) from e
+    if not rows:
+        raise DataNotSupportedError("Trace file is empty")
+    for col in [timestamp_column] + required_columns:
+        if rows.data[col.name].null_count != 0:
+            raise DataNotSupportedError(f"NoneType found in {col}")
+        try:
+            rows.cast_column(col.name, col.feature_type)
+        except ValueError as e:
+            raise DataNotSupportedError(str(e)) from e
+    return rows
+
+
+def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
+    n_in = row[config.prompt_tokens_column]
+    n_out = row[config.output_tokens_column]
+    n_blocks = len(row[config.hash_ids_column])
+    if n_in < 0 or n_out < 0:
+        raise DataNotSupportedError(
+            f"Trace token counts must be non-negative, got "
+            f"input_length={n_in}, output_length={n_out}"
+        )
+    for hash_id in row[config.hash_ids_column]:
+        if hash_id < 0:
+            raise DataNotSupportedError(
+                f"Hash ID must be non-negative, got {hash_id}"
+            )
+    if math.ceil(n_in / config.hash_id_block_size) != n_blocks:
+        raise DataNotSupportedError(
+            f"Input token count of {n_in} split into blocks of size "
+            f"{config.hash_id_block_size} does not match given {n_blocks} blocks"
+        )
 
 
 @DatasetDeserializerFactory.register("trace_mooncake")
@@ -165,14 +204,14 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
                 f"{type(self).__name__} expects a path to a trace file, "
                 f"got {config.path}"
             )
-        rows = load_trace_rows(
+        rows = _load_formatted_trace_rows(
             config.path,
+            Column(config.timestamp_column, Value("float")),
             required_columns=[
-                config.prompt_tokens_column,
-                config.output_tokens_column,
-                config.hash_ids_column,
-            ],
-            timestamp_column=config.timestamp_column,
+                Column(config.prompt_tokens_column, Value("int64")),
+                Column(config.output_tokens_column, Value("int64")),
+                Column(config.hash_ids_column, List(Value("int64"))),
+            ]
         )
         processor = processor_factory()
         faker = Faker()
@@ -188,7 +227,7 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
                     _resize_to_hold_id(hash_id_table, hash_id)
                     prev_id = None if idx == 0 else ids[idx - 1]
                     num_tokens = _calculate_required_prompt_tokens(
-                        config.hash_id_block_size, row, hash_id
+                        row, config, hash_id
                     )
                     sibling_token_blocks.setdefault(prev_id, [])
                     hash_id_table[hash_id] = _create_distinct_token_block(

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -1,16 +1,16 @@
 """
-Trace deserializer for Mooncake formatted files that generates synthetic prompts per row.
+Trace deserializer for Mooncake formatted files that generates synthetic prompts per
+row.
 
-Reads a trace file (timestamp, input_length, output_length, hash_ids) and yields one row per
-line with a synthetic prompt matching the requested input_length for replay benchmarks.
+Reads a trace file (timestamp, input_length, output_length, hash_ids) and yields one
+row per line with a synthetic prompt matching the requested input_length for replay
+benchmarks.
 """
 
+import math
 from collections.abc import Callable
-from pathlib import Path
-from typing import Any, Literal
 
 from datasets import Dataset
-from datasets.exceptions import DatasetGenerationError
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -30,14 +30,113 @@ __all__ = ["TraceMooncakeDataArgs", "TraceMooncakeDatasetDeserializer"]
 @DataArgs.register("trace_mooncake")
 class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
     hash_ids_column: str = Field(
-        default = "hash_ids",
-        description = "Column name for lists of hash IDs in the trace file."
+        default="hash_ids",
+        description="Column name for lists of hash IDs in the trace file.",
     )
     hash_id_block_size: int = Field(
-        gt = 0,
-        default = 512,  # Default used in Mooncake's paper https://arxiv.org/pdf/2407.00079
-        description = "Amount of tokens represented by one hash ID."
+        gt=0,
+        # Default used in Mooncake's paper https://arxiv.org/pdf/2407.00079
+        default=512,
+        description="Amount of tokens represented by one hash ID.",
     )
+
+
+def _validate_row(row: dict, config: TraceMooncakeDataArgs) -> None:
+    n_in = row[config.prompt_tokens_column]
+    n_out = row[config.output_tokens_column]
+    n_blocks = len(row[config.hash_ids_column])
+    if n_in < 0 or n_out < 0:
+        raise DataNotSupportedError(
+            f"Trace token counts must be non-negative, got "
+            f"input_length={n_in}, output_length={n_out}"
+        )
+    for hash_id in row[config.hash_ids_column]:
+        if hash_id < 0:
+            raise ValueError(f"Hash ID must be non-negative, got {hash_id}.")
+    if math.ceil(n_in / config.hash_id_block_size) != n_blocks:
+        raise DataNotSupportedError(
+            f"Input token count of {n_in} split into blocks of size "
+            f"{config.hash_id_block_size} does not match expected {n_blocks} blocks."
+        )
+
+
+def _is_in_table(hash_id_table: list[list[int]], hash_id: int) -> bool:
+    return (
+        hash_id < len(hash_id_table)
+        and hash_id >= 0
+        and hash_id_table[hash_id] is not None
+    )
+
+
+def _resize_to_hold_id(hash_id_table: list[list[int]], hash_id: int) -> None:
+    num_new_entries = hash_id - (len(hash_id_table) - 1)
+    hash_id_table.extend(None for _ in range(num_new_entries))
+
+
+def _calculate_required_prompt_tokens(block_size: int, row: dict, hash_id: int) -> int:
+    """Returns the number of prompt tokens needed to satisfy the row input length.
+    This will be less than `block_size` if the input length is not divisible by it and
+    `hash_id` is the final ID for the row."""
+    if row["hash_ids"][-1] == hash_id:
+        return block_size - row["input_length"] % block_size
+    return block_size
+
+
+def _generate_token_ids(
+    amount: int, processor: PreTrainedTokenizerBase, faker: Faker, max_attempts: int = 8
+) -> list[int]:
+    """Generate `amount` synthetic token ids for trace prompt construction."""
+    margin_of_safety = 2
+    attempt = 0
+    while attempt < max_attempts:
+        attempt += 1
+        # The Faker.text() can only generate text of at least 5 characters.
+        num_chars = max(amount * margin_of_safety * attempt, 5)
+        text = faker.text(max_nb_chars=num_chars)
+        token_ids = processor.encode(text)
+        if len(token_ids) >= amount:
+            return token_ids[:amount]
+    raise DataNotSupportedError(
+        "Failed to generate enough synthetic prompt tokens for "
+        f"{amount} tokens after {attempt} attempts."
+    )
+
+
+def _create_distinct_token_block(
+    block_size: int,
+    exhausted_token_blocks: list[list[int]],
+    processor: PreTrainedTokenizerBase,
+    faker: Faker,
+    max_distinctness_attempts: int = 20,
+) -> list[int]:
+    """Constructs a new token block of `block_size` that does not appear in
+    `sibling_nodes`."""
+    attempt = 0
+    while attempt < max_distinctness_attempts:
+        token_ids = _generate_token_ids(block_size, processor, faker)
+        if token_ids not in exhausted_token_blocks:
+            return token_ids
+        attempt += 1
+    raise DataNotSupportedError(
+        f"Failed to generate distinct synthetic token block after {attempt} attempts."
+    )
+
+
+def _create_prompt_from_hash_ids(
+    hash_ids: list[int],
+    hash_id_table: list[list[int]],
+    processor: PreTrainedTokenizerBase,
+) -> str:
+    """Returns a synthetic prompt from `hash_ids` using pre-generated token blocks.
+
+    Precondition: All ids in `hash_ids` appear in `hash_id_table`."""
+    prompt_token_ids = [
+        token for hash_id in hash_ids for token in hash_id_table[hash_id]
+    ]
+    prompt = processor.decode(prompt_token_ids, skip_special_tokens=True)
+    if isinstance(prompt, list):
+        return prompt[0] if prompt else ""
+    return prompt
 
 
 @DatasetDeserializerFactory.register("trace_mooncake")
@@ -49,8 +148,8 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
     blocks in a prompt. The relationships of IDs forms a tree, where every first ID
     in a prompt has a parent node of `None`. Parent nodes can have an unbounded
     number of children. Two hash IDs can represent identical blocks of tokens so long
-    as they do not share the same parent (previous ID). For more details, see section 4 of
-    https://arxiv.org/pdf/2407.00079.
+    as they do not share the same parent (previous ID). For more details, see section 4
+    of https://arxiv.org/pdf/2407.00079.
 
     Generated prompts match the prompt token count of the row."""
 
@@ -58,6 +157,52 @@ class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
         self,
         config: TraceMooncakeDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
-        random_seed: int
+        random_seed: int,
     ) -> Dataset:
-        ...
+        if not config.path.is_file():
+            raise DataNotSupportedError(
+                f"{type(self).__name__} expects a path to a trace file, "
+                f"got {config.path}"
+            )
+        rows = load_trace_rows(
+            config.path,
+            required_columns=[
+                config.prompt_tokens_column,
+                config.output_tokens_column,
+                config.hash_ids_column,
+            ],
+            timestamp_column=config.timestamp_column,
+        )
+        processor = processor_factory()
+        faker = Faker()
+        faker.seed_instance(random_seed)
+        hash_id_table = []
+        sibling_token_blocks = {}
+        prompts = []
+        for row in rows:
+            _validate_row(row, config)
+            ids = row[config.hash_ids_column]
+            for idx, hash_id in enumerate(ids):
+                if not _is_in_table(hash_id_table, hash_id):
+                    _resize_to_hold_id(hash_id_table, hash_id)
+                    prev_id = None if idx == 0 else ids[idx - 1]
+                    num_tokens = _calculate_required_prompt_tokens(
+                        config.hash_id_block_size, row, hash_id
+                    )
+                    sibling_token_blocks.setdefault(prev_id, [])
+                    hash_id_table[hash_id] = _create_distinct_token_block(
+                        num_tokens, sibling_token_blocks[prev_id], processor, faker
+                    )
+                    sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
+            prompt = _create_prompt_from_hash_ids(ids, hash_id_table, processor)
+            prompts.append(prompt)
+
+        return Dataset.from_dict(
+            {
+                "prompt": prompts,
+                "prompt_tokens_count": rows[config.prompt_tokens_column],
+                "output_tokens_count": rows[config.output_tokens_column],
+                "hash_ids": rows[config.hash_ids_column],
+            },
+            **config.load_kwargs,
+        )

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -1,0 +1,63 @@
+"""
+Trace deserializer for Mooncake formatted files that generates synthetic prompts per row.
+
+Reads a trace file (timestamp, input_length, output_length, hash_ids) and yields one row per
+line with a synthetic prompt matching the requested input_length for replay benchmarks.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from datasets import Dataset
+from datasets.exceptions import DatasetGenerationError
+from faker import Faker
+from pydantic import Field
+from transformers import PreTrainedTokenizerBase
+
+from guidellm.data.deserializers.deserializer import (
+    DataNotSupportedError,
+    DatasetDeserializer,
+    DatasetDeserializerFactory,
+)
+from guidellm.data.deserializers.trace_synthetic import TraceSyntheticDataArgs
+from guidellm.data.schemas import DataArgs
+from guidellm.utils.trace_io import load_trace_rows
+
+__all__ = ["TraceMooncakeDataArgs", "TraceMooncakeDatasetDeserializer"]
+
+
+@DataArgs.register("trace_mooncake")
+class TraceMooncakeDataArgs(TraceSyntheticDataArgs):
+    hash_ids_column: str = Field(
+        default = "hash_ids",
+        description = "Column name for lists of hash IDs in the trace file."
+    )
+    hash_id_block_size: int = Field(
+        gt = 0,
+        default = 512,  # Default used in Mooncake's paper https://arxiv.org/pdf/2407.00079
+        description = "Amount of tokens represented by one hash ID."
+    )
+
+
+@DatasetDeserializerFactory.register("trace_mooncake")
+class TraceMooncakeDatasetDeserializer(DatasetDeserializer):
+    """Mooncake trace format requires a column for timestamps, prompt token counts,
+    ouput token counts and lists of hash IDs.
+
+    Hash IDs are globally unique identifiers based on the current and previous token
+    blocks in a prompt. The relationships of IDs forms a tree, where every first ID
+    in a prompt has a parent node of `None`. Parent nodes can have an unbounded
+    number of children. Two hash IDs can represent identical blocks of tokens so long
+    as they do not share the same parent (previous ID). For more details, see section 4 of
+    https://arxiv.org/pdf/2407.00079.
+
+    Generated prompts match the prompt token count of the row."""
+
+    def __call__(
+        self,
+        config: TraceMooncakeDataArgs,
+        processor_factory: Callable[[], PreTrainedTokenizerBase],
+        random_seed: int
+    ) -> Dataset:
+        ...

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-from datasets import Dataset
+from datasets import IterableDataset
 from pydantic import ValidationError
 
 from guidellm.data.deserializers.trace_mooncake import (
@@ -53,7 +53,9 @@ def _write_trace(tmp_path: Path, content: str, suffix: str = ".jsonl") -> Path:
     return path
 
 
-def _make_valid_hash_ids(n_rows: int, prompt_lengths: list[int], block_size: int):
+def _make_valid_hash_ids(
+    n_rows: int, prompt_lengths: list[int], block_size: int
+) -> list[list[int]]:
     """The final token block of every row may be less than the hash id block
     size due to the prompt length not being divisible by it. Use this
     when testing large trace prompts to avoid including token blocks with
@@ -138,13 +140,12 @@ class TestTraceMooncakeDatasetDeserializer:
             ),
         )
         ds = self._deserialize(deserializer, trace)
-        assert isinstance(ds, Dataset)
-        assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
-        assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
-        for prompt, token_count in zip(
-            ds["prompt"], ds["prompt_tokens_count"], strict=True
-        ):
-            assert len(_ascending_processor().encode(prompt)) == token_count
+        assert isinstance(ds, IterableDataset)
+        proc = _ascending_processor()
+        for i, row in enumerate(ds):
+            assert row["prompt_tokens_count"] == i + 1
+            assert row["output_tokens_count"] == (i + 1) * 10
+            assert len(proc.encode(row["prompt"])) == row["prompt_tokens_count"]
 
     @pytest.mark.smoke
     def test_honors_custom_column_names(self, tmp_path: Path, deserializer):
@@ -169,8 +170,9 @@ class TestTraceMooncakeDatasetDeserializer:
             output_tokens_column="generated_tokens",
             hash_ids_column="ids",
         )
-        assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
-        assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
+        for i, row in enumerate(ds):
+            assert row["prompt_tokens_count"] == i + 1
+            assert row["output_tokens_count"] == (i + 1) * 10
 
     @pytest.mark.smoke
     def test_custom_hash_id_block_size(self, tmp_path: Path, deserializer):
@@ -221,14 +223,15 @@ class TestTraceMooncakeDatasetDeserializer:
             processor_factory=lambda: processor,
             random_seed=42,
         )
-        assert ds["prompt_tokens_count"] == prompt_lengths
-        assert ds["output_tokens_count"] == output_lengths
-        assert processor.encode.call_count <= sum([sum(i) for i in hash_ids])
-        for prompt, token_count in zip(
-            ds["prompt"], ds["prompt_tokens_count"], strict=True
-        ):
-            if len(processor.encode(prompt)) != token_count:
-                pytest.fail(f"{len(processor.encode(prompt))} != {token_count}")
+
+        for i, row in enumerate(ds):
+            in_cnt = row["prompt_tokens_count"]
+            assert in_cnt == prompt_lengths[i]
+            assert row["output_tokens_count"] == output_lengths[i]
+
+            actual_prompt_length = len(processor.encode(row["prompt"]))
+            if actual_prompt_length != in_cnt:
+                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
 
     @pytest.mark.smoke
     def test_rejects_invalid_path(self, deserializer):
@@ -271,7 +274,7 @@ class TestTraceMooncakeDatasetDeserializer:
                 '{"timestamp": 0, "input_length": "bad", "output_length": 5, '
                 '"hash_ids": [0]}\n',
                 {},
-                "scalar of type int64",
+                "scalar of type int32",
             ),
             (
                 '{"timestamp": 0, "input_length": 10, "output_length": null, '
@@ -327,12 +330,14 @@ class TestTraceMooncakeDatasetDeserializer:
             ),
         )
         config = TraceMooncakeDataArgs(path=trace)
-        with pytest.raises(DataNotSupportedError, match="generate distinct"):
-            deserializer(
-                config=config,
-                processor_factory=lambda: _ascending_processor(),
-                random_seed=42,
-            )
+        ds = deserializer(
+            config=config,
+            processor_factory=lambda: _ascending_processor(),
+            random_seed=42,
+        )
+        with pytest.raises(ValueError, match="generate distinct"):
+            for _ in ds:
+                ...
 
     @pytest.mark.smoke
     def test_token_block_distinctness(self, tmp_path: Path, deserializer):
@@ -356,7 +361,9 @@ class TestTraceMooncakeDatasetDeserializer:
             processor_factory=lambda: _compatible_processor(),
             random_seed=42,
         )
-        root_block = [ds["prompt"][row][:n_in//2] for row in range(n_rows)]
-        sibling_blocks = [ds["prompt"][row][n_in//2:] for row in range(n_rows)]
-        assert _all_equal(root_block)
+        root_blocks, sibling_blocks = zip(
+            *[(row["prompt"][: n_in // 2], row["prompt"][n_in // 2 :]) for row in ds],
+            strict=False,
+        )
+        assert _all_equal(root_blocks)
         assert _all_distinct(sibling_blocks)

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -106,7 +106,9 @@ class TraceColumn:
 
 def _generate_trace(num_rows: int, columns: list[TraceColumn]) -> str:
     return "\n".join(
-        f"{{{', '.join(f'"{col.name}": {col.data_generator(idx)}' for col in columns)}}}"
+        "{"
+        + ", ".join(f'"{col.name}": {col.data_generator(idx)}' for col in columns)
+        + "}"
         for idx in range(num_rows)
     )
 

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -1,9 +1,10 @@
 import copy
 import dataclasses
+import itertools
 import math
 import random
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 from unittest.mock import Mock
 
 from datasets import Dataset
@@ -59,6 +60,36 @@ def _write_trace(tmp_path: Path, content: str, suffix: str = ".jsonl") -> Path:
     path = tmp_path / f"trace{suffix}"
     path.write_text(content)
     return path
+
+
+def _make_valid_hash_ids(n_rows: int, prompt_lengths: list[int], block_size: int):
+    """The final token block of every row may be less than the hash id block
+    size due to the prompt length not being divisible by it. Use this
+    when testing large trace prompts to avoid including token blocks with
+    less than the block size in the middle of later rows."""
+    tail_hash_ids = []
+    original_prompt_positions = dict(zip(prompt_lengths, range(n_rows)))
+    sorted_lengths = copy.deepcopy(prompt_lengths)
+    sorted_lengths.sort()
+    hash_ids = [None for _ in range(n_rows)]
+    for length in sorted_lengths:
+        original_position = original_prompt_positions[length]
+        n_blocks = math.ceil(length / block_size)
+        n_to_generate = n_blocks + len(tail_hash_ids)
+        hash_ids[original_position] = [
+            i for i in range(n_to_generate) if i not in tail_hash_ids
+        ]
+        tail_hash_ids.append(hash_ids[original_position][-1])
+    return hash_ids
+
+
+def _all_equal(items: list):
+    return len(set(items)) == 1
+
+
+def _all_distinct(items: list):
+    seen = set()
+    return not any(i in seen or seen.add(i) for i in items)
 
 
 @dataclasses.dataclass
@@ -161,28 +192,6 @@ class TestTraceMooncakeDatasetDeserializer():
             ]),
         )
         self._deserialize(deserializer, trace, hash_id_block_size=n_in / 5)
-    
-    def _make_valid_hash_ids(
-        self, n_rows: int, prompt_lengths: list[int], block_size: int
-    ):
-        """The final token block of every row may be less than the hash id block
-        size due to the prompt length not being divisible by it. Use this
-        when testing large trace prompts to avoid including token blocks with
-        less than the block size in the middle of later rows."""
-        tail_hash_ids = []
-        original_prompt_positions = dict(zip(prompt_lengths, range(n_rows)))
-        sorted_lengths = copy.deepcopy(prompt_lengths)
-        sorted_lengths.sort()
-        hash_ids = [None for _ in range(n_rows)]
-        for length in sorted_lengths:
-            original_position = original_prompt_positions[length]
-            n_blocks = math.ceil(length / block_size)
-            n_to_generate = n_blocks + len(tail_hash_ids)
-            hash_ids[original_position] = [
-                i for i in range(n_to_generate) if i not in tail_hash_ids
-            ]
-            tail_hash_ids.append(hash_ids[original_position][-1])
-        return hash_ids
 
     @pytest.mark.smoke
     def test_generates_large_trace_prompts(self, tmp_path: Path, deserializer):
@@ -193,7 +202,7 @@ class TestTraceMooncakeDatasetDeserializer():
         times = [0.0, 0.5, 1.0, 2.0]
         timestamps = [times[int(i / n_rows * len(times))] for i in range(n_rows)]
         block_size = TraceMooncakeDataArgs(path=tmp_path).hash_id_block_size
-        hash_ids = self._make_valid_hash_ids(n_rows, prompt_lengths, block_size)
+        hash_ids = _make_valid_hash_ids(n_rows, prompt_lengths, block_size)
         trace = _write_trace(
             tmp_path,
             _generate_trace(n_rows, [
@@ -294,8 +303,58 @@ class TestTraceMooncakeDatasetDeserializer():
     def test_unsupported_file_suffix_raises(self, tmp_path: Path, deserializer):
         trace = _write_trace(
             tmp_path,
-            '{"timestamp": 0, "input_length": 10, "output_length": 5}\n',
+            '{"timestamp": 0, "input_length": 10, "output_length": 5, '
+            '"hash_ids": [0]}\n',
             suffix=".json",
         )
         with pytest.raises(DataNotSupportedError, match=r"Unsupported.*\.json"):
             self._deserialize(deserializer, trace)
+
+    @pytest.mark.sanity
+    def test_incompatible_encoding_raises(self, tmp_path: Path, deserializer):
+        n_rows = 2
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("timestamp", lambda i: i),
+                TraceColumn("input_length", lambda _: 1024),
+                TraceColumn("output_length", lambda _: 5),
+                TraceColumn("hash_ids", lambda i: [0, i + 1]),
+            ]),
+        )
+        config = TraceMooncakeDataArgs(path=trace)
+        with pytest.raises(DataNotSupportedError, match="generate enough"):
+            deserializer(
+                config=config,
+                processor_factory=lambda: _incompetent_processor(),
+                random_seed=42,
+            )
+        with pytest.raises(DataNotSupportedError, match="generate distinct"):
+            deserializer(
+                config=config,
+                processor_factory=lambda: _ascending_processor(),
+                random_seed=42,
+            )
+
+    @pytest.mark.smoke
+    def test_token_block_distinctness(self, tmp_path: Path, deserializer):
+        n_rows = 4
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("timestamp", lambda i: i),
+                TraceColumn("input_length", lambda _: 1024),
+                TraceColumn("output_length", lambda _: 5),
+                TraceColumn("hash_ids", lambda i: [0, i + 1]),
+            ]),
+        )
+        config = TraceMooncakeDataArgs(path=trace)
+        ds = deserializer(
+            config=config,
+            processor_factory=lambda: _compatible_processor(),
+            random_seed=42,
+        )
+        root_block = [ds["hash_ids"][row][0] for row in range(n_rows)]
+        sibling_blocks = [ds["hash_ids"][row][1] for row in range(n_rows)]
+        assert _all_equal(root_block)
+        assert _all_distinct(sibling_blocks)

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -106,9 +106,7 @@ class TraceColumn:
 
 def _generate_trace(num_rows: int, columns: list[TraceColumn]) -> str:
     return "\n".join(
-        f"{{{
-            ', '.join(f'"{col.name}": {col.data_generator(idx)}' for col in columns)
-        }}}"
+        f"{{{', '.join(f'"{col.name}": {col.data_generator(idx)}' for col in columns)}}}"
         for idx in range(num_rows)
     )
 

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -1,10 +1,9 @@
 import copy
 import dataclasses
-import itertools
 import math
 import random
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable
 from unittest.mock import Mock
 
 from datasets import Dataset

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -141,7 +141,6 @@ class TestTraceMooncakeDatasetDeserializer:
         assert isinstance(ds, Dataset)
         assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
         assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
-        assert ds["hash_ids"] == [[i + 1] for i in range(n_rows)]
         for prompt, token_count in zip(
             ds["prompt"], ds["prompt_tokens_count"], strict=True
         ):
@@ -172,7 +171,6 @@ class TestTraceMooncakeDatasetDeserializer:
         )
         assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
         assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
-        assert ds["hash_ids"] == [[i] for i in range(n_rows)]
 
     @pytest.mark.smoke
     def test_custom_hash_id_block_size(self, tmp_path: Path, deserializer):
@@ -225,7 +223,6 @@ class TestTraceMooncakeDatasetDeserializer:
         )
         assert ds["prompt_tokens_count"] == prompt_lengths
         assert ds["output_tokens_count"] == output_lengths
-        assert ds["hash_ids"] == hash_ids
         assert processor.encode.call_count <= sum([sum(i) for i in hash_ids])
         for prompt, token_count in zip(
             ds["prompt"], ds["prompt_tokens_count"], strict=True
@@ -340,13 +337,14 @@ class TestTraceMooncakeDatasetDeserializer:
     @pytest.mark.smoke
     def test_token_block_distinctness(self, tmp_path: Path, deserializer):
         n_rows = 4
+        n_in = 1024
         trace = _write_trace(
             tmp_path,
             _generate_trace(
                 n_rows,
                 [
                     TraceColumn("timestamp", lambda i: i),
-                    TraceColumn("input_length", lambda _: 1024),
+                    TraceColumn("input_length", lambda _: n_in),
                     TraceColumn("output_length", lambda _: 5),
                     TraceColumn("hash_ids", lambda i: [0, i + 1]),
                 ],
@@ -358,7 +356,7 @@ class TestTraceMooncakeDatasetDeserializer:
             processor_factory=lambda: _compatible_processor(),
             random_seed=42,
         )
-        root_block = [ds["hash_ids"][row][0] for row in range(n_rows)]
-        sibling_blocks = [ds["hash_ids"][row][1] for row in range(n_rows)]
+        root_block = [ds["prompt"][row][:n_in//2] for row in range(n_rows)]
+        sibling_blocks = [ds["prompt"][row][n_in//2:] for row in range(n_rows)]
         assert _all_equal(root_block)
         assert _all_distinct(sibling_blocks)

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -31,20 +31,6 @@ def _ascending_processor() -> Mock:
     return proc
 
 
-def _incompetent_processor() -> Mock:
-    """Tokenizer that encodes the entire string as one token. Compatible
-    tokenizers are expected to be capable of generating a large enough
-    token id list to fit the hash id block size."""
-    proc = Mock()
-    proc.encode.side_effect = lambda text: [
-        0,
-    ]
-    proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
-        f"tok{i}" for i, _ in enumerate(tokens)
-    )
-    return proc
-
-
 def _compatible_processor() -> Mock:
     """Tokenizer where each whitespace-delimited word is assigned a token
     selected from a range of random integers. This is compatible with most
@@ -344,12 +330,6 @@ class TestTraceMooncakeDatasetDeserializer:
             ),
         )
         config = TraceMooncakeDataArgs(path=trace)
-        with pytest.raises(DataNotSupportedError, match="generate enough"):
-            deserializer(
-                config=config,
-                processor_factory=lambda: _incompetent_processor(),
-                random_seed=42,
-            )
         with pytest.raises(DataNotSupportedError, match="generate distinct"):
             deserializer(
                 config=config,

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -1,0 +1,301 @@
+import copy
+import dataclasses
+import math
+import random
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import Mock
+
+from datasets import Dataset
+import pytest
+from pydantic import ValidationError
+
+from guidellm.data.deserializers.trace_mooncake import (
+    TraceMooncakeDataArgs,
+    TraceMooncakeDatasetDeserializer
+)
+from guidellm.data.schemas import DataNotSupportedError
+
+
+def _ascending_processor() -> Mock:
+    """Tokenizer where each whitespace-delimited word is assigned a token
+    in ascending order starting from 0. This is incompatible with most mooncake
+    traces as there is no way to generate distinct token blocks for sibling
+    nodes."""
+    proc = Mock()
+    proc.encode.side_effect = lambda text: list(range(len(text.split())))
+    proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
+        f"tok{i}" for i, _ in enumerate(tokens))
+    return proc
+
+
+def _incompetent_processor() -> Mock:
+    """Tokenizer that encodes the entire string as one token. Compatible
+    tokenizers are expected to be capable of generating a large enough
+    token id list to fit the hash id block size."""
+    proc = Mock()
+    proc.encode.side_effect = lambda text: [0,]
+    proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
+        f"tok{i}" for i, _ in enumerate(tokens))
+    return proc
+
+
+def _compatible_processor() -> Mock:
+    """Tokenizer where each whitespace-delimited word is assigned a token
+    selected from a range of random integers. This is compatible with most
+    mooncake traces as there is a way to generate distinct token blocks for
+    sibling nodes."""
+    random.seed(0)
+    proc = Mock()
+    proc.encode.side_effect = lambda text: [
+        random.randint(0, 1000) for _ in range(len(text.split()))
+    ]
+    proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
+        f"tok{t}" for t in tokens)
+    return proc
+
+
+def _write_trace(tmp_path: Path, content: str, suffix: str = ".jsonl") -> Path:
+    path = tmp_path / f"trace{suffix}"
+    path.write_text(content)
+    return path
+
+
+@dataclasses.dataclass
+class TraceColumn:
+    name: str
+    # Function with row index as the one argument 
+    data_generator: Callable[[int], Any]
+
+
+def _generate_trace(num_rows: int, columns: list[TraceColumn]) -> str:
+    return "\n".join(
+        f"{{{", ".join(f"\"{col.name}\": {col.data_generator(idx)}"
+                       for col in columns)}}}"
+        for idx in range(num_rows)
+    )
+
+
+class TestTraceMooncakeDatasetDeserializer():
+    @pytest.fixture
+    def deserializer(self) -> TraceMooncakeDatasetDeserializer:
+        return TraceMooncakeDatasetDeserializer()
+
+    def _deserialize(self, deserializer, data, **kwargs):
+        field_names = (
+            "timestamp_column", "prompt_tokens_column", "output_tokens_column",
+            "hash_ids_column", "hash_id_block_size"
+        )
+        col_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k in field_names
+        }
+        config = TraceMooncakeDataArgs(path=data, **col_kwargs)
+        return deserializer(
+            config=config,
+            processor_factory=_ascending_processor,
+            random_seed=42,
+        )
+
+    @pytest.mark.smoke
+    def test_loads_sorted_rows_and_keeps_token_columns_aligned(
+        self, tmp_path: Path, deserializer
+    ):
+        n_rows = 10
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("timestamp", lambda i: n_rows - i),
+                TraceColumn("input_length", lambda i: n_rows - i),
+                TraceColumn("output_length", lambda i: (n_rows - i) * 10),
+                TraceColumn("hash_ids", lambda i: [n_rows - i]),
+            ]),
+        )
+        ds = self._deserialize(deserializer, trace)
+        assert isinstance(ds, Dataset)
+        assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
+        assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
+        assert ds["hash_ids"] == [[i + 1] for i in range(n_rows)]
+        for prompt, token_count in zip(
+            ds["prompt"], ds["prompt_tokens_count"], strict=True
+        ):
+            assert len(_ascending_processor().encode(prompt)) == token_count
+
+    @pytest.mark.smoke
+    def test_honors_custom_column_names(self, tmp_path: Path, deserializer):
+        n_rows = 3
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("ts", lambda i: i),
+                TraceColumn("input_tokens", lambda i: i + 1),
+                TraceColumn("generated_tokens", lambda i: (i + 1) * 10),
+                TraceColumn("ids", lambda i: [i]),
+            ]),
+        )
+        ds = self._deserialize(
+            deserializer, trace,
+            timestamp_column="ts",
+            prompt_tokens_column="input_tokens",
+            output_tokens_column="generated_tokens",
+            hash_ids_column="ids",
+        )
+        assert ds["prompt_tokens_count"] == [i + 1 for i in range(n_rows)]
+        assert ds["output_tokens_count"] == [(i + 1) * 10 for i in range(n_rows)]
+        assert ds["hash_ids"] == [[i] for i in range(n_rows)]
+
+    @pytest.mark.smoke
+    def test_custom_hash_id_block_size(self, tmp_path: Path, deserializer):
+        n_rows = 1
+        n_in = 1000
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("timestamp", lambda i: i),
+                TraceColumn("input_length", lambda _: n_in),
+                TraceColumn("output_length", lambda i: i + 1),
+                # Would throw a DataNotSupportedError with default block size 512
+                # See row validation in trace_mooncake.py
+                TraceColumn("hash_ids", lambda _: [0, 1, 2, 3, 4]),
+            ]),
+        )
+        self._deserialize(deserializer, trace, hash_id_block_size=n_in / 5)
+    
+    def _make_valid_hash_ids(
+        self, n_rows: int, prompt_lengths: list[int], block_size: int
+    ):
+        """The final token block of every row may be less than the hash id block
+        size due to the prompt length not being divisible by it. Use this
+        when testing large trace prompts to avoid including token blocks with
+        less than the block size in the middle of later rows."""
+        tail_hash_ids = []
+        original_prompt_positions = dict(zip(prompt_lengths, range(n_rows)))
+        sorted_lengths = copy.deepcopy(prompt_lengths)
+        sorted_lengths.sort()
+        hash_ids = [None for _ in range(n_rows)]
+        for length in sorted_lengths:
+            original_position = original_prompt_positions[length]
+            n_blocks = math.ceil(length / block_size)
+            n_to_generate = n_blocks + len(tail_hash_ids)
+            hash_ids[original_position] = [
+                i for i in range(n_to_generate) if i not in tail_hash_ids
+            ]
+            tail_hash_ids.append(hash_ids[original_position][-1])
+        return hash_ids
+
+    @pytest.mark.smoke
+    def test_generates_large_trace_prompts(self, tmp_path: Path, deserializer):
+        random.seed(0)
+        n_rows = 25
+        prompt_lengths = [random.randint(2000, 100000) for _ in range(n_rows)]
+        output_lengths = [random.randint(3, 800) for _ in range(n_rows)]
+        times = [0.0, 0.5, 1.0, 2.0]
+        timestamps = [times[int(i / n_rows * len(times))] for i in range(n_rows)]
+        block_size = TraceMooncakeDataArgs(path=tmp_path).hash_id_block_size
+        hash_ids = self._make_valid_hash_ids(n_rows, prompt_lengths, block_size)
+        trace = _write_trace(
+            tmp_path,
+            _generate_trace(n_rows, [
+                TraceColumn("timestamp", lambda i: timestamps[i]),
+                TraceColumn("input_length", lambda i: prompt_lengths[i]),
+                TraceColumn("output_length", lambda i: output_lengths[i]),
+                TraceColumn("hash_ids", lambda i: hash_ids[i]),
+            ]),
+        )
+        processor = _ascending_processor()
+        config = TraceMooncakeDataArgs(path=trace)
+        ds = deserializer(
+            config=config,
+            processor_factory=lambda: processor,
+            random_seed=42,
+        )
+        assert ds["prompt_tokens_count"] == prompt_lengths
+        assert ds["output_tokens_count"] == output_lengths
+        assert ds["hash_ids"] == hash_ids
+        assert processor.encode.call_count <= sum([sum(i) for i in hash_ids])
+        for prompt, token_count in zip(
+            ds["prompt"], ds["prompt_tokens_count"], strict=True
+        ):
+            if not len(processor.encode(prompt)) == token_count:
+                pytest.fail(f"{len(processor.encode(prompt))} != {token_count}")
+
+    @pytest.mark.smoke
+    def test_rejects_invalid_path(self, deserializer):
+        with pytest.raises(ValidationError, match="not a valid path"):
+            self._deserialize(deserializer, 123)
+        with pytest.raises(DataNotSupportedError, match="path to a trace file"):
+            self._deserialize(deserializer, "bad_path.jsonl")
+
+    @pytest.mark.sanity
+    @pytest.mark.parametrize(
+        ("content", "kwargs", "match"),
+        [
+            ("", {}, "empty"),
+            (
+                '{"ts": 0, "input_length": 10, "output_length": 5, "hash_ids": [0]}\n',
+                {},
+                "timestamp",
+            ),
+            (
+                '{"timestamp": 0, "input_length": 10, "hash_ids": [0]}\n',
+                {},
+                "output_length",
+            ),
+            (
+                '{"timestamp": 0, "prompt_tokens": 10, "output_length": 5, '
+                '"hash_ids": [0]}\n',
+                {
+                    "prompt_tokens_column": "prompt_tokens",
+                    "output_tokens_column": "out",
+                },
+                "out",
+            ),
+            (
+                '{"timestamp": "bad", "input_length": 10, "output_length": 5, '
+                '"hash_ids": [0]}\n',
+                {},
+                "scalar of type float",
+            ),
+            (
+                '{"timestamp": 0, "input_length": "bad", "output_length": 5, '
+                '"hash_ids": [0]}\n',
+                {},
+                "scalar of type int64",
+            ),
+            (
+                '{"timestamp": 0, "input_length": 10, "output_length": null, '
+                '"hash_ids": [0]}\n',
+                {},
+                "NoneType",
+            ),
+            (
+                '{"timestamp": 0, "input_length": 10, "output_length": 5, '
+                '"hash_ids": [0]}\nnot-json\n',
+                {},
+                "generating the dataset",
+            ),
+            (
+                '{"timestamp": 0, "input_length": 1024, "output_length": 5, '
+                '"hash_ids": [0]}\n',
+                {},
+                "given 1 blocks",
+            ),
+        ],
+    )
+    def test_trace_validation_raises(
+        self, tmp_path: Path, deserializer, content, kwargs, match
+    ):
+        trace = _write_trace(tmp_path, content)
+        with pytest.raises(DataNotSupportedError, match=match):
+            self._deserialize(deserializer, trace, **kwargs)
+
+    @pytest.mark.sanity
+    def test_unsupported_file_suffix_raises(self, tmp_path: Path, deserializer):
+        trace = _write_trace(
+            tmp_path,
+            '{"timestamp": 0, "input_length": 10, "output_length": 5}\n',
+            suffix=".json",
+        )
+        with pytest.raises(DataNotSupportedError, match=r"Unsupported.*\.json"):
+            self._deserialize(deserializer, trace)

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -2,17 +2,18 @@ import copy
 import dataclasses
 import math
 import random
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import Mock
 
-from datasets import Dataset
 import pytest
+from datasets import Dataset
 from pydantic import ValidationError
 
 from guidellm.data.deserializers.trace_mooncake import (
     TraceMooncakeDataArgs,
-    TraceMooncakeDatasetDeserializer
+    TraceMooncakeDatasetDeserializer,
 )
 from guidellm.data.schemas import DataNotSupportedError
 
@@ -25,7 +26,8 @@ def _ascending_processor() -> Mock:
     proc = Mock()
     proc.encode.side_effect = lambda text: list(range(len(text.split())))
     proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
-        f"tok{i}" for i, _ in enumerate(tokens))
+        f"tok{i}" for i, _ in enumerate(tokens)
+    )
     return proc
 
 
@@ -34,9 +36,12 @@ def _incompetent_processor() -> Mock:
     tokenizers are expected to be capable of generating a large enough
     token id list to fit the hash id block size."""
     proc = Mock()
-    proc.encode.side_effect = lambda text: [0,]
+    proc.encode.side_effect = lambda text: [
+        0,
+    ]
     proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
-        f"tok{i}" for i, _ in enumerate(tokens))
+        f"tok{i}" for i, _ in enumerate(tokens)
+    )
     return proc
 
 
@@ -51,7 +56,8 @@ def _compatible_processor() -> Mock:
         random.randint(0, 1000) for _ in range(len(text.split()))
     ]
     proc.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
-        f"tok{t}" for t in tokens)
+        f"tok{t}" for t in tokens
+    )
     return proc
 
 
@@ -67,7 +73,7 @@ def _make_valid_hash_ids(n_rows: int, prompt_lengths: list[int], block_size: int
     when testing large trace prompts to avoid including token blocks with
     less than the block size in the middle of later rows."""
     tail_hash_ids = []
-    original_prompt_positions = dict(zip(prompt_lengths, range(n_rows)))
+    original_prompt_positions = dict(zip(prompt_lengths, range(n_rows), strict=False))
     sorted_lengths = copy.deepcopy(prompt_lengths)
     sorted_lengths.sort()
     hash_ids = [None for _ in range(n_rows)]
@@ -94,33 +100,33 @@ def _all_distinct(items: list):
 @dataclasses.dataclass
 class TraceColumn:
     name: str
-    # Function with row index as the one argument 
+    # Function with row index as the one argument
     data_generator: Callable[[int], Any]
 
 
 def _generate_trace(num_rows: int, columns: list[TraceColumn]) -> str:
     return "\n".join(
-        f"{{{", ".join(f"\"{col.name}\": {col.data_generator(idx)}"
-                       for col in columns)}}}"
+        f"{{{
+            ', '.join(f'"{col.name}": {col.data_generator(idx)}' for col in columns)
+        }}}"
         for idx in range(num_rows)
     )
 
 
-class TestTraceMooncakeDatasetDeserializer():
+class TestTraceMooncakeDatasetDeserializer:
     @pytest.fixture
     def deserializer(self) -> TraceMooncakeDatasetDeserializer:
         return TraceMooncakeDatasetDeserializer()
 
     def _deserialize(self, deserializer, data, **kwargs):
         field_names = (
-            "timestamp_column", "prompt_tokens_column", "output_tokens_column",
-            "hash_ids_column", "hash_id_block_size"
+            "timestamp_column",
+            "prompt_tokens_column",
+            "output_tokens_column",
+            "hash_ids_column",
+            "hash_id_block_size",
         )
-        col_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k in field_names
-        }
+        col_kwargs = {k: v for k, v in kwargs.items() if k in field_names}
         config = TraceMooncakeDataArgs(path=data, **col_kwargs)
         return deserializer(
             config=config,
@@ -135,12 +141,15 @@ class TestTraceMooncakeDatasetDeserializer():
         n_rows = 10
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("timestamp", lambda i: n_rows - i),
-                TraceColumn("input_length", lambda i: n_rows - i),
-                TraceColumn("output_length", lambda i: (n_rows - i) * 10),
-                TraceColumn("hash_ids", lambda i: [n_rows - i]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("timestamp", lambda i: n_rows - i),
+                    TraceColumn("input_length", lambda i: n_rows - i),
+                    TraceColumn("output_length", lambda i: (n_rows - i) * 10),
+                    TraceColumn("hash_ids", lambda i: [n_rows - i]),
+                ],
+            ),
         )
         ds = self._deserialize(deserializer, trace)
         assert isinstance(ds, Dataset)
@@ -157,15 +166,19 @@ class TestTraceMooncakeDatasetDeserializer():
         n_rows = 3
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("ts", lambda i: i),
-                TraceColumn("input_tokens", lambda i: i + 1),
-                TraceColumn("generated_tokens", lambda i: (i + 1) * 10),
-                TraceColumn("ids", lambda i: [i]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("ts", lambda i: i),
+                    TraceColumn("input_tokens", lambda i: i + 1),
+                    TraceColumn("generated_tokens", lambda i: (i + 1) * 10),
+                    TraceColumn("ids", lambda i: [i]),
+                ],
+            ),
         )
         ds = self._deserialize(
-            deserializer, trace,
+            deserializer,
+            trace,
             timestamp_column="ts",
             prompt_tokens_column="input_tokens",
             output_tokens_column="generated_tokens",
@@ -181,14 +194,17 @@ class TestTraceMooncakeDatasetDeserializer():
         n_in = 1000
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("timestamp", lambda i: i),
-                TraceColumn("input_length", lambda _: n_in),
-                TraceColumn("output_length", lambda i: i + 1),
-                # Would throw a DataNotSupportedError with default block size 512
-                # See row validation in trace_mooncake.py
-                TraceColumn("hash_ids", lambda _: [0, 1, 2, 3, 4]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("timestamp", lambda i: i),
+                    TraceColumn("input_length", lambda _: n_in),
+                    TraceColumn("output_length", lambda i: i + 1),
+                    # Would throw a DataNotSupportedError with default block size 512
+                    # See row validation in trace_mooncake.py
+                    TraceColumn("hash_ids", lambda _: [0, 1, 2, 3, 4]),
+                ],
+            ),
         )
         self._deserialize(deserializer, trace, hash_id_block_size=n_in / 5)
 
@@ -204,12 +220,15 @@ class TestTraceMooncakeDatasetDeserializer():
         hash_ids = _make_valid_hash_ids(n_rows, prompt_lengths, block_size)
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("timestamp", lambda i: timestamps[i]),
-                TraceColumn("input_length", lambda i: prompt_lengths[i]),
-                TraceColumn("output_length", lambda i: output_lengths[i]),
-                TraceColumn("hash_ids", lambda i: hash_ids[i]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("timestamp", lambda i: timestamps[i]),
+                    TraceColumn("input_length", lambda i: prompt_lengths[i]),
+                    TraceColumn("output_length", lambda i: output_lengths[i]),
+                    TraceColumn("hash_ids", lambda i: hash_ids[i]),
+                ],
+            ),
         )
         processor = _ascending_processor()
         config = TraceMooncakeDataArgs(path=trace)
@@ -225,7 +244,7 @@ class TestTraceMooncakeDatasetDeserializer():
         for prompt, token_count in zip(
             ds["prompt"], ds["prompt_tokens_count"], strict=True
         ):
-            if not len(processor.encode(prompt)) == token_count:
+            if len(processor.encode(prompt)) != token_count:
                 pytest.fail(f"{len(processor.encode(prompt))} != {token_count}")
 
     @pytest.mark.smoke
@@ -314,12 +333,15 @@ class TestTraceMooncakeDatasetDeserializer():
         n_rows = 2
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("timestamp", lambda i: i),
-                TraceColumn("input_length", lambda _: 1024),
-                TraceColumn("output_length", lambda _: 5),
-                TraceColumn("hash_ids", lambda i: [0, i + 1]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("timestamp", lambda i: i),
+                    TraceColumn("input_length", lambda _: 1024),
+                    TraceColumn("output_length", lambda _: 5),
+                    TraceColumn("hash_ids", lambda i: [0, i + 1]),
+                ],
+            ),
         )
         config = TraceMooncakeDataArgs(path=trace)
         with pytest.raises(DataNotSupportedError, match="generate enough"):
@@ -340,12 +362,15 @@ class TestTraceMooncakeDatasetDeserializer():
         n_rows = 4
         trace = _write_trace(
             tmp_path,
-            _generate_trace(n_rows, [
-                TraceColumn("timestamp", lambda i: i),
-                TraceColumn("input_length", lambda _: 1024),
-                TraceColumn("output_length", lambda _: 5),
-                TraceColumn("hash_ids", lambda i: [0, i + 1]),
-            ]),
+            _generate_trace(
+                n_rows,
+                [
+                    TraceColumn("timestamp", lambda i: i),
+                    TraceColumn("input_length", lambda _: 1024),
+                    TraceColumn("output_length", lambda _: 5),
+                    TraceColumn("hash_ids", lambda i: [0, i + 1]),
+                ],
+            ),
         )
         config = TraceMooncakeDataArgs(path=trace)
         ds = deserializer(


### PR DESCRIPTION
## Summary
Add support for generating synthetic prompts from a Mooncake formatted trace file. This involves handling the *hash_ids* column, as well as validating that two different hash IDs do not represent the exact same sequence of tokens if they share the same previous ID (parent node).

Future PRs should create a common file/class for the similar functionality of `TraceMooncakeDatasetDeserializer` and `TraceSyntheticDatasetDeserializer`, as well as to make adding support for additional trace formats easier.

## Details
- Add `src/guidellm/data/deserializers/trace_mooncake.py`
  - `TraceMooncakeDataArgs`: Adds two new fields `hash_ids_column` and `hash_id_block_size`
  - `TraceMooncakeDatasetDeserializer`: Takes a processor, and a path to a .jsonl file, and returns a `datasets.Dataset` with the columns *("prompt", "prompt_token_count", "output_token_count", "hash_ids")*
- Register new classes with `DataArgs` and `DatasetDeserializerFactory`
- Add unit test coverage in `test_trace_mooncake.py`

## Test Plan
- `tox -e test-unit -- tests/unit/data/deserializers/test_trace_mooncake.py`
- `tox -e lint-check && tox -e type-check`

## Related Issues
- Addresses issue [#597](https://github.com/vllm-project/guidellm/issues/597) (1. Trace Parser)

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit de90d4061affdeb4fe416e383ae817c2a4328a89
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jun 3 15:10:36 2026 -0400

    Add TraceMooncake objects
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit a58605e97d25a7134d000cd473384814983c4837
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jun 3 16:59:02 2026 -0400

    Populate trace_mooncake.py
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit fe5a3f6fab585a63c40b3713775c4e0b54a316e9
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 4 09:52:27 2026 -0400

    Update type hints
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit d770bfa61df4a3348a2405a5d5519ee580d495ac
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 5 13:33:27 2026 -0400

    Add test_trace_mooncake.py
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit b2f0cde5e346f84c67a0be19248473f2a59548eb
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 5 15:02:30 2026 -0400

    Add additional tests
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 214fcef80bd9de50a2a3f25ac03c10f35bc5ff82
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 5 15:03:26 2026 -0400

    Remove unused imports
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit b9ffd891673935c7c323025dcefd6d4199ef13ab
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 5 15:24:01 2026 -0400

    Update type hints
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 68c530f1d573413c6db7a553d62f265e7a54b6a2
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 5 15:32:41 2026 -0400

    Register Mooncake trace objects
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit a38db6304afbc1c0388a488743d181b92a5d8cf4
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Sat Jun 6 21:36:22 2026 -0400

    Fix formatting in _generate_trace function
    
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit b26e3d702fd011d303dc446b6b845573f2acd5d0
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Mon Jun 8 13:12:37 2026 -0400

    Fix _generate_trace formatting
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 3f67e4624c7c482c8e83c02f374455fee190c976
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Jun 9 12:41:59 2026 -0400

    Add `kind` field to TraceMooncakeDataArgs
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 2a9811029f395571714a7f83d12c3061cad3dd26
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Jun 9 13:33:57 2026 -0400

    Rename parameters
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 3021f8bfbcb7e36729250ddd81cdeba92188be6e
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Jun 9 15:31:12 2026 -0400

    Update docstrings, DataArgs.register name
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 8954956998a586cf35630d2aa7db107e0b3375ef
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Jun 9 16:57:39 2026 -0400

    Remove raise in _generate_token_ids
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit a6bfb8b07f27c71684a37834acf9999e5f7ed406
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jun 10 11:53:04 2026 -0400

    Remove hash_ids column from generated Dataset
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit ca85a658573040d6000282ec4654d03d7224656c
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jun 10 17:05:08 2026 -0400

    Return IterableDataset to avoid pre-generating for entire trace
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit b1b85e5d47e0600cbeef3babad5f01f10a566fac
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 11 12:20:39 2026 -0400

    Move iteration_count increment to end of __iter__
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit f7ab87e35746ac526a9c2d6e9c5c3dd9de9a8a4f
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 11 12:25:10 2026 -0400

    Track row index state locally to examples interable
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit ac9233f401000e5032e249793943c16d7e4fade7
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 11 13:21:17 2026 -0400

    Increase `margin_of_safety` to minimize re-attempts
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 7c7d1e499ef1431d1c0e18f657167877e46fedec
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 11 13:33:11 2026 -0400

    Fix: increment row_idx
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 903a443d4ea9cb0a37d7e524fc3bf096c531a817
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jun 11 14:26:04 2026 -0400

    Change `kind` to match registered name
    
    Co-authored-by: Samuel Monson <smonson@irbash.net>
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

commit 2100dbd78f76b3fc41a98bf5e969b2dfd8cd87ef
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 11 15:50:27 2026 -0400

    Implement  methods required by _BaseExamplesIterable
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 6472f554bbd03992cb6c9760f44e4ea6c39ba466
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Jun 12 09:15:58 2026 -0400

    Satisfy linting
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

---------

Co-authored-by: Samuel Monson <smonson@irbash.net>
Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>
Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
