### PR TITLE
Simplify constraint parameter names

### DIFF
--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -156,9 +156,7 @@ class ReplayProfile(Profile):
         relative_timestamps = _resolve_relative_timestamps(data, data_samples)
         new_constraints = dict(constraints or {})
         if "max_requests" not in new_constraints:
-            constraint_args = MaxRequestsConstraintArgs(
-                max_num=len(relative_timestamps)
-            )
+            constraint_args = MaxRequestsConstraintArgs(count=len(relative_timestamps))
             new_constraints["max_requests"] = ConstraintsInitializerFactory.create(
                 constraint_args
             )

--- a/src/guidellm/scheduler/constraints/error.py
+++ b/src/guidellm/scheduler/constraints/error.py
@@ -53,7 +53,7 @@ class MaxErrorsConstraintArgs(ConstraintArgs):
         default="max_errors",
         description="Constraint type discriminator",
     )
-    max_errors: PositiveNumOrList = Field(
+    count: PositiveNumOrList = Field(
         description="Maximum number of errors before stopping execution",
     )
 
@@ -72,10 +72,10 @@ class MaxErrorRateConstraintArgs(ConstraintArgs):
         default="max_error_rate",
         description="Constraint type discriminator",
     )
-    max_error_rate: ErrorRateOrList = Field(
+    rate: ErrorRateOrList = Field(
         description="Maximum error rate (0.0 to 1.0) before stopping execution",
     )
-    window_size: int | float = Field(
+    window: int | float = Field(
         default_factory=lambda: settings.constraint_error_window_size,
         gt=0,
         description="Size of sliding window for calculating error rate",
@@ -97,10 +97,10 @@ class MaxGlobalErrorRateConstraintArgs(ConstraintArgs):
         default="max_global_error_rate",
         description="Constraint type discriminator",
     )
-    max_error_rate: ErrorRateOrList = Field(
+    rate: ErrorRateOrList = Field(
         description="Maximum global error rate (0.0 to 1.0) before stopping",
     )
-    min_processed: int | float | None = Field(
+    minimum: int | float | None = Field(
         default_factory=lambda: settings.constraint_error_min_processed,
         gt=0,
         description="Minimum requests processed before applying error rate constraint",
@@ -147,9 +147,9 @@ class MaxErrorsConstraint(PydanticConstraintInitializer):
         _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_errors = (
-            self.args.max_errors
-            if isinstance(self.args.max_errors, int | float)
-            else self.args.max_errors[min(current_index, len(self.args.max_errors) - 1)]
+            self.args.count
+            if isinstance(self.args.count, int | float)
+            else self.args.count[min(current_index, len(self.args.count) - 1)]
         )
         errors_exceeded = state.errored_requests >= max_errors
         stop_time = (
@@ -215,16 +215,14 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
         """
         current_index = max(0, self.current_index)
         max_error_rate = (
-            self.args.max_error_rate
-            if isinstance(self.args.max_error_rate, int | float)
-            else self.args.max_error_rate[
-                min(current_index, len(self.args.max_error_rate) - 1)
-            ]
+            self.args.rate
+            if isinstance(self.args.rate, int | float)
+            else self.args.rate[min(current_index, len(self.args.rate) - 1)]
         )
 
         if request_info.status in ["completed", "errored", "cancelled"]:
             self.error_window.append(request_info.status == "errored")
-            if len(self.error_window) > self.args.window_size:
+            if len(self.error_window) > self.args.window:
                 self.error_window.pop(0)
 
         error_count = sum(self.error_window)
@@ -232,7 +230,7 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
         error_rate = (
             error_count / float(window_requests) if window_requests > 0 else 0.0
         )
-        exceeded_min_processed = state.processed_requests >= self.args.window_size
+        exceeded_min_processed = state.processed_requests >= self.args.window
         exceeded_error_rate = error_rate >= max_error_rate
         exceeded = exceeded_min_processed and exceeded_error_rate
         stop_time = None if not exceeded else request_info.completed_at or time.time()
@@ -242,7 +240,7 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
             request_processing="stop_all" if exceeded else "continue",
             metadata={
                 "max_error_rate": max_error_rate,
-                "window_size": self.args.window_size,
+                "window_size": self.args.window,
                 "error_count": error_count,
                 "processed_count": state.processed_requests,
                 "current_window_size": len(self.error_window),
@@ -298,16 +296,13 @@ class MaxGlobalErrorRateConstraint(PydanticConstraintInitializer):
         _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_error_rate = (
-            self.args.max_error_rate
-            if isinstance(self.args.max_error_rate, int | float)
-            else self.args.max_error_rate[
-                min(current_index, len(self.args.max_error_rate) - 1)
-            ]
+            self.args.rate
+            if isinstance(self.args.rate, int | float)
+            else self.args.rate[min(current_index, len(self.args.rate) - 1)]
         )
 
         exceeded_min_processed = (
-            self.args.min_processed is None
-            or state.processed_requests >= self.args.min_processed
+            self.args.minimum is None or state.processed_requests >= self.args.minimum
         )
         error_rate = (
             state.errored_requests / float(state.processed_requests)
@@ -323,7 +318,7 @@ class MaxGlobalErrorRateConstraint(PydanticConstraintInitializer):
             request_processing="stop_all" if exceeded else "continue",
             metadata={
                 "max_error_rate": max_error_rate,
-                "min_processed": self.args.min_processed,
+                "min_processed": self.args.minimum,
                 "processed_requests": state.processed_requests,
                 "errored_requests": state.errored_requests,
                 "error_rate": error_rate,

--- a/src/guidellm/scheduler/constraints/request.py
+++ b/src/guidellm/scheduler/constraints/request.py
@@ -53,7 +53,7 @@ class MaxDurationConstraintArgs(ConstraintArgs):
         default="max_duration",
         description="Constraint type discriminator",
     )
-    max_duration: PositiveNumOrList = Field(
+    seconds: PositiveNumOrList = Field(
         description="Maximum duration in seconds before stopping execution",
     )
 
@@ -72,7 +72,7 @@ class MaxRequestsConstraintArgs(ConstraintArgs):
         default="max_requests",
         description="Constraint type discriminator",
     )
-    max_num: PositiveNumOrList = Field(
+    count: PositiveNumOrList = Field(
         description="Maximum number of requests before stopping execution",
     )
 
@@ -119,9 +119,9 @@ class MaxNumberConstraint(PydanticConstraintInitializer):
         _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_num = (
-            self.args.max_num
-            if isinstance(self.args.max_num, int | float)
-            else self.args.max_num[min(current_index, len(self.args.max_num) - 1)]
+            self.args.count
+            if isinstance(self.args.count, int | float)
+            else self.args.count[min(current_index, len(self.args.count) - 1)]
         )
 
         create_exceeded = state.created_requests >= max_num
@@ -191,11 +191,9 @@ class MaxDurationConstraint(PydanticConstraintInitializer):
         _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_duration = (
-            self.args.max_duration
-            if isinstance(self.args.max_duration, int | float)
-            else self.args.max_duration[
-                min(current_index, len(self.args.max_duration) - 1)
-            ]
+            self.args.seconds
+            if isinstance(self.args.seconds, int | float)
+            else self.args.seconds[min(current_index, len(self.args.seconds) - 1)]
         )
 
         start_time = state.start_requests_time or state.start_time

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -93,12 +93,12 @@ class OverSaturationConstraintArgs(ConstraintArgs):
         default="over_saturation",
         description="Constraint type discriminator",
     )
-    mode: Literal["active", "passive"] = Field(
-        default="active",
+    mode: Literal["enforce", "monitor"] = Field(
+        default="enforce",
         description=(
             "Whether to stop the benchmark if over-saturation is detected. "
-            "Set to `active` to stop the benchmark if over-saturation is "
-            "detected, and `passive` to only monitor for over-saturation."
+            "Set to `enforce` to stop the benchmark if over-saturation is "
+            "detected, and `monitor` to only report over-saturation."
         ),
     )
     min_seconds: int | float = Field(
@@ -361,7 +361,7 @@ class OverSaturationConstraint(Constraint):
         minimum_window_size: int = 5,
         confidence: float = 0.95,
         eps: float = 1e-12,
-        mode: Literal["active", "passive"] = "active",
+        mode: Literal["enforce", "monitor"] = "enforce",
     ) -> None:  # noqa: PLR0913
         """
         Initialize the over-saturation constraint.
@@ -643,7 +643,7 @@ class OverSaturationConstraintInitializer(PydanticConstraintInitializer):
 
         from guidellm.scheduler.constraints import OverSaturationConstraintArgs
 
-        args = OverSaturationConstraintArgs(mode="active", min_seconds=60.0)
+        args = OverSaturationConstraintArgs(mode="enforce", min_seconds=60.0)
         initializer = OverSaturationConstraintInitializer(args=args)
         constraint = initializer.create_constraint()
     """

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -389,7 +389,7 @@ class OverSaturationConstraint(Constraint):
         :param eps: Epsilon for numerical stability in calculations
             (default: 1e-12)
         :param mode: Whether to stop when over-saturation is detected, or only monitor
-            (default: "active")
+            (default: "enforce")
         """
         self.minimum_duration = minimum_duration
         self.minimum_ttft = minimum_ttft
@@ -613,7 +613,7 @@ class OverSaturationConstraint(Constraint):
         concurrent_slope_moe = self.concurrent_slope_checker.margin_of_error
         concurrent_n = self.concurrent_slope_checker.n
 
-        should_stop = is_over_saturated and self.mode == "active"
+        should_stop = is_over_saturated and self.mode == "enforce"
         return SchedulerUpdateAction(
             request_queuing="stop" if should_stop else "continue",
             request_processing="stop_all" if should_stop else "continue",

--- a/tests/e2e/test_over_saturated_benchmark.py
+++ b/tests/e2e/test_over_saturated_benchmark.py
@@ -52,7 +52,7 @@ def test_over_saturated_benchmark(server: VllmSimServer, tmp_path: Path):
     client.start_benchmark(
         rate=rate,
         max_seconds=20,
-        over_saturation={"mode": "active", "min_seconds": 0},
+        over_saturation={"mode": "enforce", "min_seconds": 0},
         extra_env={
             "GOMAXPROCS": "1",
         },
@@ -97,7 +97,7 @@ def test_over_saturated_benchmark_with_dict_config(
         rate=rate,
         max_seconds=20,
         over_saturation={
-            "mode": "active",
+            "mode": "enforce",
             "min_seconds": 0,
             "max_window_seconds": 120.0,
             "moe_threshold": 2.0,

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -93,15 +93,13 @@ class GuidellmClient:
         ]
 
         if max_seconds is not None:
-            cmd_parts.append(f'--constraint max_duration "max_duration={max_seconds}"')
+            cmd_parts.append(f'--constraint max_duration "seconds={max_seconds}"')
 
         if max_requests is not None:
-            cmd_parts.append(f'--constraint max_requests "max_num={max_requests}"')
+            cmd_parts.append(f'--constraint max_requests "count={max_requests}"')
 
         if max_error_rate is not None:
-            cmd_parts.append(
-                f'--constraint max_error_rate "max_error_rate={max_error_rate}"'
-            )
+            cmd_parts.append(f'--constraint max_error_rate "rate={max_error_rate}"')
 
         if over_saturation is not None:
             if not isinstance(over_saturation, dict):

--- a/tests/integration/scheduler/test_scheduler.py
+++ b/tests/integration/scheduler/test_scheduler.py
@@ -103,7 +103,7 @@ class MockBackend(BackendInterface):
             NonDistributedEnvironment(),
             {
                 "max_requests": MaxNumberConstraint(
-                    args=MaxRequestsConstraintArgs(max_num=100)
+                    args=MaxRequestsConstraintArgs(count=100)
                 )
             },
         ),

--- a/tests/integration/scheduler/test_scheduler.py
+++ b/tests/integration/scheduler/test_scheduler.py
@@ -156,15 +156,15 @@ async def test_scheduler_run_integration(
         last_state = state
 
     assert len(received_updates) == num_requests
-    assert len(received_responses) == constraints["max_requests"].args.max_num
-    assert last_state.created_requests == constraints["max_requests"].args.max_num
+    assert len(received_responses) == constraints["max_requests"].args.count
+    assert last_state.created_requests == constraints["max_requests"].args.count
     assert last_state.queued_requests == 0
     assert last_state.processing_requests == 0
-    assert last_state.processed_requests == constraints["max_requests"].args.max_num
+    assert last_state.processed_requests == constraints["max_requests"].args.count
     assert last_state.cancelled_requests == 0
     assert (
         last_state.successful_requests + last_state.errored_requests
-    ) == constraints["max_requests"].args.max_num
+    ) == constraints["max_requests"].args.count
 
     def _request_indices():
         while True:

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -162,7 +162,7 @@ async def test_trace_replay_multiprocess_from_trace_file(tmp_path: Path):
         requests=requests,
         strategy=strategy,
         max_number=MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=NUM_REQUESTS)
+            args=MaxRequestsConstraintArgs(count=NUM_REQUESTS)
         ),
     )
 

--- a/tests/integration/scheduler/test_worker_group.py
+++ b/tests/integration/scheduler/test_worker_group.py
@@ -128,27 +128,23 @@ class TestWorkerGroup:
         [
             {
                 "max_requests": MaxNumberConstraint(
-                    args=MaxRequestsConstraintArgs(max_num=100)
+                    args=MaxRequestsConstraintArgs(count=100)
                 )
             },
             {
                 "max_duration": MaxDurationConstraint(
-                    args=MaxDurationConstraintArgs(max_duration=0.5)
+                    args=MaxDurationConstraintArgs(seconds=0.5)
                 )
             },
-            {
-                "max_errors": MaxErrorsConstraint(
-                    args=MaxErrorsConstraintArgs(max_errors=20)
-                )
-            },
+            {"max_errors": MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count=20))},
             {
                 "max_error_rate": MaxErrorRateConstraint(
-                    args=MaxErrorRateConstraintArgs(max_error_rate=0.1)
+                    args=MaxErrorRateConstraintArgs(rate=0.1)
                 )
             },
             {
                 "max_global_error_rate": MaxGlobalErrorRateConstraint(
-                    args=MaxGlobalErrorRateConstraintArgs(max_error_rate=0.1)
+                    args=MaxGlobalErrorRateConstraintArgs(rate=0.1)
                 )
             },
         ],

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -124,7 +124,7 @@ class TestReplayProfile:
         assert isinstance(profile, ReplayProfile)
         assert profile.args.time_scale == expected_scale
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=3), current_index=-1
+            args=MaxRequestsConstraintArgs(count=3), current_index=-1
         )
 
     @pytest.mark.sanity
@@ -166,7 +166,7 @@ class TestReplayProfile:
         )
 
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=3), current_index=-1
+            args=MaxRequestsConstraintArgs(count=3), current_index=-1
         )
 
     @pytest.mark.smoke
