### PR TITLE
Switch BenchmarksArgs to BenchmarkScernario in output

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -514,7 +514,7 @@ async def benchmark_generative_text(
         outputs=benchmark_args.outputs, console=console
     )
 
-    report = GenerativeBenchmarksReport(config=benchmark_args)
+    report = GenerativeBenchmarksReport(config=args)
     if console:
         console.print_update(
             title="Setup complete, starting benchmarks...", status="success"

--- a/src/guidellm/benchmark/outputs/html.py
+++ b/src/guidellm/benchmark/outputs/html.py
@@ -27,6 +27,7 @@ from guidellm.benchmark.outputs.output import GenerativeBenchmarkerOutput
 from guidellm.benchmark.schemas import (
     BenchmarkArgs,
     BenchmarkOutputArgs,
+    BenchmarkScenario,
     GenerativeBenchmark,
     GenerativeBenchmarksReport,
 )
@@ -311,7 +312,7 @@ def _inject_data(js_data: dict[str, str], html: str) -> str:
 
 
 def _build_ui_data(
-    benchmarks: list[GenerativeBenchmark], args: BenchmarkArgs
+    benchmarks: list[GenerativeBenchmark], config: BenchmarkScenario
 ) -> dict[str, Any]:
     """
     Build complete UI data structure from benchmarks.
@@ -324,8 +325,8 @@ def _build_ui_data(
     :return: Dictionary with run_info, workload_details, and benchmarks sections
     """
     return {
-        "run_info": _build_run_info(benchmarks, args),
-        "workload_details": _build_workload_details(benchmarks, args),
+        "run_info": _build_run_info(benchmarks, config.spec),
+        "workload_details": _build_workload_details(benchmarks, config.spec),
         "benchmarks": _build_benchmarks(benchmarks),
     }
 

--- a/src/guidellm/benchmark/schemas/report.py
+++ b/src/guidellm/benchmark/schemas/report.py
@@ -20,7 +20,7 @@ import yaml
 from pydantic import Field
 
 from guidellm.benchmark.schemas.benchmark import GenerativeBenchmark
-from guidellm.benchmark.schemas.entrypoints import BenchmarkArgs
+from guidellm.benchmark.schemas.entrypoints import BenchmarkScenario
 from guidellm.schemas import StandardBaseModel
 
 __all__ = ["GenerativeBenchmarkMetadata", "GenerativeBenchmarksReport"]
@@ -71,7 +71,7 @@ class GenerativeBenchmarksReport(StandardBaseModel):
         description="Metadata about the benchmark report and execution environment",
         default_factory=GenerativeBenchmarkMetadata,
     )
