### PR TITLE
Fix unpicklable lambda collate_fn in TorchDataLoader for Python 3.14

### DIFF
--- a/src/guidellm/data/loaders/torch.py
+++ b/src/guidellm/data/loaders/torch.py
@@ -25,6 +25,10 @@ from guidellm.utils.mixins import InfoMixin
 __all__ = ["DatasetsIterator", "TorchDataLoader", "TorchDataLoaderArgs"]
 
 
+def _collate_first(batch: list) -> Any:
+    return batch[0]
+
+
 @DataLoaderArgs.register("pytorch")
 class TorchDataLoaderArgs(DataLoaderArgs):
     kind: Literal["pytorch"] = Field(  # type: ignore[assignment]
@@ -181,7 +185,7 @@ class TorchDataLoader(PyTorchDataLoader[DataT], InfoMixin, DataLoader[DataT]):
             dataset=iterator,
             batch_size=1,
             shuffle=config.shuffle,
-            collate_fn=lambda batch: batch[0],
+            collate_fn=_collate_first,
             num_workers=config.num_workers,
             generator=gen,
             **kwargs,


### PR DESCRIPTION
## Summary

Python 3.14 changed the default multiprocessing start method on Linux to forkserver, which requires DataLoader worker arguments to be picklable. The lambda batch: batch[0] passed as collate_fn is not picklable, causing a PicklingError at runtime. Replace it with a module-level _collate_first function.

## Details

This is a regression introduced with recent CLI refactoring

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3d285dbf9fa3d25149d470c9421056cbd0cdca94
Author: Radoslav Gerganov <rgerganov@gmail.com>
Date:   Mon Jun 8 16:07:33 2026 +0300

    Fix unpicklable lambda collate_fn in TorchDataLoader for Python 3.14
    
    Python 3.14 changed the default multiprocessing start method on Linux to
    forkserver, which requires DataLoader worker arguments to be picklable.
    The lambda batch: batch[0] passed as collate_fn is not picklable, causing
    a PicklingError at runtime. Replace it with a module-level _collate_first
    function.
    
    Signed-off-by: Radoslav Gerganov <rgerganov@gmail.com>

---------

Signed-off-by: Radoslav Gerganov <rgerganov@gmail.com>
