### PR TITLE
Fix report serialization for nested paths

### DIFF
--- a/src/guidellm/benchmark/schemas/generative/report.py
+++ b/src/guidellm/benchmark/schemas/generative/report.py
@@ -101,7 +101,7 @@ class GenerativeBenchmarksReport(StandardBaseModel):
         )
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_type = type_ or file_path.suffix.lower()[1:]
-        model_dict = self.model_dump()
+        model_dict = self.model_dump(mode="json")
         if file_type == "json":
             save_str = json.dumps(model_dict)
         elif file_type in ["yaml", "yml"]:

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -37,6 +37,38 @@ def minimal_report() -> GenerativeBenchmarksReport:
     return GenerativeBenchmarksReport(args=args)
 
 
+@pytest.fixture
+def file_path_report(tmp_path: Path) -> GenerativeBenchmarksReport:
+    """
+    Create a report whose benchmark args contain nested Path values.
+
+    ## WRITTEN BY AI ##
+    """
+    args = BenchmarkGenerativeTextArgs.model_validate(
+        {
+            "backend_kwargs": {
+                "kind": "openai_http",
+                "target": "http://localhost:8000/v1",
+                "model": "test-model",
+            },
+            "data": [
+                {
+                    "kind": "json_file",
+                    "path": tmp_path / "data.jsonl",
+                    "load_kwargs": {"split": "train"},
+                }
+            ],
+            "tokenizer": {"kind": "huggingface_auto", "model": "test-model"},
+            "data_column_mapper": {"kind": "generative_column_mapper"},
+            "data_preprocessors": [],
+            "data_finalizer": {"kind": "generative"},
+            "data_loader": {"kind": "pytorch"},
+            "output_dir": tmp_path / "outputs",
+        }
+    )
+    return GenerativeBenchmarksReport(args=args)
+
+
 class TestResolveFormatType:
     """
     Tests that resolve() propagates the format key correctly.
@@ -145,6 +177,42 @@ class TestFinalizeFormats:
         parsed = json.loads(content)
         assert isinstance(parsed, dict)
         assert "args" in parsed
+
+    @pytest.mark.asyncio
+    async def test_finalize_json_serializes_nested_paths(
+        self, tmp_path: Path, file_path_report: GenerativeBenchmarksReport
+    ):
+        """
+        JSON report serialization should convert nested Path values to strings.
+
+        ## WRITTEN BY AI ##
+        """
+        handler = GenerativeBenchmarkerSerialized(
+            output_path=tmp_path, format_type="json"
+        )
+        result_path = await handler.finalize(file_path_report)
+
+        parsed = json.loads(result_path.read_text())
+        assert parsed["args"]["data"][0]["path"] == str(tmp_path / "data.jsonl")
+        assert parsed["args"]["output_dir"] == str(tmp_path / "outputs")
+
+    @pytest.mark.asyncio
+    async def test_finalize_yaml_serializes_nested_paths(
+        self, tmp_path: Path, file_path_report: GenerativeBenchmarksReport
+    ):
+        """
+        YAML report serialization should emit nested Path values as safe strings.
+
+        ## WRITTEN BY AI ##
+        """
+        handler = GenerativeBenchmarkerSerialized(
+            output_path=tmp_path, format_type="yaml"
+        )
+        result_path = await handler.finalize(file_path_report)
+
+        parsed = yaml.safe_load(result_path.read_text())
+        assert parsed["args"]["data"][0]["path"] == str(tmp_path / "data.jsonl")
+        assert parsed["args"]["output_dir"] == str(tmp_path / "outputs")
 
     @pytest.mark.asyncio
     async def test_finalize_explicit_path_respects_extension(


### PR DESCRIPTION
## Summary

Fixes #781.

Benchmark report persistence currently dumps the report in Python mode, so nested `Path` values in benchmark args can remain as `PosixPath` objects and break JSON output or emit unsafe YAML tags. This switches report persistence to Pydantic's JSON mode so nested path values are converted before writing JSON/YAML files.

## Details

- Use `model_dump(mode="json")` before serializing benchmark reports.
- Add regression coverage for `json_file` data paths and `output_dir` path values in JSON and YAML report output.

## Test Plan

- `uv run pytest tests/unit/benchmark/test_serialized_output.py -k nested_paths`
- `uv run pytest tests/unit/benchmark/test_serialized_output.py`
- `uv run pytest tests/unit/benchmark`
- `uv run ruff check src/guidellm/benchmark/schemas/generative/report.py tests/unit/benchmark/test_serialized_output.py && uv run ruff format --check src/guidellm/benchmark/schemas/generative/report.py tests/unit/benchmark/test_serialized_output.py`
- Attempted `uv run tox -e test-unit -- tests/unit/benchmark/test_serialized_output.py -k nested_paths` (failed before test collection in this local checkout because `.tox/test-unit/bin/python` had no `pytest` module installed).

## Related Issues

- Fixes #781
- Fixes #764
- Closes #765 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.

<!-- begin:squash-data -->

---

# git log

commit 37777334d7938acaca78cf15a229ad2586fa35e2
Author: jinhyuk9714 <jinhyuk9714@gmail.com>
Date:   Wed Jun 10 00:15:40 2026 +0900

    Fix report serialization for nested paths
    
    Assisted-by: Codex
    Signed-off-by: jinhyuk9714 <jinhyuk9714@gmail.com>

---------

Assisted-by: Codex
Signed-off-by: jinhyuk9714 <jinhyuk9714@gmail.com>