-    config: BenchmarkArgs = Field(
+    config: BenchmarkScenario = Field(
         description="Benchmark arguments used for all benchmarks in the report"
     )
     benchmarks: list[GenerativeBenchmark] = Field(

--- a/tests/unit/benchmark/test_serialized_output.py
+++ b/tests/unit/benchmark/test_serialized_output.py
@@ -11,7 +11,7 @@ from guidellm.benchmark.outputs.serialized import (
     YAMLBenchmarkOutputArgs,
 )
 from guidellm.benchmark.schemas import (
-    BenchmarkArgs,
+    BenchmarkScenario,
     GenerativeBenchmarksReport,
 )
 
@@ -19,27 +19,22 @@ from guidellm.benchmark.schemas import (
 @pytest.fixture
 def minimal_report() -> GenerativeBenchmarksReport:
     """
-    Create a minimal GenerativeBenchmarksReport for testing serialization.
-
-    ## WRITTEN BY AI ##
+    Create a GenerativeBenchmarksReport for testing serialization.
     """
-    args = BenchmarkArgs.model_validate(
+    config = BenchmarkScenario.model_validate(
         {
-            "backend": {
-                "kind": "openai_http",
-                "target": "http://localhost:8000/v1",
-                "model": "test-model",
+            "spec": {
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://localhost:8000/v1",
+                    "model": "test-model",
+                },
+                "data": [{"kind": "huggingface", "source": "test_data.jsonl"}],
+                "profile": {"kind": "constant", "rate": 10.0},
             },
-            "data": [{"kind": "huggingface", "source": "test_data.jsonl"}],
-            "profile": {"kind": "sweep", "rate": [10.0]},
-            "tokenizer": {"kind": "huggingface_auto", "model": "test-model"},
-            "data_column_mapper": {"kind": "generative_column_mapper"},
-            "data_preprocessors": [],
-            "data_finalizer": {"kind": "generative"},
-            "data_loader": {"kind": "pytorch"},
         }
     )
-    return GenerativeBenchmarksReport(config=args)
+    return GenerativeBenchmarksReport(config=config)
 
 
 @pytest.fixture
@@ -49,26 +44,28 @@ def file_path_report(tmp_path: Path) -> GenerativeBenchmarksReport:
 
     ## WRITTEN BY AI ##
     """
-    args = BenchmarkArgs.model_validate(
+    args = BenchmarkScenario.model_validate(
         {
-            "backend": {
-                "kind": "openai_http",
-                "target": "http://localhost:8000/v1",
-                "model": "test-model",
+            "spec": {
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://localhost:8000/v1",
+                    "model": "test-model",
+                },
+                "profile": {"kind": "sweep"},
+                "data": [
+                    {
+                        "kind": "json_file",
+                        "path": tmp_path / "data.jsonl",
+                        "load_kwargs": {"split": "train"},
+                    }
+                ],
+                "tokenizer": {"kind": "huggingface_auto", "model": "test-model"},
+                "data_column_mapper": {"kind": "generative_column_mapper"},
+                "data_preprocessors": [],
+                "data_finalizer": {"kind": "generative"},
+                "data_loader": {"kind": "pytorch"},
             },
-            "profile": {"kind": "sweep"},
-            "data": [
-                {
-                    "kind": "json_file",
-                    "path": tmp_path / "data.jsonl",
-                    "load_kwargs": {"split": "train"},
-                }
-            ],
-            "tokenizer": {"kind": "huggingface_auto", "model": "test-model"},
-            "data_column_mapper": {"kind": "generative_column_mapper"},
-            "data_preprocessors": [],
-            "data_finalizer": {"kind": "generative"},
-            "data_loader": {"kind": "pytorch"},
         }
     )
     return GenerativeBenchmarksReport(config=args)
@@ -195,7 +192,9 @@ class TestFinalizeFormats:
         result_path = await handler.finalize(file_path_report)
 
         parsed = json.loads(result_path.read_text())
-        assert parsed["config"]["data"][0]["path"] == str(tmp_path / "data.jsonl")
+        assert parsed["config"]["spec"]["data"][0]["path"] == str(
+            tmp_path / "data.jsonl"
+        )
 
     @pytest.mark.asyncio
     async def test_finalize_yaml_serializes_nested_paths(
@@ -212,7 +211,9 @@ class TestFinalizeFormats:
         result_path = await handler.finalize(file_path_report)
 
         parsed = yaml.safe_load(result_path.read_text())
-        assert parsed["config"]["data"][0]["path"] == str(tmp_path / "data.jsonl")
+        assert parsed["config"]["spec"]["data"][0]["path"] == str(
+            tmp_path / "data.jsonl"
+        )
 
     @pytest.mark.asyncio
     async def test_finalize_explicit_path_respects_extension(


### PR DESCRIPTION
## Summary

Fix serialized output exporting last BenchmarkArgs rather then BenchmarkScenario for the global config.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 8f5da02a0de0b55f2421a58cb45494b0f0a40fae
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 18 14:06:36 2026 -0400

    Switch BenchmarksArgs to Scernario in output
    
    Fix serialized output exporting last BenchmarkArgs rather then
    BenchmarkScenario for the global config.
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit f546f97860b9543d6c349933659d7ee4f37ef15e
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 18 14:09:40 2026 -0400

    Fix tests
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: GitHub Copilot GPT-4.1
Signed-off-by: Samuel Monson <smonson@redhat.com>