@@ -250,7 +250,7 @@ class TestReplayProfile:
         profile = _replay_profile(data=[TraceSyntheticDataArgs(path=trace)])
 
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=27), current_index=-1
+            args=MaxRequestsConstraintArgs(count=27), current_index=-1
         )
 
     @pytest.mark.smoke
@@ -347,7 +347,7 @@ class TestReplayProfile:
         )
 
         assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=2), current_index=-1
+            args=MaxRequestsConstraintArgs(count=2), current_index=-1
         )
 
     @pytest.mark.smoke

--- a/tests/unit/scheduler/test_constraint_args.py
+++ b/tests/unit/scheduler/test_constraint_args.py
@@ -128,10 +128,10 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxDurationConstraintArgs(max_duration=300)
+        args = MaxDurationConstraintArgs(seconds=300)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxDurationConstraint)
-        assert init.args.max_duration == 300
+        assert init.args.seconds == 300
 
     @pytest.mark.smoke
     def test_max_duration_list_values(self):
@@ -140,10 +140,10 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxDurationConstraintArgs(max_duration=[60, 120, 300])
+        args = MaxDurationConstraintArgs(seconds=[60, 120, 300])
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxDurationConstraint)
-        assert init.args.max_duration == [60, 120, 300]
+        assert init.args.seconds == [60, 120, 300]
 
     @pytest.mark.smoke
     def test_max_requests_to_initializer(self):
@@ -152,10 +152,10 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxRequestsConstraintArgs(max_num=1000)
+        args = MaxRequestsConstraintArgs(count=1000)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxNumberConstraint)
-        assert init.args.max_num == 1000
+        assert init.args.count == 1000
 
     @pytest.mark.smoke
     def test_max_errors_to_initializer(self):
@@ -164,10 +164,10 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxErrorsConstraintArgs(max_errors=10)
+        args = MaxErrorsConstraintArgs(count=10)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxErrorsConstraint)
-        assert init.args.max_errors == 10
+        assert init.args.count == 10
 
     @pytest.mark.smoke
     def test_max_error_rate_to_initializer(self):
