### PR TITLE
Update container build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -94,4 +94,4 @@ LABEL io.k8s.display-name="GuideLLM" \
 COPY --chown=1001:0 --from=builder /opt/app-root /opt/app-root
 
 ENTRYPOINT [ "/opt/app-root/bin/guidellm" ]
-CMD [ "benchmark", "run" ]
+CMD [ "run" ]

--- a/Containerfile.vllm
+++ b/Containerfile.vllm
@@ -50,4 +50,4 @@ VOLUME /results
 USER 1001:0
 
 ENTRYPOINT [ "guidellm" ]
-CMD [ "benchmark", "run" ]
+CMD [ "run" ]

--- a/src/guidellm/cli/benchmark/__init__.py
+++ b/src/guidellm/cli/benchmark/__init__.py
@@ -12,7 +12,7 @@ __all__ = ["benchmark"]
 
 
 @click.group(
-    help="Run a benchmark or load a previously saved benchmark report.",
+    help="Load a previously saved benchmark report.",
     cls=DefaultGroupHandler,
     default="run",
 )


### PR DESCRIPTION
## Summary

Fix the Containerfile default command

## Details

The "guidellm benchmark run" command defaulted in the Containerfile is no longer value. Update the default command to just `[ "run" ]`. The `guidellm --help` also implies that "benchmark" is still used to run benchmarks, so I also updated that.

## Test Plan

Build & run from container

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit f9224f30b628e0632e3864f32c9a6b381d618a49
Author: David Butenhof <dbutenho@redhat.com>
Date:   Mon Jun 22 10:52:10 2026 -0400

    Update container build
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
