### PR TITLE
Add a HuggingFace cache step to tox-run

### DIFF
--- a/.github/actions/run-tox/action.yml
+++ b/.github/actions/run-tox/action.yml
@@ -17,6 +17,14 @@ runs:
       uses: ./.github/actions/python-uv
       with:
         python-version: ${{ inputs.python-version }}
+    - name: Cache HuggingFace
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.cache/huggingface
+        key: huggingface-${{ runner.os }}-${{ inputs.python-version }}-${{ inputs.tox-env }}
+        restore-keys: |
+          huggingface-${{ runner.os }}-${{ inputs.python-version }}-
+          huggingface-${{ runner.os }}-
     - name: Install system dependencies
       run: |
         sudo apt update && sudo apt install -y ffmpeg


### PR DESCRIPTION
## Summary

Save the HuggingFace cache as a GitHub action cache. This should help with rate-limits we have seen from HuggingFace.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #778

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3de29239937350ffa8ba1765b5cff51f0045e935
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 17 17:16:38 2026 -0400

    Add a HuggingFace cache step to tox run
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Generated-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