@@ -176,11 +176,11 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxErrorRateConstraintArgs(max_error_rate=0.5, window_size=50)
+        args = MaxErrorRateConstraintArgs(rate=0.5, window=50)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxErrorRateConstraint)
-        assert init.args.max_error_rate == 0.5
-        assert init.args.window_size == 50
+        assert init.args.rate == 0.5
+        assert init.args.window == 50
 
     @pytest.mark.smoke
     def test_max_error_rate_default_window_size(self):
@@ -189,10 +189,10 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxErrorRateConstraintArgs(max_error_rate=0.3)
+        args = MaxErrorRateConstraintArgs(rate=0.3)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxErrorRateConstraint)
-        assert init.args.window_size == 30  # settings default
+        assert init.args.window == 30  # settings default
 
     @pytest.mark.smoke
     def test_max_global_error_rate_to_initializer(self):
@@ -201,11 +201,11 @@ class TestConstraintArgsToInitializerHelper:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxGlobalErrorRateConstraintArgs(max_error_rate=0.2, min_processed=50)
+        args = MaxGlobalErrorRateConstraintArgs(rate=0.2, minimum=50)
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, MaxGlobalErrorRateConstraint)
-        assert init.args.max_error_rate == 0.2
-        assert init.args.min_processed == 50
+        assert init.args.rate == 0.2
+        assert init.args.minimum == 50
 
     @pytest.mark.smoke
     def test_over_saturation_to_initializer(self):
@@ -290,8 +290,8 @@ class TestResolveConstraintsTranslation:
         assert "max_requests" in resolved
         assert isinstance(resolved["max_duration"], MaxDurationConstraint)
         assert isinstance(resolved["max_requests"], MaxNumberConstraint)
-        assert resolved["max_duration"].args.max_duration == 120
-        assert resolved["max_requests"].args.max_num == 500
+        assert resolved["max_duration"].args.seconds == 120
+        assert resolved["max_requests"].args.count == 500
 
     @pytest.mark.smoke
     def test_no_constraints_returns_empty(self):

--- a/tests/unit/scheduler/test_constraint_args.py
+++ b/tests/unit/scheduler/test_constraint_args.py
@@ -58,19 +58,19 @@ class TestConstraintArgsPolymorphicValidation:
     @pytest.mark.parametrize(
         ("payload", "expected_type"),
         [
-            ({"kind": "max_duration", "max_duration": 60}, MaxDurationConstraintArgs),
-            ({"kind": "max_requests", "max_num": 100}, MaxRequestsConstraintArgs),
-            ({"kind": "max_errors", "max_errors": 5}, MaxErrorsConstraintArgs),
+            ({"kind": "max_duration", "seconds": 60}, MaxDurationConstraintArgs),
+            ({"kind": "max_requests", "count": 100}, MaxRequestsConstraintArgs),
+            ({"kind": "max_errors", "count": 5}, MaxErrorsConstraintArgs),
             (
-                {"kind": "max_error_rate", "max_error_rate": 0.5},
+                {"kind": "max_error_rate", "rate": 0.5},
                 MaxErrorRateConstraintArgs,
             ),
             (
-                {"kind": "max_global_error_rate", "max_error_rate": 0.3},
+                {"kind": "max_global_error_rate", "rate": 0.3},
                 MaxGlobalErrorRateConstraintArgs,
             ),
             (
-                {"kind": "over_saturation", "mode": "active"},
+                {"kind": "over_saturation", "mode": "enforce"},
                 OverSaturationConstraintArgs,
             ),
         ],
@@ -114,7 +114,7 @@ class TestConstraintArgsPolymorphicValidation:
         """
         with pytest.raises(ValidationError):
             ConstraintArgs.model_validate(
-                {"kind": "max_duration", "max_duration": 60, "bogus_field": True}
+                {"kind": "max_duration", "seconds": 60, "bogus_field": True}
             )
 
 
@@ -216,11 +216,11 @@ class TestConstraintArgsToInitializerHelper:
         ## WRITTEN BY AI ##
         """
         args = OverSaturationConstraintArgs(
-            mode="active", min_seconds=60, max_window_seconds=180
+            mode="enforce", min_seconds=60, max_window_seconds=180
         )
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, OverSaturationConstraintInitializer)
-        assert init.args.mode == "active"
+        assert init.args.mode == "enforce"
         assert init.args.min_seconds == 60
         assert init.args.max_window_seconds == 180
 
@@ -234,7 +234,7 @@ class TestConstraintArgsToInitializerHelper:
         args = OverSaturationConstraintArgs()
         init = ConstraintsInitializerFactory.create(args)
         assert isinstance(init, OverSaturationConstraintInitializer)
-        assert init.args.mode == "active"
+        assert init.args.mode == "enforce"
         assert init.args.min_seconds == 30.0
         assert init.args.moe_threshold == 2.0
 
