### PR TITLE
fix(openai): surface streaming SSE error payloads as request failures (#743)

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -212,7 +212,7 @@ def _wrap_reasoning(reasoning_text: str | None, mode: bool | str) -> str | None:
     """Apply the configured reasoning format to reasoning text.
 
     :param reasoning_text: Raw reasoning text from the model response.
-    :param mode: Wrapping mode â€” False disables, True uses the default
+    :param mode: Wrapping mode — False disables, True uses the default
         ``<think>...</think>`` template, a string is used as a format
         template containing ``{reasoning}``.
     :return: Formatted reasoning string, or None when disabled or no text.
@@ -511,7 +511,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
         if text is None:
-            # text not applicable (e.g. tool-call-only) â€” exclude from aggregation
+            # text not applicable (e.g. tool-call-only) — exclude from aggregation
             text_words = None
             text_chars = None
         else:
@@ -1097,7 +1097,7 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
         if text is None:
-            # text not applicable (e.g. tool-call-only) â€” exclude from aggregation
+            # text not applicable (e.g. tool-call-only) — exclude from aggregation
             text_words = None
             text_chars = None
         else:
@@ -1705,7 +1705,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         # for multimodal breakdowns, mirroring chat completions'
         # "prompt_tokens_details"/"completion_tokens_details".
         if text is None:
-            # text not applicable â€” exclude from aggregation
+            # text not applicable — exclude from aggregation
             text_words = None
             text_chars = None
         else:

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -152,6 +152,38 @@ class OpenAIRequestHandlerFactory(RegistryMixin[type[OpenAIRequestHandler]]):
         return handler_cls()
 
 
+def _check_streaming_error(data: Any) -> None:
+    """Raise when a streaming SSE payload conveys a server-side error.
+
+    Some OpenAI-compatible servers (e.g. vLLM's
+    ``create_streaming_error_response``) return HTTP 200 and report failures
+    through the stream body as ``data: {"error": {...}}`` followed by
+    ``data: [DONE]``. Without this check the error payload is ignored, the
+    request is recorded as a successful but empty generation, and timing
+    metrics (TTFT, ITL) are reported as zero. Raising ``ValueError`` follows
+    the same convention as other request-level failures so the worker marks
+    the request as errored.
+
+    :param data: Parsed JSON payload from a single streaming line.
+    :raises ValueError: If the payload contains a non-empty ``error`` field.
+    """
+    if not isinstance(data, dict):
+        return
+    error = data.get("error")
+    if not error:
+        return
+    if isinstance(error, dict):
+        message = (
+            error.get("message")
+            or error.get("type")
+            or error.get("code")
+            or str(error)
+        )
+    else:
+        message = str(error)
+    raise ValueError(f"Streaming response returned an error: {message}")
+
+
 def _apply_tool_call_metrics(
     output_metrics: UsageMetrics,
     tool_call_count: int,
@@ -454,7 +486,9 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
 
         line = line[len("data:") :].strip()
 
-        return json.loads(line)
+        data = json.loads(line)
+        _check_streaming_error(data)
+        return data
 
     def extract_choices_and_usage(
         self, response: dict
@@ -1432,7 +1466,9 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         if line == "data: [DONE]":
             return None
 
-        return json.loads(line[len("data:") :].strip())
+        data = json.loads(line[len("data:") :].strip())
+        _check_streaming_error(data)
+        return data
 
     @staticmethod
     def _responses_item_to_tool_call(item: dict[str, Any]) -> ToolCall:

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -174,10 +174,7 @@ def _check_streaming_error(data: Any) -> None:
         return
     if isinstance(error, dict):
         message = (
-            error.get("message")
-            or error.get("type")
-            or error.get("code")
-            or str(error)
+            error.get("message") or error.get("type") or error.get("code") or str(error)
         )
     else:
         message = str(error)
@@ -215,7 +212,7 @@ def _wrap_reasoning(reasoning_text: str | None, mode: bool | str) -> str | None:
     """Apply the configured reasoning format to reasoning text.
 
     :param reasoning_text: Raw reasoning text from the model response.
-    :param mode: Wrapping mode — False disables, True uses the default
+    :param mode: Wrapping mode â€” False disables, True uses the default
         ``<think>...</think>`` template, a string is used as a format
         template containing ``{reasoning}``.
     :return: Formatted reasoning string, or None when disabled or no text.
@@ -514,7 +511,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
         if text is None:
-            # text not applicable (e.g. tool-call-only) — exclude from aggregation
+            # text not applicable (e.g. tool-call-only) â€” exclude from aggregation
             text_words = None
             text_chars = None
         else:
@@ -1100,7 +1097,7 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
         :return: Tuple of input_metrics and output_metrics as UsageMetrics objects
         """
         if text is None:
-            # text not applicable (e.g. tool-call-only) — exclude from aggregation
+            # text not applicable (e.g. tool-call-only) â€” exclude from aggregation
             text_words = None
             text_chars = None
         else:
@@ -1708,7 +1705,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         # for multimodal breakdowns, mirroring chat completions'
         # "prompt_tokens_details"/"completion_tokens_details".
         if text is None:
-            # text not applicable — exclude from aggregation
+            # text not applicable â€” exclude from aggregation
             text_words = None
             text_chars = None
         else:

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -428,6 +428,29 @@ class TestTextCompletionsRequestHandler:
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(
+        "line",
+        [
+            'data: {"error": {"message": "TimeoutError", "type": '
+            '"GatewayTimeout", "code": 504}}',
+            'data: {"error": "boom"}',
+        ],
+    )
+    def test_extract_line_data_streaming_error(self, valid_instances, line):
+        """Streaming SSE error payloads must surface as request failures.
+
+        Some OpenAI-compatible servers return HTTP 200 and report errors via
+        the stream body (e.g. vLLM's ``create_streaming_error_response``)
+        rather than an HTTP status, which would otherwise be recorded as a
+        successful empty generation.
+        """
+        instance = valid_instances
+        with pytest.raises(
+            ValueError, match="Streaming response returned an error"
+        ):
+            instance.extract_line_data(line)
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
         ("response", "expected_choices", "expected_usage"),
         [
             (

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -444,9 +444,7 @@ class TestTextCompletionsRequestHandler:
         successful empty generation.
         """
         instance = valid_instances
-        with pytest.raises(
-            ValueError, match="Streaming response returned an error"
-        ):
+        with pytest.raises(ValueError, match="Streaming response returned an error"):
             instance.extract_line_data(line)
 
     @pytest.mark.smoke


### PR DESCRIPTION
## Summary

Fixes #743. Streaming responses that convey a server-side error through the
SSE body — `data: {"error": {...}}` followed by `data: [DONE]`, returned with
HTTP 200 — were treated as successful empty generations.

Several OpenAI-compatible servers report mid-stream failures this way (e.g.
vLLM's `create_streaming_error_response`). Because the HTTP connection
succeeds and guidellm only inspected `choices`/`delta` payloads, the error
field was ignored. The request was recorded as **successful** with:

- TTFT and ITL reported as `0` (no content streamed)
- token counts showing the requested numbers rather than the actual output
- words/characters reported as `0`

## Change

- Add a small module-level helper `_check_streaming_error(data)` that raises
  `ValueError` when a parsed SSE payload carries a non-empty top-level
  `error` field, surfacing the server-provided message
  (`message` → `type` → `code` → repr).
- Call it from both `extract_line_data` implementations: the
  `TextCompletionsRequestHandler` base (shared by chat / audio / pooling) and
  the `ResponsesRequestHandler` override.

Raising `ValueError` matches the existing request-failure convention in this
backend (see `_check_tool_call_expectations`'s `error_stop` path), so the
streaming loop in `http.py` propagates it and the worker marks the request as
errored. Empty or `null` `error` fields (which some servers emit on normal
chunks) are ignored.

## Notes

- The issue raised a design question of *error vs. incomplete* classification.
  This PR implements the straightforward "treat as error" behavior, which is
  the natural default when the error is the first/only streaming message.
  Preserving already-streamed tokens for the partial-then-error case could be
  layered on top later without changing this detection point.

## Test

Adds `test_extract_line_data_streaming_error` asserting `extract_line_data`
raises `ValueError` for both dict-form and string-form error payloads. Since
chat/audio/pooling inherit the base `extract_line_data`, the shared path is
covered once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit 598d578cb5d1fd630e611ad809c173703847c0ff
Author: Tai An <antai12232931@outlook.com>
Date:   Tue Jun 16 10:03:06 2026 +0000

    fix(openai): surface streaming SSE error payloads as request failures (#743)
    
    Some OpenAI-compatible servers (e.g. vLLM's create_streaming_error_response)
    return HTTP 200 and report failures through the stream body as
    `data: {"error": {...}}` followed by `data: [DONE]`. guidellm only inspected
    choices/delta payloads, so the error was silently ignored: the request was
    recorded as a successful but empty generation with TTFT/ITL reported as zero
    and the requested (not actual) token counts.
    
    Add a shared `_check_streaming_error` helper invoked from both
    `extract_line_data` implementations (the TextCompletions base shared by
    chat/audio/pooling, and the Responses override). When a parsed SSE payload
    carries a non-empty top-level `error` field it raises `ValueError` with the
    server-provided message, following the same convention as other request-level
    failures so the worker marks the request as errored. Empty/null `error`
    fields are ignored.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

commit dd7fa5199e34e08dcff38abbf1e0dbd5b1d51980
Author: Tai An <antai12232931@outlook.com>
Date:   Tue Jun 16 22:07:09 2026 +0000

    style: apply ruff format to request_handlers and test
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

commit dbe8daf40e36f759bf70b093e2b8751483ba3ccc
Author: Tai An <antai12232931@outlook.com>
Date:   Thu Jun 18 06:10:28 2026 -0700

    fix: restore em-dashes mangled by Windows cp1252 encoding
    
    dbutenhof noted that the earlier commit converted several em-dashes (U+2014)
    in comments/docstrings of request_handlers.py into mojibake. Restore the
    original em-dash characters.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

---------

Signed-off-by: Tai An <antai12232931@outlook.com>
