### PR TITLE
Infer audio encoding format from source instead of defaulting to MP3

### DIFF
--- a/docs/guides/multimodal/audio.md
+++ b/docs/guides/multimodal/audio.md
@@ -71,7 +71,7 @@ Supported arguments include:
 
 - "sample_rate": The sample rate of the input audio data. Only required if it cannot be inferred (e.g., for raw numpy/torch arrays).
 - "encode_sample_rate": Target sample rate for the audio sent to the API. (default: 16000 Hz).
-- "audio_format": File format for the payload. Supported formats are "wav", "mp3", and "flac" (default: "mp3").
+- "audio_format": File format for the payload. Supported formats are "wav", "mp3", and "flac". If not specified, the format is auto-detected from the source audio codec. When detection is not possible (e.g., raw arrays), defaults to "wav".
 - "bitrate": Bitrate for lossy formats like mp3 (default: "64k").
 - "max_duration": If specified, audio longer than this duration (in seconds) will be truncated.
 - "mono": Whether to convert audio to mono (default: True).

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -992,10 +992,8 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
         Sets up internal state for accumulating streaming response data including
         audio buffers, text chunks, and usage metrics.
         """
+        super().__init__()
         self.streaming_buffer: bytearray = bytearray()
-        self.streaming_texts: list[str] = []
-        self.streaming_usage: dict[str, int | dict[str, int]] | None = None
-        self.streaming_response_id: str | None = None
 
     def format(
         self,

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -302,11 +302,8 @@ class VLLMPythonBackend(Backend):
                     try:
                         # Decode raw audio bytes into an array since vLLM audio models
                         # expect either raw numpy arrays or specific tensor formats
-                        audio_samples, _ = audio._decode_audio(audio_bytes)  # noqa: SLF001
-                        # torchcodec decodes audio on CPU, so .data is always
-                        # a CPU torch.Tensor. .cpu() is a no-op on CPU tensors.
-                        audio_array = audio_samples.data.cpu().numpy()
-                        multi_modal_data["audio"] = audio_array
+                        audio_data = audio.decode_audio(audio_bytes)
+                        multi_modal_data["audio"] = audio_data
                     except (ValueError, TypeError, OSError, RuntimeError) as exc:
                         raise ValueError(
                             f"Failed to decode audio from audio_column for vLLM: {exc}"

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -302,7 +302,7 @@ class VLLMPythonBackend(Backend):
                     try:
                         # Decode raw audio bytes into an array since vLLM audio models
                         # expect either raw numpy arrays or specific tensor formats
-                        audio_samples = audio._decode_audio(audio_bytes)  # noqa: SLF001
+                        audio_samples, _ = audio._decode_audio(audio_bytes)  # noqa: SLF001
                         # torchcodec decodes audio on CPU, so .data is always
                         # a CPU torch.Tensor. .cpu() is a no-op on CPU tensors.
                         audio_array = audio_samples.data.cpu().numpy()

--- a/src/guidellm/utils/audio.py
+++ b/src/guidellm/utils/audio.py
@@ -32,8 +32,6 @@ _CODEC_TO_FORMAT: dict[str, str] = {
     "opus": "ogg",
 }
 
-_wav_fallback_state = {"warned": False}
-
 
 def _codec_to_format(codec: str) -> str | None:
     """