@@ -246,13 +246,13 @@ class TestConstraintArgsConstraintKey:
     @pytest.mark.parametrize(
         ("args_class", "kwargs", "expected_key"),
         [
-            (MaxDurationConstraintArgs, {"max_duration": 60}, "max_duration"),
-            (MaxRequestsConstraintArgs, {"max_num": 100}, "max_requests"),
-            (MaxErrorsConstraintArgs, {"max_errors": 5}, "max_errors"),
-            (MaxErrorRateConstraintArgs, {"max_error_rate": 0.5}, "max_error_rate"),
+            (MaxDurationConstraintArgs, {"seconds": 60}, "max_duration"),
+            (MaxRequestsConstraintArgs, {"count": 100}, "max_requests"),
+            (MaxErrorsConstraintArgs, {"count": 5}, "max_errors"),
+            (MaxErrorRateConstraintArgs, {"rate": 0.5}, "max_error_rate"),
             (
                 MaxGlobalErrorRateConstraintArgs,
-                {"max_error_rate": 0.3},
+                {"rate": 0.3},
                 "max_global_error_rate",
             ),
             (OverSaturationConstraintArgs, {}, "over_saturation"),
@@ -280,8 +280,8 @@ class TestResolveConstraintsTranslation:
         """
         args = _minimal_args(
             constraints=[
-                {"kind": "max_duration", "max_duration": 120},
-                {"kind": "max_requests", "max_num": 500},
+                {"kind": "max_duration", "seconds": 120},
+                {"kind": "max_requests", "count": 500},
             ]
         )
         resolved = resolve_constraints(args)
@@ -313,8 +313,8 @@ class TestResolveConstraintsTranslation:
         """
         args = _minimal_args(
             constraints=[
-                {"kind": "max_duration", "max_duration": 60},
-                {"kind": "max_errors", "max_errors": 3},
+                {"kind": "max_duration", "seconds": 60},
+                {"kind": "max_errors", "count": 3},
             ]
         )
         resolved = resolve_constraints(args)
@@ -331,7 +331,7 @@ class TestResolveConstraintsTranslation:
 
         ## WRITTEN BY AI ##
         """
-        args = _minimal_args(constraints=[{"kind": "max_duration", "max_duration": 60}])
+        args = _minimal_args(constraints=[{"kind": "max_duration", "seconds": 60}])
         resolved = resolve_constraints(args, max_requests=200)
         assert "max_duration" in resolved
         assert "max_requests" in resolved
@@ -345,7 +345,7 @@ class TestResolveConstraintsTranslation:
         """
         args = _minimal_args(
             constraints=[
-                {"kind": "over_saturation", "mode": "active", "min_seconds": 45}
+                {"kind": "over_saturation", "mode": "enforce", "min_seconds": 45}
             ]
         )
         resolved = resolve_constraints(args)
@@ -353,7 +353,7 @@ class TestResolveConstraintsTranslation:
         assert "over_saturation" in resolved
         init = resolved["over_saturation"]
         assert isinstance(init, OverSaturationConstraintInitializer)
-        assert init.args.mode == "active"
+        assert init.args.mode == "enforce"
         assert init.args.min_seconds == 45
 
     @pytest.mark.smoke
@@ -365,12 +365,12 @@ class TestResolveConstraintsTranslation:
         """
         args = _minimal_args(
             constraints=[
-                {"kind": "max_duration", "max_duration": 120},
-                {"kind": "max_requests", "max_num": 1000},
-                {"kind": "max_errors", "max_errors": 10},
-                {"kind": "max_error_rate", "max_error_rate": 0.5},
-                {"kind": "max_global_error_rate", "max_error_rate": 0.3},
-                {"kind": "over_saturation", "mode": "active"},
+                {"kind": "max_duration", "seconds": 120},
+                {"kind": "max_requests", "count": 1000},
+                {"kind": "max_errors", "count": 10},
+                {"kind": "max_error_rate", "rate": 0.5},
+                {"kind": "max_global_error_rate", "rate": 0.3},
+                {"kind": "over_saturation", "mode": "enforce"},
             ]
         )
         resolved = resolve_constraints(args)
@@ -391,11 +391,11 @@ class TestResolveConstraintsTranslation:
 
         ## WRITTEN BY AI ##
         """
-        args = _minimal_args(constraints=[{"kind": "max_requests", "max_num": 50}])
+        args = _minimal_args(constraints=[{"kind": "max_requests", "count": 50}])
         assert len(args.constraints) == 1
         resolved = resolve_constraints(args)
         assert "max_requests" in resolved
-        assert resolved["max_requests"].args.max_num == 50
+        assert resolved["max_requests"].args.count == 50
 
 
 class TestConstraintArgsSerialization:
@@ -405,12 +405,12 @@ class TestConstraintArgsSerialization:
     @pytest.mark.parametrize(
         "payload",
         [
-            {"kind": "max_duration", "max_duration": 120},
-            {"kind": "max_requests", "max_num": 500},
-            {"kind": "max_errors", "max_errors": 10},
-            {"kind": "max_error_rate", "max_error_rate": 0.5, "window_size": 20},
-            {"kind": "max_global_error_rate", "max_error_rate": 0.3},
-            {"kind": "over_saturation", "mode": "active", "min_seconds": 45},
+            {"kind": "max_duration", "seconds": 120},
+            {"kind": "max_requests", "count": 500},
+            {"kind": "max_errors", "count": 10},
+            {"kind": "max_error_rate", "rate": 0.5, "window": 20},
+            {"kind": "max_global_error_rate", "rate": 0.3},
+            {"kind": "over_saturation", "mode": "enforce", "min_seconds": 45},
         ],
     )
     def test_model_dump_round_trip(self, payload):

--- a/tests/unit/scheduler/test_constraints.py
+++ b/tests/unit/scheduler/test_constraints.py
@@ -309,7 +309,7 @@ class TestUnserializableConstraintInitializer:
 class TestMaxNumberConstraint:
     """Test the MaxNumberConstraint implementation."""
 
-    @pytest.fixture(params=[{"max_num": 100}, {"max_num": 50.5}, {"max_num": 1}])
+    @pytest.fixture(params=[{"count": 100}, {"count": 50.5}, {"count": 1}])
     def valid_instances(self, request):
         constructor_args = request.param
         instance = MaxNumberConstraint(
@@ -357,7 +357,7 @@ class TestMaxNumberConstraint:
         instance, constructor_args = valid_instances
         start_time = time.time()
 
-        for num_requests in range(0, int(constructor_args["max_num"]) * 2 + 1, 1):
+        for num_requests in range(0, int(constructor_args["count"]) * 2 + 1, 1):
             state = SchedulerState(
                 start_time=start_time,
                 created_requests=num_requests,
@@ -381,7 +381,7 @@ class TestMaxNumberConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxNumberConstraint.model_validate(data)
-        assert reconstructed.args.count == instance.args.max_num
+        assert reconstructed.args.count == instance.args.count
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -393,7 +393,7 @@ class TestMaxNumberConstraint:
 
         constraint = instance.create_constraint()
         assert isinstance(constraint, MaxNumberConstraint)
-        assert constraint.args.count == constructor_args["max_num"]
+        assert constraint.args.count == constructor_args["count"]
 
     @pytest.mark.smoke
     def test_create_constraint(self, valid_instances):
@@ -404,7 +404,7 @@ class TestMaxNumberConstraint:
 
         assert isinstance(constraint, MaxNumberConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.count == instance.args.max_num
+        assert constraint.args.count == instance.args.count
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -445,9 +445,7 @@ class TestMaxNumberConstraint:
 class TestMaxDurationConstraint:
     """Test the MaxDurationConstraint implementation."""
 
-    @pytest.fixture(
-        params=[{"max_duration": 2.0}, {"max_duration": 1}, {"max_duration": 0.5}]
-    )
+    @pytest.fixture(params=[{"seconds": 2.0}, {"seconds": 1}, {"seconds": 0.5}])
     def valid_instances(self, request):
         constructor_args = request.param
         instance = MaxDurationConstraint(
@@ -497,7 +495,7 @@ class TestMaxDurationConstraint:
         instance, constructor_args = valid_instances
         start_time = time.time()
 
-        max_duration = constructor_args["max_duration"]
+        max_duration = constructor_args["seconds"]
         sleep_interval = max_duration * 0.05
         target_duration = max_duration * 1.5
 
@@ -560,7 +558,7 @@ class TestMaxDurationConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxDurationConstraint.model_validate(data)
-        assert reconstructed.args.seconds == instance.args.max_duration
+        assert reconstructed.args.seconds == instance.args.seconds
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -572,7 +570,7 @@ class TestMaxDurationConstraint:
 
         constraint = instance.create_constraint()
         assert isinstance(constraint, MaxDurationConstraint)
-        assert constraint.args.seconds == constructor_args["max_duration"]
+        assert constraint.args.seconds == constructor_args["seconds"]
 
     @pytest.mark.smoke
     def test_create_constraint(self, valid_instances):
@@ -583,7 +581,7 @@ class TestMaxDurationConstraint:
 
         assert isinstance(constraint, MaxDurationConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.seconds == instance.args.max_duration
+        assert constraint.args.seconds == instance.args.seconds
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -624,7 +622,7 @@ class TestMaxDurationConstraint:
 class TestMaxErrorsConstraint:
     """Test the MaxErrorsConstraint implementation."""
 
-    @pytest.fixture(params=[{"max_errors": 10}, {"max_errors": 5.5}, {"max_errors": 1}])
+    @pytest.fixture(params=[{"count": 10}, {"count": 5.5}, {"count": 1}])
     def valid_instances(self, request):
         constructor_args = request.param
         instance = MaxErrorsConstraint(args=MaxErrorsConstraintArgs(**constructor_args))
@@ -672,7 +670,7 @@ class TestMaxErrorsConstraint:
         instance, constructor_args = valid_instances
         start_time = time.time()
 
-        for num_errors in range(int(constructor_args["max_errors"] * 2)):
+        for num_errors in range(int(constructor_args["count"] * 2)):
             created_requests = (num_errors + 1) * 2
             processed_requests = num_errors + 1
             state = SchedulerState(
@@ -692,7 +690,7 @@ class TestMaxErrorsConstraint:
             )
             action = instance(state, request)
             assert isinstance(action, SchedulerUpdateAction)
-            errors_exceeded = num_errors >= constructor_args["max_errors"]
+            errors_exceeded = num_errors >= constructor_args["count"]
             if not errors_exceeded:
                 assert action.request_queuing == "continue"
                 assert action.request_processing == "continue"
@@ -702,7 +700,7 @@ class TestMaxErrorsConstraint:
 
             assert isinstance(action.metadata, dict)
             expected_metadata = {
-                "max_errors": constructor_args["max_errors"],
+                "max_errors": constructor_args["count"],
                 "errors_exceeded": errors_exceeded,
                 "current_errors": num_errors,
             }
@@ -722,7 +720,7 @@ class TestMaxErrorsConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxErrorsConstraint.model_validate(data)
-        assert reconstructed.args.count == instance.args.max_errors
+        assert reconstructed.args.count == instance.args.count
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -736,7 +734,7 @@ class TestMaxErrorsConstraint:
 
         assert isinstance(constraint, MaxErrorsConstraint)
         assert constraint is not instance
-        assert constraint.args.count == instance.args.max_errors
+        assert constraint.args.count == instance.args.count
         assert instance.current_index == original_index + 1
         assert constraint.current_index == original_index + 1
 
@@ -779,9 +777,9 @@ class TestMaxErrorRateConstraint:
 
     @pytest.fixture(
         params=[
-            {"max_error_rate": 0.1, "window_size": 40},
-            {"max_error_rate": 0.5, "window_size": 50},
-            {"max_error_rate": 0.05, "window_size": 55},
+            {"rate": 0.1, "window": 40},
+            {"rate": 0.5, "window": 50},
+            {"rate": 0.05, "window": 55},
         ]
     )
     def valid_instances(self, request):
@@ -837,8 +835,8 @@ class TestMaxErrorRateConstraint:
         instance, constructor_args = valid_instances
         start_time = time.time()
 
-        max_error_rate = constructor_args["max_error_rate"]
-        window_size = constructor_args["window_size"]
+        max_error_rate = constructor_args["rate"]
+        window_size = constructor_args["window"]
         safety_factor = 1.5
         total_errors = 0
         error_window = []
@@ -910,8 +908,8 @@ class TestMaxErrorRateConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxErrorRateConstraint.model_validate(data)
-        assert reconstructed.args.rate == instance.args.max_error_rate
-        assert reconstructed.args.window == instance.args.window_size
+        assert reconstructed.args.rate == instance.args.rate
+        assert reconstructed.args.window == instance.args.window
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -925,8 +923,8 @@ class TestMaxErrorRateConstraint:
 
         assert isinstance(constraint, MaxErrorRateConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.rate == instance.args.max_error_rate
-        assert constraint.args.window == instance.args.window_size
+        assert constraint.args.rate == instance.args.rate
+        assert constraint.args.window == instance.args.window
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -972,9 +970,9 @@ class TestMaxGlobalErrorRateConstraint:
 
     @pytest.fixture(
         params=[
-            {"max_error_rate": 0.1, "min_processed": 50},
-            {"max_error_rate": 0.2, "min_processed": 100},
-            {"max_error_rate": 0.05, "min_processed": 31},
+            {"rate": 0.1, "minimum": 50},
+            {"rate": 0.2, "minimum": 100},
+            {"rate": 0.05, "minimum": 31},
         ]
     )
     def valid_instances(self, request):
@@ -1039,8 +1037,8 @@ class TestMaxGlobalErrorRateConstraint:
         instance, constructor_args = valid_instances
         start_time = time.time()
 
-        max_error_rate = constructor_args["max_error_rate"]
-        min_processed = constructor_args["min_processed"]
+        max_error_rate = constructor_args["rate"]
+        min_processed = constructor_args["minimum"]
         safety_factor = 1.5
         total_requests = min_processed * 2
         total_errors = 0
@@ -1117,8 +1115,8 @@ class TestMaxGlobalErrorRateConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxGlobalErrorRateConstraint.model_validate(data)
-        assert reconstructed.args.rate == instance.args.max_error_rate
-        assert reconstructed.args.minimum == instance.args.min_processed
+        assert reconstructed.args.rate == instance.args.rate
+        assert reconstructed.args.minimum == instance.args.minimum
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -1132,8 +1130,8 @@ class TestMaxGlobalErrorRateConstraint:
 
         assert isinstance(constraint, MaxGlobalErrorRateConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.rate == instance.args.max_error_rate
-        assert constraint.args.minimum == instance.args.min_processed
+        assert constraint.args.rate == instance.args.rate
+        assert constraint.args.minimum == instance.args.minimum
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -1224,7 +1222,7 @@ class TestConstraintsInitializerFactory:
     def test_resolve_with_invalid_type(self):
         """Test that resolve raises TypeError for unsupported value types."""
         invalid_spec = {
-            "max_requests": {"max_num": 100},  # raw dicts are no longer supported
+            "max_requests": {"count": 100},  # raw dicts are no longer supported
         }
 
         with pytest.raises(TypeError, match="unsupported value type"):

--- a/tests/unit/scheduler/test_constraints.py
+++ b/tests/unit/scheduler/test_constraints.py
@@ -345,11 +345,11 @@ class TestMaxNumberConstraint:
         with pytest.raises(ValidationError):
             MaxNumberConstraint()
         with pytest.raises(ValidationError):
-            MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num=-1))
+            MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=-1))
         with pytest.raises(ValidationError):
-            MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num=0))
+            MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=0))
         with pytest.raises(ValidationError):
-            MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num="invalid"))
+            MaxNumberConstraint(args=MaxRequestsConstraintArgs(count="invalid"))
 
     @pytest.mark.smoke
     def test_constraint_functionality(self, valid_instances):
