### PR TITLE
Disable reloading parent schemas by default

### DIFF
--- a/src/guidellm/benchmark/__init__.py
+++ b/src/guidellm/benchmark/__init__.py
@@ -56,8 +56,8 @@ from .schemas import (
 
 # Rebuild schemas one more time before
 # export to catch any nested field changes
-BenchmarkArgs.model_rebuild(force=True)
-BenchmarkScenario.model_rebuild(force=True)
+BenchmarkArgs.reload_schema()
+BenchmarkScenario.reload_schema()
 
 __all__ = [
     "AsyncProfile",

--- a/src/guidellm/benchmark/schemas/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/entrypoints.py
@@ -38,7 +38,11 @@ from guidellm.data import (
     DataTokenizerArgs,
 )
 from guidellm.scheduler.constraints import ConstraintArgs
-from guidellm.schemas import StandardBaseModel, standard_model_config
+from guidellm.schemas import (
+    ReloadableBaseModel,
+    StandardBaseModel,
+    standard_model_config,
+)
 from guidellm.utils.arg_string import ArgStringParser
 
 __all__ = [
@@ -73,7 +77,7 @@ def default_kind_list(*kinds: str) -> list[dict[str, Any]]:
     return [default_kind(kind) for kind in kinds]
 
 
-class BenchmarkArgs(StandardBaseModel):
+class BenchmarkArgs(ReloadableBaseModel):
     """Common benchmark configuration arguments."""
 
     model_config = args_model_config()
@@ -152,7 +156,7 @@ class BenchmarkMetadata(StandardBaseModel):
     )
 
 
-class BenchmarkScenario(BaseSettings):
+class BenchmarkScenario(ReloadableBaseModel, BaseSettings):
     """
     Configuration arguments for generative text benchmark execution.
 

--- a/src/guidellm/schemas/base.py
+++ b/src/guidellm/schemas/base.py
@@ -76,7 +76,7 @@ class ReloadableBaseModel(BaseModel):
     model_config = standard_model_config(extra="ignore")
 
     @classmethod
-    def reload_schema(cls, parents: bool = True) -> None:
+    def reload_schema(cls, parents: bool = False) -> None:
         """
         Reload the class schema with updated registry information.
 

--- a/tests/unit/schemas/test_base.py
+++ b/tests/unit/schemas/test_base.py
@@ -162,7 +162,7 @@ class TestReloadableBaseModel:
             mock.patch.object(TestModel, "model_rebuild") as mock_rebuild,
             mock.patch.object(TestModel, "reload_parent_schemas") as mock_parents,
         ):
-            TestModel.reload_schema()
+            TestModel.reload_schema(parents=True)
             mock_rebuild.assert_called_once_with(force=True)
             mock_parents.assert_called_once()
 


### PR DESCRIPTION
## Summary

`ReloadableBaseModel` instances will walk the entire list of `ReloadableBaseModel` and `StandardBaseModel` subclasses to check if any depend on the instance. This is slow and expensive so disable by default until we can find a better method.

## Details

Disabling this means that the order of imports matter when generating model schemas. To ensure that parents of reloadable models are fully up to date `reload_schema()` or `model_rebuild(force=True)` must be called on the parents after all child schema changes have been made.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit b424c9831c6f8ef6039d5612a20e1b095ed36c64
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 17 16:47:21 2026 -0400

    Disable reloading parent schemas by default
    
    `ReloadableBaseModel` instances will walk the entire list of
    `ReloadableBaseModel` and `StandardBaseModel` subclasses to check if any
    depend on the instance. This is slow and expensive so disable by default
    until we can find a better method.
    
    Disabling this means that the order of imports matter when generating
    model schemas. To ensure that parents of reloadable models are fully up
    to date `reload_schema()` or `model_rebuild(force=True)` must be called
    on the parents after all child schema changes have been made.
    
    Assisted-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