@@ -103,13 +101,7 @@ def encode_audio(
             audio_format = _codec_to_format(source_codec)
         if audio_format is None:
             audio_format = "wav"
-            if not _wav_fallback_state["warned"]:
-                _wav_fallback_state["warned"] = True
-                logger.warning(
-                    "Could not detect source audio codec; "
-                    "falling back to WAV encoding. "
-                    "Set audio_format explicitly to suppress this warning."
-                )
+            logger.debug("Falling back to WAV audio formatting")
 
     bitrate_val = (
         int(bitrate.rstrip("k")) * 1000 if bitrate.endswith("k") else int(bitrate)
@@ -124,24 +116,25 @@ def encode_audio(
         mono=mono,
     )
 
-    # Use source file name when available, otherwise build from resolved format
-    if isinstance(audio, str | Path):
-        resolved_file_name = get_file_name(audio)
-    elif file_name is not None:
-        resolved_file_name = file_name
-    else:
-        resolved_file_name = f"audio.{format_val}"
-
     return {
         "type": "audio_file",
         "audio": encoded_audio,
-        "file_name": resolved_file_name,
+        "file_name": get_file_name(audio)
+        if isinstance(audio, str | Path)
+        else file_name,
         "format": audio_format,
         "mimetype": f"audio/{format_val}",
         "audio_samples": samples.sample_rate,
         "audio_seconds": samples.duration_seconds,
         "audio_bytes": len(encoded_audio),
     }
+
+
+def decode_audio(audio: bytes):
+    audio_samples, _ = _decode_audio(audio)
+    # torchcodec decodes audio on CPU, so .data is always
+    # a CPU torch.Tensor. .cpu() is a no-op on CPU tensors.
+    return audio_samples.data.cpu().numpy()
 
 
 def _decode_audio(  # noqa: C901, PLR0912, PLR0915

--- a/src/guidellm/utils/audio.py
+++ b/src/guidellm/utils/audio.py
@@ -10,6 +10,7 @@ import torch
 # CRITICAL: Use 'import ... as libs' pattern to preserve lazy loading
 # This defers errors until attributes are actually accessed
 import guidellm.extras.audio as libs
+from guidellm.logger import logger
 
 __all__ = [
     "encode_audio",
@@ -21,6 +22,31 @@ def is_url(text: Any) -> bool:
     return isinstance(text, str) and text.startswith(("http://", "https://"))
 
 
+# Maps torchcodec codec names to encoder-compatible container format strings.
+# PCM variants (pcm_s16le, pcm_f32le, etc.) are handled separately via prefix.
+_CODEC_TO_FORMAT: dict[str, str] = {
+    "flac": "flac",
+    "mp3": "mp3",
+    "vorbis": "ogg",
+    "aac": "aac",
+    "opus": "ogg",
+}
+
+_wav_fallback_state = {"warned": False}
+
+
+def _codec_to_format(codec: str) -> str | None:
+    """
+    Map a torchcodec codec name to an encoder-compatible container format.
+
+    :param codec: Codec string from ``AudioDecoder.metadata.codec``.
+    :return: Container format string, or None if the codec is unrecognized.
+    """
+    if codec.startswith("pcm_"):
+        return "wav"
+    return _CODEC_TO_FORMAT.get(codec)
+
+
 def encode_audio(
     audio: libs.AudioDecoder
     | bytes
@@ -30,11 +56,11 @@ def encode_audio(
     | torch.Tensor
     | dict[str, Any],
     sample_rate: int | None = None,
-    file_name: str = "audio.wav",
+    file_name: str | None = None,
     encode_sample_rate: int = 16000,
     max_duration: float | None = None,
     mono: bool = True,
-    audio_format: str = "mp3",
+    audio_format: str | None = None,
     bitrate: str = "64k",
 ) -> dict[
     Literal[
@@ -49,8 +75,41 @@ def encode_audio(
     ],
     str | int | float | bytes | None,
 ]:
-    """Decode audio (if necessary) and re-encode to specified format."""
-    samples = _decode_audio(audio, sample_rate=sample_rate, max_duration=max_duration)
+    """
+    Decode audio (if necessary) and re-encode to specified format.
+
+    If ``audio_format`` is not provided, the format is detected from the
+    source codec (via torchcodec metadata). When detection is not possible
+    (e.g. raw float tensors), falls back to WAV with a one-time warning.
+
+    :param audio: Audio input in any supported form.
+    :param sample_rate: Sample rate hint for raw decoded audio.
+    :param file_name: Override file name in output metadata. Defaults to a
+        name derived from the resolved format.
+    :param encode_sample_rate: Target sample rate for the encoded output.
+    :param max_duration: Truncate audio to this duration in seconds.
+    :param mono: Convert to mono if True.
+    :param audio_format: Target encoding format. If None, detected from source.
+    :param bitrate: Bitrate for lossy formats like mp3.
+    :return: Dict containing encoded audio bytes and metadata.
+    """
+    samples, source_codec = _decode_audio(
+        audio, sample_rate=sample_rate, max_duration=max_duration
+    )
+
+    # Resolve format: explicit > codec-detected > WAV fallback
+    if audio_format is None:
+        if source_codec:
+            audio_format = _codec_to_format(source_codec)
+        if audio_format is None:
+            audio_format = "wav"
+            if not _wav_fallback_state["warned"]:
+                _wav_fallback_state["warned"] = True
+                logger.warning(
+                    "Could not detect source audio codec; "
+                    "falling back to WAV encoding. "
+                    "Set audio_format explicitly to suppress this warning."
+                )
 
     bitrate_val = (
         int(bitrate.rstrip("k")) * 1000 if bitrate.endswith("k") else int(bitrate)
@@ -65,12 +124,18 @@ def encode_audio(
         mono=mono,
     )
 
+    # Use source file name when available, otherwise build from resolved format
+    if isinstance(audio, str | Path):
+        resolved_file_name = get_file_name(audio)
+    elif file_name is not None:
+        resolved_file_name = file_name
+    else:
+        resolved_file_name = f"audio.{format_val}"
+
     return {
         "type": "audio_file",
         "audio": encoded_audio,
-        "file_name": get_file_name(audio)
-        if isinstance(audio, str | Path)
-        else file_name,
+        "file_name": resolved_file_name,
         "format": audio_format,
         "mimetype": f"audio/{format_val}",
         "audio_samples": samples.sample_rate,
@@ -79,7 +144,7 @@ def encode_audio(
     }
 
 
-def _decode_audio(  # noqa: C901, PLR0912
+def _decode_audio(  # noqa: C901, PLR0912, PLR0915
     audio: libs.AudioDecoder
     | bytes
     | str
@@ -89,8 +154,12 @@ def _decode_audio(  # noqa: C901, PLR0912
     | dict[str, Any],
     sample_rate: int | None = None,
     max_duration: float | None = None,
-) -> libs.AudioSamples:
-    """Decode audio from various input types into AudioSamples."""
+) -> tuple[libs.AudioSamples, str | None]:
+    """
+    Decode audio from various input types into AudioSamples.
+
+    :return: Tuple of (decoded samples, detected codec string or None).
+    """
     # If input is a dict, unwrap it into a function call
     if isinstance(audio, dict):
         sample_rate = audio.get("sample_rate", audio.get("sampling_rate", sample_rate))
@@ -118,11 +187,14 @@ def _decode_audio(  # noqa: C901, PLR0912
         )
 
     data: torch.Tensor | bytes
+    codec: str | None = None
+
     # HF datasets return AudioDecoder for audio column
     if isinstance(audio, libs.AudioDecoder):
+        codec = audio.metadata.codec
         samples = audio.get_samples_played_in_range(stop_seconds=max_duration)
     elif isinstance(audio, torch.Tensor):
-        # If float stream assume decoded audio
+        # If float stream assume decoded audio -- no codec info available
         if torch.is_floating_point(audio):
             if sample_rate is None:
                 raise ValueError("Sample rate must be set for decoded audio")
@@ -149,6 +221,7 @@ def _decode_audio(  # noqa: C901, PLR0912
                 source=audio,
                 sample_rate=sample_rate,
             )
+            codec = decoder.metadata.codec
             samples = decoder.get_samples_played_in_range(stop_seconds=max_duration)
 
         else:
@@ -160,6 +233,7 @@ def _decode_audio(  # noqa: C901, PLR0912
             source=audio,
             sample_rate=sample_rate,
         )
+        codec = decoder.metadata.codec
         samples = decoder.get_samples_played_in_range(stop_seconds=max_duration)
 
     # If str or Path, assume file path or URL to encoded audio
@@ -175,18 +249,19 @@ def _decode_audio(  # noqa: C901, PLR0912
         decoder = libs.AudioDecoder(
             source=data,
         )
+        codec = decoder.metadata.codec
         samples = decoder.get_samples_played_in_range(stop_seconds=max_duration)
     else:
         raise ValueError(f"Unsupported audio type: {type(audio)}")
 
-    return samples
+    return samples, codec
 
 
 def _encode_audio(
     samples: libs.AudioSamples,
     resample_rate: int | None = None,
     bitrate: int = 64000,
-    audio_format: str = "mp3",
+    audio_format: str = "wav",
     mono: bool = True,
 ) -> bytes:
     encoder = libs.AudioEncoder(

--- a/tests/unit/backends/vllm_python/test_vllm.py
+++ b/tests/unit/backends/vllm_python/test_vllm.py
@@ -44,18 +44,18 @@ def _fake_sampling_params(**kwargs):
     return SimpleNamespace(**kwargs)
 
 
-def _mock_audio_decode_result(audio_array: np.ndarray) -> Mock:
+def _mock_audio_decode_result(audio_array: np.ndarray) -> tuple[Mock, str]:
     """
     Build a mock torchcodec AudioSamples whose .data behaves like a CPU
     torch.Tensor: .data.cpu() returns self, .data.cpu().numpy() returns
-    the given numpy array.
+    the given numpy array. Returns a tuple matching _decode_audio's signature.
     """
     mock_data = Mock()
     mock_data.cpu.return_value = mock_data
     mock_data.numpy.return_value = audio_array
     result = Mock()
     result.data = mock_data
-    return result
+    return result, "pcm_s16le"
 
 
 @pytest.fixture

--- a/tests/unit/extras/test_audio.py
+++ b/tests/unit/extras/test_audio.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from loguru import logger
 
 from guidellm.utils import audio as _audio_mod
 
@@ -50,6 +51,14 @@ def real_wav_file():
         temp_path.unlink()
 
 
+@pytest.fixture(autouse=True)
+def _reset_wav_fallback_warning():
+    """Reset the module-level warn-once flag between tests."""
+    _audio_mod._wav_fallback_state["warned"] = False
+    yield
+    _audio_mod._wav_fallback_state["warned"] = False
+
+
 def test_encode_audio_with_tensor_input(sample_audio_tensor):
     result = _audio_mod.encode_audio(
         audio=sample_audio_tensor,
@@ -69,67 +78,84 @@ def test_encode_audio_with_tensor_input(sample_audio_tensor):
 
 
 def test_encode_audio_with_numpy_array(sample_audio_tensor):
+    """
+    Numpy array input has no codec metadata, so format falls back to WAV.
+
+    ## WRITTEN BY AI ##
+    """
     numpy_audio = sample_audio_tensor.numpy()
 
     result = _audio_mod.encode_audio(audio=numpy_audio, sample_rate=16000)
 
     assert result["type"] == "audio_file"
     assert isinstance(result["audio"], bytes)
+    assert result["format"] == "wav"
     assert result["audio_bytes"] > 0
 
 
 def test_encode_audio_with_real_file_path(real_wav_file):
+    """
+    WAV file should be detected as pcm codec and re-encoded as WAV.
+
+    ## WRITTEN BY AI ##
+    """
     result = _audio_mod.encode_audio(
         audio=real_wav_file, sample_rate=16000, max_duration=1.0
     )
 
     assert result["type"] == "audio_file"
     assert isinstance(result["audio"], bytes)
-    assert result["format"] == "mp3"
-    assert result["mimetype"] == "audio/mp3"
+    assert result["format"] == "wav"
+    assert result["mimetype"] == "audio/wav"
     assert result["file_name"] == Path(real_wav_file).name
     assert result["audio_bytes"] > 0
     assert result["audio_seconds"] <= 1.0
 
 
 def test_encode_audio_with_dict_input_complete():
+    """
+    Dict with raw 'data' key (float tensor) has no codec, falls back to WAV.
+
+    ## WRITTEN BY AI ##
+    """
     audio_dict = {"data": torch.randn(1, 16000), "sample_rate": 16000}
 
     result = _audio_mod.encode_audio(audio=audio_dict)
 
     assert result["type"] == "audio_file"
+    assert result["format"] == "wav"
     assert result["audio_bytes"] > 0
     assert result["audio_samples"] == 16000
     assert result["audio_seconds"] == 1.0
 
 
-@patch("httpx.get")
 @patch("guidellm.utils.audio._encode_audio")
-def test_encode_audio_with_url(mock_http_get, sample_audio_tensor):
-    # mock http get response
-    mock_response = MagicMock()
-    mock_response.content = b"fake_audio_content"
-    mock_response.raise_for_status = MagicMock()
-    mock_http_get.return_value = mock_response
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_with_url(mock_decoder, mock_encode, sample_audio_tensor):
+    """
+    URL input: _decode_audio returns codec, format is derived from it.
 
-    # mock decode - return sample audio tensor
-    with patch("guidellm.utils.audio._decode_audio") as mock_decoder:
-        mock_audio_result = MagicMock()
-        mock_audio_result.data = sample_audio_tensor
-        mock_audio_result.sample_rate = 16000
-        mock_decoder.return_value = mock_audio_result
+    ## WRITTEN BY AI ##
+    """
+    mock_audio_result = MagicMock()
+    mock_audio_result.sample_rate = 16000
+    mock_audio_result.duration_seconds = 1.0
+    mock_decoder.return_value = (mock_audio_result, "pcm_s16le")
+    mock_encode.return_value = b"encoded_data"
 
-        result = _audio_mod.encode_audio(
-            audio="https://example.com/audio.wav", sample_rate=16000
-        )
-        assert result["type"] == "audio_file"
+    result = _audio_mod.encode_audio(
+        audio="https://example.com/audio.wav", sample_rate=16000
+    )
+    assert result["type"] == "audio_file"
+    assert result["format"] == "wav"
+    assert result["file_name"] == "audio.wav"
 
 
 def test_encode_audio_with_max_duration(sample_audio_tensor):
     long_audio = torch.randn(1, 32000)
 
     result = _audio_mod.encode_audio(
-        audio=long_audio, sample_rate=16000, max_duration=1.0
+        audio=long_audio, sample_rate=16000, max_duration=1.0, audio_format="wav"
     )
 
     assert result["audio_seconds"] == 1.0
@@ -156,6 +182,7 @@ def test_encode_audio_resampling(sample_audio_tensor):
         audio=sample_audio_tensor,
         sample_rate=original_rate,
         encode_sample_rate=target_rate,
+        audio_format="wav",
     )
 
     assert "audio_samples" in result
@@ -200,3 +227,152 @@ def test_end_to_end_audio_processing(sample_audio_tensor):
     assert result["format"] == "mp3"
     assert result["audio_samples"] == 16000
     assert result["audio_seconds"] == min(original_duration, 0.5)
+
+
+# --- Codec detection tests ---
+
+
+def test_codec_to_format_mapping():
+    """
+    _codec_to_format should map known codec strings to container formats.
+
+    ## WRITTEN BY AI ##
+    """
+    assert _audio_mod._codec_to_format("pcm_s16le") == "wav"
+    assert _audio_mod._codec_to_format("pcm_f32le") == "wav"
+    assert _audio_mod._codec_to_format("flac") == "flac"
+    assert _audio_mod._codec_to_format("mp3") == "mp3"
+    assert _audio_mod._codec_to_format("vorbis") == "ogg"
+    assert _audio_mod._codec_to_format("aac") == "aac"
+    assert _audio_mod._codec_to_format("opus") == "ogg"
+    assert _audio_mod._codec_to_format("unknown_codec") is None
+
+
+def test_codec_detection_from_wav_file(real_wav_file):
+    """
+    Decoding a WAV file should detect a pcm_* codec and re-encode as WAV.
+
+    ## WRITTEN BY AI ##
+    """
+    result = _audio_mod.encode_audio(audio=real_wav_file, max_duration=1.0)
+
+    assert result["format"] == "wav"
+    assert result["mimetype"] == "audio/wav"
+
+
+def test_codec_detection_from_wav_bytes(sample_audio_tensor):
+    """
+    Encoding to WAV then decoding from raw bytes should detect pcm codec
+    and re-encode as WAV without needing explicit audio_format.
+
+    ## WRITTEN BY AI ##
+    """
+    # First encode as WAV to get valid WAV bytes
+    wav_result = _audio_mod.encode_audio(
+        audio=sample_audio_tensor, sample_rate=16000, audio_format="wav"
+    )
+    wav_bytes = wav_result["audio"]
+
+    # Now feed raw bytes back -- codec detection should find pcm_*
+    result = _audio_mod.encode_audio(audio=wav_bytes)
+
+    assert result["format"] == "wav"
+    assert result["mimetype"] == "audio/wav"
+
+
+def test_codec_detection_from_flac_bytes(sample_audio_tensor):
+    """
+    Encoding to FLAC then decoding from raw bytes should detect flac codec
+    and re-encode as FLAC.
+
+    ## WRITTEN BY AI ##
+    """
+    flac_result = _audio_mod.encode_audio(
+        audio=sample_audio_tensor, sample_rate=16000, audio_format="flac"
+    )
+    flac_bytes = flac_result["audio"]
+
+    result = _audio_mod.encode_audio(audio=flac_bytes)
+
+    assert result["format"] == "flac"
+    assert result["mimetype"] == "audio/flac"
+
+
+def test_codec_detection_from_mp3_bytes(sample_audio_tensor):
+    """
+    Encoding to MP3 then decoding from raw bytes should detect mp3 codec
+    and re-encode as MP3.
+
+    ## WRITTEN BY AI ##
+    """
+    mp3_result = _audio_mod.encode_audio(
+        audio=sample_audio_tensor, sample_rate=16000, audio_format="mp3"
+    )
+    mp3_bytes = mp3_result["audio"]
+
+    result = _audio_mod.encode_audio(audio=mp3_bytes)
+
+    assert result["format"] == "mp3"
+    assert result["mimetype"] == "audio/mp3"
+
+
+def test_fallback_to_wav_for_raw_tensor(sample_audio_tensor):
+    """
+    Raw float tensor has no codec info -- should fall back to WAV and
+    emit a warning.
+
+    ## WRITTEN BY AI ##
+    """
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+
+    try:
+        result = _audio_mod.encode_audio(
+            audio=sample_audio_tensor,
+            sample_rate=16000,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert result["format"] == "wav"
+    assert result["mimetype"] == "audio/wav"
+    assert result["file_name"] == "audio.wav"
+    assert any("falling back to WAV" in m for m in messages)
+
+
+def test_warn_once_on_fallback(sample_audio_tensor):
+    """
+    The WAV fallback warning should only fire once per process (reset
+    between tests via fixture).
+
+    ## WRITTEN BY AI ##
+    """
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+
+    try:
+        _audio_mod.encode_audio(audio=sample_audio_tensor, sample_rate=16000)
+        _audio_mod.encode_audio(audio=sample_audio_tensor, sample_rate=16000)
+    finally:
+        logger.remove(sink_id)
+
+    warning_count = sum(1 for m in messages if "falling back to WAV" in m)
+    assert warning_count == 1
+
+
+def test_explicit_format_overrides_codec(real_wav_file):
+    """
+    An explicit audio_format kwarg should override the codec detected
+    from the source.
+
+    ## WRITTEN BY AI ##
+    """
+    result = _audio_mod.encode_audio(
+        audio=real_wav_file,
+        sample_rate=16000,
+        audio_format="mp3",
+        max_duration=1.0,
+    )
+
+    assert result["format"] == "mp3"
+    assert result["mimetype"] == "audio/mp3"

--- a/tests/unit/extras/test_audio.py
+++ b/tests/unit/extras/test_audio.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
-from loguru import logger
 
 from guidellm.utils import audio as _audio_mod
 
@@ -49,14 +48,6 @@ def real_wav_file():
 
     if temp_path.exists():
         temp_path.unlink()
-
-
-@pytest.fixture(autouse=True)
-def _reset_wav_fallback_warning():
-    """Reset the module-level warn-once flag between tests."""
-    _audio_mod._wav_fallback_state["warned"] = False
-    yield
-    _audio_mod._wav_fallback_state["warned"] = False
 
 
 def test_encode_audio_with_tensor_input(sample_audio_tensor):
@@ -314,50 +305,6 @@ def test_codec_detection_from_mp3_bytes(sample_audio_tensor):
 
     assert result["format"] == "mp3"
     assert result["mimetype"] == "audio/mp3"
-
-
-def test_fallback_to_wav_for_raw_tensor(sample_audio_tensor):
-    """
-    Raw float tensor has no codec info -- should fall back to WAV and
-    emit a warning.
-
-    ## WRITTEN BY AI ##
-    """
-    messages: list[str] = []
-    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
-
-    try:
-        result = _audio_mod.encode_audio(
-            audio=sample_audio_tensor,
-            sample_rate=16000,
-        )
-    finally:
-        logger.remove(sink_id)
-
-    assert result["format"] == "wav"
-    assert result["mimetype"] == "audio/wav"
-    assert result["file_name"] == "audio.wav"
-    assert any("falling back to WAV" in m for m in messages)
-
-
-def test_warn_once_on_fallback(sample_audio_tensor):
-    """
-    The WAV fallback warning should only fire once per process (reset
-    between tests via fixture).
-
-    ## WRITTEN BY AI ##
-    """
-    messages: list[str] = []
-    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
-
-    try:
-        _audio_mod.encode_audio(audio=sample_audio_tensor, sample_rate=16000)
-        _audio_mod.encode_audio(audio=sample_audio_tensor, sample_rate=16000)
-    finally:
-        logger.remove(sink_id)
-
-    warning_count = sum(1 for m in messages if "falling back to WAV" in m)
-    assert warning_count == 1
 
 
 def test_explicit_format_overrides_codec(real_wav_file):


### PR DESCRIPTION
## Summary

Uses the source's audio format rather than defaulting to MP3

## Details

- If no format is provided by the user, and it cannot be inferred, it defaults to WAV and warns the user.
- Simply uses the format read from the dataset if none is provided.
- Includes a fix for a missing super call in the response handler.

## Test Plan

Make sure you install vLLM with the audio features.

You can run this with multiple datasets. Some options include:
```bash
guidellm benchmark run   --target "http://localhost:8000"   --request-type /v1/audio/transcriptions   --profile kind=synchronous   --max-requests 10   --data '{"kind": "huggingface", "source": "google/fleurs", "load_kwargs": {"name": "en_us", "split": "test"}}'   --data-column-mapper '{"column_mappings": {"audio_column": "audio"}}'   --disable-progress
```

```bash
guidellm benchmark run   --target "http://localhost:8000"   --request-type /v1/audio/transcriptions   --profile kind=synchronous   --max-requests 10   --data '{"kind": "huggingface", "source": "openslr/librispeech_asr", "load_kwargs": {"name": "clean", "split": "test"}}'   --data-column-mapper '{"column_mappings": {"audio_column": "audio"}}'   --disable-progress
```

To explicitly use MP3 like it used to, do:
```bash
guidellm benchmark run \
  --target "http://localhost:8000" \
  --request-type /v1/audio/transcriptions \
  --profile kind=synchronous \
  --max-requests 10 \
  --data '{"kind": "huggingface", "source": "openslr/librispeech_asr", "load_kwargs": {"name": "clean", "split": "test"}}' \
  --data-column-mapper '{"column_mappings": {"audio_column": "audio"}}' \
  --data-preprocessors '{"kind": "encode_media", "audio_kwargs": {"audio_format": "mp3"}}' \
  --disable-progress
```

## Related Issues

- Resolves #623 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 6cc6e9fa72178752632956b5b193a4107c3aee98
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Jun 11 15:00:08 2026 -0400

    Infer audio encoding format from source instead of defaulting to MP3
    
    Generated-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 09d77d0bd91ad68ad5424b6c3a46554cf0f20c8b
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Mon Jun 15 19:13:30 2026 -0400

    Address review feedback
    
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Claude Opus 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