@@ -381,7 +381,7 @@ class TestMaxNumberConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxNumberConstraint.model_validate(data)
-        assert reconstructed.args.max_num == instance.args.max_num
+        assert reconstructed.args.count == instance.args.max_num
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -393,7 +393,7 @@ class TestMaxNumberConstraint:
 
         constraint = instance.create_constraint()
         assert isinstance(constraint, MaxNumberConstraint)
-        assert constraint.args.max_num == constructor_args["max_num"]
+        assert constraint.args.count == constructor_args["max_num"]
 
     @pytest.mark.smoke
     def test_create_constraint(self, valid_instances):
@@ -404,7 +404,7 @@ class TestMaxNumberConstraint:
 
         assert isinstance(constraint, MaxNumberConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.max_num == instance.args.max_num
+        assert constraint.args.count == instance.args.max_num
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -426,10 +426,10 @@ class TestMaxNumberConstraint:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxRequestsConstraintArgs(max_num=100)
+        args = MaxRequestsConstraintArgs(count=100)
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, MaxNumberConstraint)
-        assert initializer.args.max_num == 100
+        assert initializer.args.count == 100
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -437,7 +437,7 @@ class TestMaxNumberConstraint:
 
         ## WRITTEN BY AI ##
         """
-        instance = MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num=75))
+        instance = MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=75))
         resolved = ConstraintsInitializerFactory.resolve({"max_requests": instance})
         assert isinstance(resolved["max_requests"], MaxNumberConstraint)
 
@@ -485,13 +485,11 @@ class TestMaxDurationConstraint:
         with pytest.raises(ValidationError):
             MaxDurationConstraint()
         with pytest.raises(ValidationError):
-            MaxDurationConstraint(args=MaxDurationConstraintArgs(max_duration=-1))
+            MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=-1))
         with pytest.raises(ValidationError):
-            MaxDurationConstraint(args=MaxDurationConstraintArgs(max_duration=0))
+            MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=0))
         with pytest.raises(ValidationError):
-            MaxDurationConstraint(
-                args=MaxDurationConstraintArgs(max_duration="invalid")
-            )
+            MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds="invalid"))
 
     @pytest.mark.smoke
     def test_constraint_functionality(self, valid_instances):
@@ -562,7 +560,7 @@ class TestMaxDurationConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxDurationConstraint.model_validate(data)
-        assert reconstructed.args.max_duration == instance.args.max_duration
+        assert reconstructed.args.seconds == instance.args.max_duration
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -574,7 +572,7 @@ class TestMaxDurationConstraint:
 
         constraint = instance.create_constraint()
         assert isinstance(constraint, MaxDurationConstraint)
-        assert constraint.args.max_duration == constructor_args["max_duration"]
+        assert constraint.args.seconds == constructor_args["max_duration"]
 
     @pytest.mark.smoke
     def test_create_constraint(self, valid_instances):
@@ -585,7 +583,7 @@ class TestMaxDurationConstraint:
 
         assert isinstance(constraint, MaxDurationConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.max_duration == instance.args.max_duration
+        assert constraint.args.seconds == instance.args.max_duration
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -607,10 +605,10 @@ class TestMaxDurationConstraint:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxDurationConstraintArgs(max_duration=60.0)
+        args = MaxDurationConstraintArgs(seconds=60.0)
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, MaxDurationConstraint)
-        assert initializer.args.max_duration == 60.0
+        assert initializer.args.seconds == 60.0
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -618,9 +616,7 @@ class TestMaxDurationConstraint:
 
         ## WRITTEN BY AI ##
         """
-        instance = MaxDurationConstraint(
-            args=MaxDurationConstraintArgs(max_duration=45.0)
-        )
+        instance = MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=45.0))
         resolved = ConstraintsInitializerFactory.resolve({"max_duration": instance})
         assert isinstance(resolved["max_duration"], MaxDurationConstraint)
 
@@ -664,11 +660,11 @@ class TestMaxErrorsConstraint:
         with pytest.raises(ValidationError):
             MaxErrorsConstraint()
         with pytest.raises(ValidationError):
-            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(max_errors=-1))
+            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count=-1))
         with pytest.raises(ValidationError):
-            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(max_errors=0))
+            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count=0))
         with pytest.raises(ValidationError):
-            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(max_errors="invalid"))
+            MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count="invalid"))
 
     @pytest.mark.smoke
     def test_constraint_functionality(self, valid_instances):
@@ -726,7 +722,7 @@ class TestMaxErrorsConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxErrorsConstraint.model_validate(data)
-        assert reconstructed.args.max_errors == instance.args.max_errors
+        assert reconstructed.args.count == instance.args.max_errors
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -740,7 +736,7 @@ class TestMaxErrorsConstraint:
 
         assert isinstance(constraint, MaxErrorsConstraint)
         assert constraint is not instance
-        assert constraint.args.max_errors == instance.args.max_errors
+        assert constraint.args.count == instance.args.max_errors
         assert instance.current_index == original_index + 1
         assert constraint.current_index == original_index + 1
 
