### PR TITLE
Force linux LF line endings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ exclude = ["build", "dist", "env", ".venv*"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+line-ending = "lf"
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION

## Summary

PRs are contributed from various sources; we rely on the `ruff` linter to ensure consistency, and to prevent commits from "bouncing" file and code formats depending on origin.

## Details

When files are edited on Windows, they can be (depending on editor settings) converted to a CRLF line termination, which records unnecessary and non-functional diffs (e.g., appearing in GitHub as "whitespace" differences).

`ruff` can be configured to enforce standard line termination. Set `ruff` to always convert to LF line termination.

E.g., `ruff format` will fix this.

## Test Plan

N/A

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit e5e6ca4567365a6abed2526c32b7bce0cd6728c3
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jun 16 12:01:18 2026 -0400

    Force linux LF line endings
    
    Set `ruff` to always convert to LF line termination.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