@@ -762,10 +758,10 @@ class TestMaxErrorsConstraint:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxErrorsConstraintArgs(max_errors=10)
+        args = MaxErrorsConstraintArgs(count=10)
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, MaxErrorsConstraint)
-        assert initializer.args.max_errors == 10
+        assert initializer.args.count == 10
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -773,7 +769,7 @@ class TestMaxErrorsConstraint:
 
         ## WRITTEN BY AI ##
         """
-        instance = MaxErrorsConstraint(args=MaxErrorsConstraintArgs(max_errors=3))
+        instance = MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count=3))
         resolved = ConstraintsInitializerFactory.resolve({"max_errors": instance})
         assert isinstance(resolved["max_errors"], MaxErrorsConstraint)
 
@@ -825,19 +821,15 @@ class TestMaxErrorRateConstraint:
         with pytest.raises(ValidationError):
             MaxErrorRateConstraint()
         with pytest.raises(ValidationError):
-            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(max_error_rate=0))
+            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(rate=0))
         with pytest.raises(ValidationError):
-            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(max_error_rate=-1))
+            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(rate=-1))
         with pytest.raises(ValidationError):
-            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(max_error_rate=1.5))
+            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(rate=1.5))
         with pytest.raises(ValidationError):
-            MaxErrorRateConstraint(
-                args=MaxErrorRateConstraintArgs(max_error_rate=0.5, window_size=0)
-            )
+            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(rate=0.5, window=0))
         with pytest.raises(ValidationError):
-            MaxErrorRateConstraint(
-                args=MaxErrorRateConstraintArgs(max_error_rate="invalid")
-            )
+            MaxErrorRateConstraint(args=MaxErrorRateConstraintArgs(rate="invalid"))
 
     @pytest.mark.smoke
     def test_constraint_functionality(self, valid_instances):
@@ -918,8 +910,8 @@ class TestMaxErrorRateConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxErrorRateConstraint.model_validate(data)
-        assert reconstructed.args.max_error_rate == instance.args.max_error_rate
-        assert reconstructed.args.window_size == instance.args.window_size
+        assert reconstructed.args.rate == instance.args.max_error_rate
+        assert reconstructed.args.window == instance.args.window_size
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -933,8 +925,8 @@ class TestMaxErrorRateConstraint:
 
         assert isinstance(constraint, MaxErrorRateConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.max_error_rate == instance.args.max_error_rate
-        assert constraint.args.window_size == instance.args.window_size
+        assert constraint.args.rate == instance.args.max_error_rate
+        assert constraint.args.window == instance.args.window_size
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -956,11 +948,11 @@ class TestMaxErrorRateConstraint:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxErrorRateConstraintArgs(max_error_rate=0.1, window_size=50)
+        args = MaxErrorRateConstraintArgs(rate=0.1, window=50)
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, MaxErrorRateConstraint)
-        assert initializer.args.max_error_rate == 0.1
-        assert initializer.args.window_size == 50
+        assert initializer.args.rate == 0.1
+        assert initializer.args.window == 50
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -969,7 +961,7 @@ class TestMaxErrorRateConstraint:
         ## WRITTEN BY AI ##
         """
         instance = MaxErrorRateConstraint(
-            args=MaxErrorRateConstraintArgs(max_error_rate=0.2, window_size=25)
+            args=MaxErrorRateConstraintArgs(rate=0.2, window=25)
         )
         resolved = ConstraintsInitializerFactory.resolve({"max_error_rate": instance})
         assert isinstance(resolved["max_error_rate"], MaxErrorRateConstraint)
@@ -1025,26 +1017,20 @@ class TestMaxGlobalErrorRateConstraint:
         with pytest.raises(ValidationError):
             MaxGlobalErrorRateConstraint()
         with pytest.raises(ValidationError):
+            MaxGlobalErrorRateConstraint(args=MaxGlobalErrorRateConstraintArgs(rate=0))
+        with pytest.raises(ValidationError):
+            MaxGlobalErrorRateConstraint(args=MaxGlobalErrorRateConstraintArgs(rate=-1))
+        with pytest.raises(ValidationError):
             MaxGlobalErrorRateConstraint(
-                args=MaxGlobalErrorRateConstraintArgs(max_error_rate=0)
+                args=MaxGlobalErrorRateConstraintArgs(rate=1.5)
             )
         with pytest.raises(ValidationError):
             MaxGlobalErrorRateConstraint(
-                args=MaxGlobalErrorRateConstraintArgs(max_error_rate=-1)
+                args=MaxGlobalErrorRateConstraintArgs(rate=0.5, minimum=0)
             )
         with pytest.raises(ValidationError):
             MaxGlobalErrorRateConstraint(
-                args=MaxGlobalErrorRateConstraintArgs(max_error_rate=1.5)
-            )
-        with pytest.raises(ValidationError):
-            MaxGlobalErrorRateConstraint(
-                args=MaxGlobalErrorRateConstraintArgs(
-                    max_error_rate=0.5, min_processed=0
-                )
-            )
-        with pytest.raises(ValidationError):
-            MaxGlobalErrorRateConstraint(
-                args=MaxGlobalErrorRateConstraintArgs(max_error_rate="invalid")
+                args=MaxGlobalErrorRateConstraintArgs(rate="invalid")
             )
 
     @pytest.mark.smoke
@@ -1131,8 +1117,8 @@ class TestMaxGlobalErrorRateConstraint:
             assert data["args"][key] == value
 
         reconstructed = MaxGlobalErrorRateConstraint.model_validate(data)
-        assert reconstructed.args.max_error_rate == instance.args.max_error_rate
-        assert reconstructed.args.min_processed == instance.args.min_processed
+        assert reconstructed.args.rate == instance.args.max_error_rate
+        assert reconstructed.args.minimum == instance.args.min_processed
 
         for key, value in constructor_args.items():
             assert getattr(reconstructed.args, key) == value
@@ -1146,8 +1132,8 @@ class TestMaxGlobalErrorRateConstraint:
 
         assert isinstance(constraint, MaxGlobalErrorRateConstraint)
         assert constraint is not instance  # Should return a copy
-        assert constraint.args.max_error_rate == instance.args.max_error_rate
-        assert constraint.args.min_processed == instance.args.min_processed
+        assert constraint.args.rate == instance.args.max_error_rate
+        assert constraint.args.minimum == instance.args.min_processed
         assert instance.current_index == original_index + 1  # Original is incremented
         assert constraint.current_index == original_index + 1  # Copy has incremented
 
@@ -1169,11 +1155,11 @@ class TestMaxGlobalErrorRateConstraint:
 
         ## WRITTEN BY AI ##
         """
-        args = MaxGlobalErrorRateConstraintArgs(max_error_rate=0.1, min_processed=50)
+        args = MaxGlobalErrorRateConstraintArgs(rate=0.1, minimum=50)
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, MaxGlobalErrorRateConstraint)
-        assert initializer.args.max_error_rate == 0.1
-        assert initializer.args.min_processed == 50
+        assert initializer.args.rate == 0.1
+        assert initializer.args.minimum == 50
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -1182,7 +1168,7 @@ class TestMaxGlobalErrorRateConstraint:
         ## WRITTEN BY AI ##
         """
         instance = MaxGlobalErrorRateConstraint(
-            args=MaxGlobalErrorRateConstraintArgs(max_error_rate=0.15, min_processed=75)
+            args=MaxGlobalErrorRateConstraintArgs(rate=0.15, minimum=75)
         )
         resolved = ConstraintsInitializerFactory.resolve(
             {"max_global_error_rate": instance}
@@ -1216,10 +1202,10 @@ class TestConstraintsInitializerFactory:
     def test_resolve_mixed_types(self):
         """Test resolve method with constraint and initializer instances."""
         max_num_constraint = MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(max_num=25)
+            args=MaxRequestsConstraintArgs(count=25)
         )
         max_duration_initializer = MaxDurationConstraint(
-            args=MaxDurationConstraintArgs(max_duration=120.0)
+            args=MaxDurationConstraintArgs(seconds=120.0)
         )
 
         mixed_spec = {
@@ -1247,7 +1233,7 @@ class TestConstraintsInitializerFactory:
     @pytest.mark.smoke
     def test_functional_constraint_creation(self):
         """Test that created constraints are functionally correct."""
-        args = MaxRequestsConstraintArgs(max_num=10)
+        args = MaxRequestsConstraintArgs(count=10)
         initializer = ConstraintsInitializerFactory.create(args)
         constraint = initializer.create_constraint()
 

--- a/tests/unit/scheduler/test_environment.py
+++ b/tests/unit/scheduler/test_environment.py
@@ -190,7 +190,7 @@ class TestNonDistributedEnvironment:
                 SynchronousStrategy(),
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=10),
+                        args=MaxRequestsConstraintArgs(count=10),
                     ),
                 },
             ),
@@ -204,7 +204,7 @@ class TestNonDistributedEnvironment:
                 SynchronousStrategy(),
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=1),
+                        args=MaxRequestsConstraintArgs(count=1),
                     ),
                 },
             ),
@@ -213,7 +213,7 @@ class TestNonDistributedEnvironment:
                 SynchronousStrategy(),
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=5),
+                        args=MaxRequestsConstraintArgs(count=5),
                     ),
                 },
             ),

--- a/tests/unit/scheduler/test_over_saturation.py
+++ b/tests/unit/scheduler/test_over_saturation.py
@@ -34,7 +34,7 @@ class TestOverSaturationConstraintInternal:
     def valid_instances(self, request):
         """Create OverSaturationConstraint instances with valid parameters."""
         constructor_args = request.param
-        instance = OverSaturationConstraint(**constructor_args, mode="active")
+        instance = OverSaturationConstraint(**constructor_args, mode="enforce")
         return instance, constructor_args
 
     @pytest.mark.smoke
@@ -49,7 +49,7 @@ class TestOverSaturationConstraintInternal:
     @pytest.mark.smoke
     def test_initialization_defaults(self):
         """Test that OverSaturationConstraint has correct default values."""
-        constraint = OverSaturationConstraint(mode="active")
+        constraint = OverSaturationConstraint(mode="enforce")
 
         assert constraint.minimum_duration == 30.0
         assert constraint.minimum_ttft == 2.5
@@ -82,7 +82,7 @@ class TestOverSaturationConstraintInternal:
             minimum_duration=0.0,
             maximum_window_seconds=100.0,
             maximum_window_ratio=0.5,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
 
@@ -115,13 +115,13 @@ class TestOverSaturationConstraint:
     def constraint(self):
         """Create a constraint for testing."""
         return OverSaturationConstraint(
-            minimum_duration=0.0, minimum_window_size=3, mode="active"
+            minimum_duration=0.0, minimum_window_size=3, mode="enforce"
         )
 
     @pytest.fixture(
         params=[
-            {"mode": "active"},
-            {"mode": "passive"},
+            {"mode": "enforce"},
+            {"mode": "monitor"},
         ]
     )
     def valid_instances(self, request):
@@ -143,7 +143,7 @@ class TestOverSaturationConstraint:
     @pytest.mark.smoke
     def test_protocol_method_signature(self):
         """Test that OverSaturationConstraint has the correct method signature."""
-        constraint = OverSaturationConstraint(mode="active")
+        constraint = OverSaturationConstraint(mode="enforce")
         call_method = constraint.__call__
         sig = inspect.signature(call_method)
 
@@ -217,7 +217,7 @@ class TestOverSaturationConstraint:
 
     @pytest.mark.sanity
     def test_constraint_stops_when_over_saturated(self, constraint):
-        """Test constraint stops when over-saturated and mode is active."""
+        """Test constraint stops when over-saturated and mode is enforce."""
         start_time = time.time()
 
         # Simulate over-saturation by creating positive slopes through constraint calls
@@ -283,12 +283,12 @@ class TestOverSaturationConstraint:
         assert "is_over_saturated" in action.metadata
 
     @pytest.mark.sanity
-    def test_constraint_never_stops_when_mode_passive(self):
-        """Test constraint never stops when mode is passive."""
+    def test_constraint_never_stops_when_mode_monitor(self):
+        """Test constraint never stops when mode is monitor."""
         constraint = OverSaturationConstraint(
             minimum_duration=0.0,
             minimum_window_size=3,
-            mode="passive",
+            mode="monitor",
         )
         start_time = time.time()
 
@@ -307,7 +307,7 @@ class TestOverSaturationConstraint:
             scheduler_start_time=start_time,
         )
 
-        # Even if over-saturated, should continue in passive mode
+        # Even if over-saturated, should continue in monitor mode
         action = constraint(state, request)
         assert isinstance(action, SchedulerUpdateAction)
         assert action.request_queuing == "continue"
@@ -319,10 +319,10 @@ class TestOverSaturationConstraintInitializer:
 
     @pytest.fixture(
         params=[
-            {"mode": "active"},
-            {"mode": "passive"},
+            {"mode": "enforce"},
+            {"mode": "monitor"},
             {
-                "mode": "active",
+                "mode": "enforce",
                 "min_seconds": 10.0,
                 "max_window_seconds": 60.0,
             },
@@ -377,7 +377,7 @@ class TestOverSaturationConstraintInitializer:
         # Invalid type for min_seconds
         with pytest.raises(ValidationError):
             OverSaturationConstraintInitializer(
-                args=OverSaturationConstraintArgs(mode="active", min_seconds="invalid")
+                args=OverSaturationConstraintArgs(mode="enforce", min_seconds="invalid")
             )
 
     @pytest.mark.smoke
@@ -419,14 +419,14 @@ class TestOverSaturationConstraintInitializer:
 
         ## WRITTEN BY AI ##
         """
-        args = OverSaturationConstraintArgs(mode="active")
+        args = OverSaturationConstraintArgs(mode="enforce")
         initializer = ConstraintsInitializerFactory.create(args)
         assert isinstance(initializer, OverSaturationConstraintInitializer)
-        assert initializer.args.mode == "active"
+        assert initializer.args.mode == "enforce"
 
         constraint = initializer.create_constraint()
         assert isinstance(constraint, OverSaturationConstraint)
-        assert constraint.mode == "active"
+        assert constraint.mode == "enforce"
 
     @pytest.mark.smoke
     def test_factory_resolve_methods(self):
@@ -435,7 +435,7 @@ class TestOverSaturationConstraintInitializer:
         ## WRITTEN BY AI ##
         """
         instance = OverSaturationConstraintInitializer(
-            args=OverSaturationConstraintArgs(mode="passive")
+            args=OverSaturationConstraintArgs(mode="monitor")
         )
         constraint_instance = instance.create_constraint()
         resolved = ConstraintsInitializerFactory.resolve(
@@ -446,7 +446,7 @@ class TestOverSaturationConstraintInitializer:
     @pytest.mark.smoke
     def test_functional_constraint_creation(self):
         """Test that created constraints are functionally correct."""
-        args = OverSaturationConstraintArgs(mode="active")
+        args = OverSaturationConstraintArgs(mode="enforce")
         initializer = ConstraintsInitializerFactory.create(args)
         constraint = initializer.create_constraint()
 

--- a/tests/unit/scheduler/test_over_saturation_comprehensive.py
+++ b/tests/unit/scheduler/test_over_saturation_comprehensive.py
@@ -400,7 +400,7 @@ class TestOverSaturationConstraintIntegration:
             maximum_window_seconds=60.0,
             moe_threshold=1.5,
             confidence=0.90,
-            mode="active",
+            mode="enforce",
         )
 
     @pytest.mark.sanity
@@ -552,7 +552,7 @@ class TestOverSaturationConstraintPerformance:
             minimum_duration=0.0,
             maximum_window_seconds=10.0,
             minimum_window_size=5,
-            mode="active",
+            mode="enforce",
         )
 
         # Add many requests
@@ -572,7 +572,7 @@ class TestOverSaturationConstraintPerformance:
     def test_constraint_computational_efficiency(self):
         """Test that constraint operations remain efficient."""
         constraint = OverSaturationConstraint(
-            minimum_duration=0.0, minimum_window_size=10, mode="active"
+            minimum_duration=0.0, minimum_window_size=10, mode="enforce"
         )
 
         # Add baseline data
@@ -601,7 +601,7 @@ class TestOverSaturationConstraintInitializerRobustness:
         # Valid parameters via args
         initializer = OverSaturationConstraintInitializer(
             args=OverSaturationConstraintArgs(
-                mode="active",
+                mode="enforce",
                 min_seconds=5.0,
                 max_window_seconds=30.0,
                 moe_threshold=1.5,
@@ -610,7 +610,7 @@ class TestOverSaturationConstraintInitializerRobustness:
         )
 
         constraint = initializer.create_constraint()
-        assert constraint.mode == "active"
+        assert constraint.mode == "enforce"
         assert constraint.minimum_duration == 5.0
         assert constraint.maximum_window_seconds == 30.0
 
@@ -620,7 +620,7 @@ class TestOverSaturationConstraintInitializerRobustness:
         # Very permissive settings
         initializer = OverSaturationConstraintInitializer(
             args=OverSaturationConstraintArgs(
-                mode="active",
+                mode="enforce",
                 min_seconds=0.1,
                 max_window_seconds=3600.0,  # 1 hour
             )
@@ -634,7 +634,7 @@ class TestOverSaturationConstraintInitializerRobustness:
     @pytest.mark.smoke
     def test_constraint_creation_with_mock_constraint(self):
         """Test constraint creation with mocked constraint for isolation."""
-        constraint = OverSaturationConstraint(mode="active")
+        constraint = OverSaturationConstraint(mode="enforce")
         # Set up constraint state to simulate over-saturation
         constraint.ttft_slope_checker.slope = 1.5
         constraint.ttft_slope_checker.margin_of_error = 0.3
@@ -673,7 +673,7 @@ class TestOverSaturationEdgeCasesAndRegression:
     @pytest.mark.sanity
     def test_detector_with_malformed_request_data(self):
         """Test detector requires proper request data structure."""
-        constraint = OverSaturationConstraint(minimum_duration=0.0, mode="active")
+        constraint = OverSaturationConstraint(minimum_duration=0.0, mode="enforce")
 
         # Missing fields should raise KeyError
         with pytest.raises(KeyError):
@@ -701,7 +701,7 @@ class TestOverSaturationEdgeCasesAndRegression:
         """Test constraint handles missing timings data gracefully."""
         constraint = OverSaturationConstraint(
             minimum_duration=0.0,
-            mode="active",
+            mode="enforce",
         )
 
         start_time = time.time()
@@ -729,7 +729,7 @@ class TestOverSaturationEdgeCasesAndRegression:
     def test_detector_concurrent_modification_safety(self):
         """Test detector behavior under concurrent-like modifications."""
         constraint = OverSaturationConstraint(
-            minimum_duration=0.0, minimum_window_size=3, mode="active"
+            minimum_duration=0.0, minimum_window_size=3, mode="enforce"
         )
 
         # Add requests
@@ -771,7 +771,7 @@ class TestOverSaturationEdgeCasesAndRegression:
     @pytest.mark.sanity
     def test_detector_reset_clears_all_state(self):
         """Test that detector reset completely clears state."""
-        constraint = OverSaturationConstraint(minimum_duration=0.0, mode="active")
+        constraint = OverSaturationConstraint(minimum_duration=0.0, mode="enforce")
 
         # Add data and trigger computation
         for i in range(20):
@@ -812,7 +812,7 @@ class TestOverSaturationEdgeCasesAndRegression:
         mock_time.return_value = current_time
 
         constraint = OverSaturationConstraint(
-            minimum_duration=25.0, mode="active"
+            minimum_duration=25.0, mode="enforce"
         )  # Should be met
 
         state = SchedulerState(
@@ -844,7 +844,7 @@ class TestOverSaturationEdgeCasesAndRegression:
         constraint = OverSaturationConstraint(
             minimum_duration=0.0,
             minimum_ttft=2.0,  # Threshold
-            mode="active",
+            mode="enforce",
         )
 
         # Add requests with known TTFT values
@@ -879,7 +879,7 @@ class TestInstantTTFT:
             minimum_duration=0.0,
             minimum_window_size=3,
             maximum_window_ratio=1.0,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
         state = SchedulerState(
@@ -911,7 +911,7 @@ class TestInstantTTFT:
             minimum_duration=0.0,
             minimum_window_size=3,
             maximum_window_ratio=1.0,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
         state = SchedulerState(
@@ -955,7 +955,7 @@ class TestInstantTTFT:
             minimum_duration=0.0,
             minimum_window_size=3,
             maximum_window_ratio=1.0,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
         state = SchedulerState(
@@ -983,7 +983,7 @@ class TestInstantTTFT:
         constraint = OverSaturationConstraint(
             minimum_duration=0.0,
             maximum_window_ratio=1.0,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
         state = SchedulerState(
@@ -1018,7 +1018,7 @@ class TestInstantTTFT:
             minimum_duration=0.0,
             minimum_window_size=3,
             maximum_window_ratio=1.0,
-            mode="active",
+            mode="enforce",
         )
         start_time = time.time()
         state = SchedulerState(

--- a/tests/unit/scheduler/test_scheduler.py
+++ b/tests/unit/scheduler/test_scheduler.py
@@ -151,7 +151,7 @@ class TestScheduler:
                 5,
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=10),
+                        args=MaxRequestsConstraintArgs(count=10),
                     ),
                 },
             ),
@@ -159,7 +159,7 @@ class TestScheduler:
                 20,
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=25),
+                        args=MaxRequestsConstraintArgs(count=25),
                     ),
                 },
             ),
@@ -167,7 +167,7 @@ class TestScheduler:
                 1,
                 {
                     "max_requests": MaxNumberConstraint(
-                        args=MaxRequestsConstraintArgs(max_num=5),
+                        args=MaxRequestsConstraintArgs(count=5),
                     ),
                 },
             ),
@@ -215,7 +215,7 @@ class TestScheduler:
             backend=backend,
             strategy=strategy,
             env=env,
-            max_number=MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num=10)),
+            max_number=MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=10)),
         ):
             if info.status == "errored":
                 error_count += 1
@@ -259,9 +259,9 @@ class TestScheduler:
             backend=backend,
             strategy=strategy,
             env=env,
-            max_number=MaxNumberConstraint(args=MaxRequestsConstraintArgs(max_num=5)),
+            max_number=MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=5)),
             max_duration=MaxDurationConstraint(
-                args=MaxDurationConstraintArgs(max_duration=5.0)
+                args=MaxDurationConstraintArgs(seconds=5.0)
             ),
         ):
             results.append((response, request, info, state))

--- a/tests/unit/scheduler/test_worker_group.py
+++ b/tests/unit/scheduler/test_worker_group.py
@@ -112,7 +112,7 @@ class TestWorkerProcessGroup:
                 "strategy": SynchronousStrategy(),
                 "startup_duration": 0.1,
                 "max_requests": MaxNumberConstraint(
-                    args=MaxRequestsConstraintArgs(max_num=10),
+                    args=MaxRequestsConstraintArgs(count=10),
                 ),
             },
             {
@@ -120,7 +120,7 @@ class TestWorkerProcessGroup:
                 "strategy": ConcurrentStrategy(streams=2),
                 "startup_duration": 0.1,
                 "max_requests": MaxNumberConstraint(
-                    args=MaxRequestsConstraintArgs(max_num=5),
+                    args=MaxRequestsConstraintArgs(count=5),
                 ),
             },
             {
@@ -133,7 +133,7 @@ class TestWorkerProcessGroup:
                 "strategy": AsyncConstantStrategy(rate=20),
                 "startup_duration": 0.1,
                 "max_duration": MaxDurationConstraint(
-                    args=MaxDurationConstraintArgs(max_duration=1),
+                    args=MaxDurationConstraintArgs(seconds=1),
                 ),
             },
         ],


### PR DESCRIPTION
## Summary

With the new CLI constraint syntax, specifying `--constraint max_requests max_requests=<n>` is awkward. Simplify the parameter names to be more expressive, like `--constraint max_requests count=<n>`

## Details

- `--constraint max_duration seconds=60`
- `--constraint max_requests count=1000`
- `--constraint max_errors count=10`
- `--constraint max_error_rate rate=0.1,window=100`
- `--constraint max_global_error_rate rate=0.2,minimum=10`
- `--constraint over_saturation mode=enforce,min_seconds=30,max_window_seconds=120,moe_threshold=2,minimum+ttft=2.5,maximum_window_ratio=0.75,minimum_window_size=5,confidence=0.95`

> **NOTES**

- I didn't rename the parameters for "over_saturation" -- there are a lot and the meanings are fairly specific.

## Test Plan

- [ ] Manually test that constraints are parsed correctly
- [x] Unit tests have been appropriately updated.

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit f1f8a1471671421e5b141bab2a25798f8a7ef7f4
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jun 16 13:39:29 2026 -0400

    Simplify constraint parameter names
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit 25e8f92ed72e52a746168b16b90d8786b9a067eb
Author: David Butenhof <dbutenho@redhat.com>
Date:   Wed Jun 17 16:49:08 2026 -0400

    Fix rebase
    
    e2e isn't succeeding. I don't see any error indications that don't look like
    timeouts, so I'm hoping I got all the real problems.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit f2442994ed4cdb41f9c9878bb2847b459614604a
Author: David Butenhof <dbutenho@redhat.com>
Date:   Thu Jun 18 04:24:58 2026 -0400

    I hate literal string values
    
    So the over-saturation e2e test fails because I missed an "active" test in
    the scheduler. I like ENUMs. Why don't we use ENUMs?
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
