### PR TITLE
Restore startup logs and fix config environment variable support

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -140,18 +140,19 @@ async def resolve_tokenizer(
     )
 
     if args.tokenizer.model is not None:
+        model = args.tokenizer.model
         if console_step:
             console_step.finish(
-                title="Processor resolved",
-                details=f"Using tokenizer '{args.tokenizer.model}' from arguments",
+                title=f"Tokenizer resolved, Using tokenizer '{model}' from arguments",
+                details=args.tokenizer.model_dump(mode="json"),
                 status_level="success",
             )
     else:
         args.tokenizer.model = model
         if console_step:
             console_step.finish(
-                title="Processor resolved",
-                details=f"Using model '{model}' as tokenizer",
+                title=f"Tokenizer resolved, using model '{model}' as tokenizer",
+                details=args.tokenizer.model_dump(mode="json"),
                 status_level="success",
             )
 
@@ -203,49 +204,6 @@ def resolve_item_from_registry(
                 f"{base_type.__name__}."
             )
         return item_class(**kwargs)
-
-
-async def resolve_request_loader(
-    args: BenchmarkArgs,
-    console: Console | None = None,
-) -> DataLoader[GenerationRequest]:
-    """
-    Construct a DataLoader for GenerationRequest objects from raw data inputs.
-
-    Initializes and configures the data pipeline including column mapping, request
-    formatting, collation, and sampling. Resolves string-based preprocessor identifiers
-    from the PreprocessorRegistry and creates appropriate instances with provided
-    configurations.
-
-    :param args: BenchmarkArgs containing data loading configuration
-    :param console: Console instance for progress reporting, or None
-    :return: Configured DataLoader instance yielding GenerationRequest objects
-    """
-    console_step = (
-        console.print_update_step(title=f"Initializing request loader from {args.data}")
-        if console
-        else None
-    )
-
-    request_loader: DataLoader[GenerationRequest] = create_data_loader(
-        loader_config=args.data_loader,
-        data_config=args.data,
-        tokenizer_config=args.tokenizer,
-        column_mapper_config=args.data_column_mapper,
-        preprocessors_config=args.data_preprocessors,
-        finalizer_config=args.data_finalizer,
-        random_seed=args.seed.value,  # type: ignore[attr-defined]
-    )
-
-    if console_step:
-        samples = args.data_loader.samples if args.data_loader.samples > 0 else "inf"
-        console_step.finish(
-            title=(f"Request loader initialized with {samples} unique requests"),
-            details=InfoMixin.extract_from_obj(request_loader),
-            status_level="success",
-        )
-
-    return request_loader
 
 
 def resolve_constraints(
@@ -351,7 +309,7 @@ async def resolve_output_formats(
     if console_step:
         console_step.finish(
             title="Output formats resolved",
-            details={key: str(val) for key, val in resolved.items()},
+            details=[args.model_dump(mode="json") for args in outputs],
             status_level="success",
         )
 
@@ -480,26 +438,19 @@ async def benchmark_generative_text(
         console=console,
     )
     await resolve_tokenizer(args=benchmark_args, model=model, console=console)
-    request_loader = await resolve_request_loader(
-        args=benchmark_args,
+    request_loader: DataLoader[GenerationRequest] = await create_data_loader(
+        loader_config=benchmark_args.data_loader,
+        data_config=benchmark_args.data,
+        tokenizer_config=benchmark_args.tokenizer,
+        column_mapper_config=benchmark_args.data_column_mapper,
+        preprocessors_config=benchmark_args.data_preprocessors,
+        finalizer_config=benchmark_args.data_finalizer,
+        random_seed=benchmark_args.seed.value,  # type: ignore[attr-defined]
         console=console,
     )
 
     warmup = benchmark_args.profile.warmup
     cooldown = benchmark_args.profile.cooldown
-    if console:
-        console.print_update(
-            title="Resolved transient phase configurations",
-            details="\n".join(
-                [
-                    f"Warmup: {warmup}",
-                    f"Cooldown: {cooldown}",
-                    "Rampup (Throughput/Concurrent): "
-                    f"{benchmark_args.profile.rampup_duration}",
-                ]
-            ),
-            status="success",
-        )
 
     constraints = resolve_constraints(benchmark_args, **constraints)
     profile = await resolve_profile(

--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -14,6 +15,7 @@ from guidellm.scheduler import (
     ConstraintInitializer,
     SchedulingStrategy,
 )
+from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -46,6 +48,9 @@ class AsyncProfileArgs(ProfileArgs):
         Convert rates to a list from either a single number or a list of
         numbers.
         """
+        if isinstance(value, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                value = json.loads(value)
         if not value:
             raise ValueError("rate requires at least one value")
         if isinstance(value, list | tuple):

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -13,6 +14,7 @@ from guidellm.scheduler import (
     ConstraintInitializer,
     SchedulingStrategy,
 )
+from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -46,6 +48,9 @@ class ConcurrentProfileArgs(ProfileArgs):
         Convert streams to a list of integers from either a single number or a list of
         numbers.
         """
+        if isinstance(value, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                value = json.loads(value)
         if not value:
             raise ValueError("streams (rate) requires at least one value")
         if isinstance(value, list | tuple):

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import MutableMapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -18,6 +19,7 @@ from guidellm.scheduler import (
     TraceReplayStrategy,
 )
 from guidellm.scheduler.constraints.request import MaxRequestsConstraintArgs
+from guidellm.utils.imports import json
 from guidellm.utils.trace_io import load_relative_timestamps
 
 from .profile import Profile, ProfileFactory
@@ -111,6 +113,9 @@ class ReplayProfileArgs(ProfileArgs):
         """
         Accept global ``--rate`` list values as time scale.
         """
+        if isinstance(value, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                value = json.loads(value)
         if isinstance(value, list | tuple):
             if not value:
                 raise ValueError(

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -17,6 +18,7 @@ from guidellm.scheduler import (
     SynchronousStrategy,
     ThroughputStrategy,
 )
+from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -59,6 +61,9 @@ class SweepProfileArgs(ProfileArgs):
         The CLI passes ``rate`` as a list of floats; sweep uses the first entry
         as the number of strategies to run.
         """
+        if isinstance(value, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                value = json.loads(value)
         if isinstance(value, list | tuple):
             if not value:
                 raise ValueError(

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -13,6 +14,7 @@ from guidellm.scheduler import (
     SchedulingStrategy,
     ThroughputStrategy,
 )
+from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -48,6 +50,9 @@ class ThroughputProfileArgs(ProfileArgs):
         The CLI passes ``rate`` as a list of floats; throughput uses the first entry
         as the maximum concurrency.
         """
+        if isinstance(value, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                value = json.loads(value)
         if not value:
             raise ValueError("max_concurrency (rate) requires at least one value")
         if isinstance(value, list | tuple):

--- a/src/guidellm/benchmark/schemas/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/entrypoints.py
@@ -183,8 +183,8 @@ class BenchmarkScenario(ReloadableBaseModel, BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="GUIDELLM_",
-        env_nested_delimiter="_",
+        env_prefix="GUIDELLM__",
+        env_nested_delimiter="__",
         validate_default=True,
     )
 

--- a/src/guidellm/benchmark/schemas/profiles.py
+++ b/src/guidellm/benchmark/schemas/profiles.py
@@ -8,6 +8,7 @@ deserialization of profile-specific argument types.
 
 from __future__ import annotations
 
+import contextlib
 from abc import ABC
 from typing import Any, ClassVar
 
@@ -19,6 +20,7 @@ from pydantic import (
 
 from guidellm.benchmark.schemas.base import TransientPhaseConfig
 from guidellm.schemas import PydanticClassRegistryMixin, standard_model_config
+from guidellm.utils.imports import json
 
 __all__ = ["ProfileArgs"]
 
@@ -94,6 +96,9 @@ class ProfileArgs(PydanticClassRegistryMixin["ProfileArgs"], ABC):
     @field_validator("warmup", "cooldown", mode="before")
     @classmethod
     def _coerce_transient_phase(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                v = json.loads(v)
         if isinstance(v, int | float | None):
             return TransientPhaseConfig.create_from_value(v)
         return v

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -14,11 +14,13 @@ from guidellm.benchmark import (
     benchmark_generative_text,
     get_builtin_scenarios,
 )
+from guidellm.settings import Settings
 from guidellm.utils.click_pydantic import (
     format_validation_errors,
     registry_options_from_model,
 )
 from guidellm.utils.console import Console
+from guidellm.utils.env_validator import validate_env_vars
 
 __all__ = [
     "run",
@@ -86,6 +88,29 @@ def run(**kwargs):  # noqa: C901, PLR0915
         kwargs.pop("disable_console_interactive", False) or disable_console
     )
     console = Console() if not disable_console else None
+
+    if console:
+        invalid_set_envs, valid_set_envs = validate_env_vars(Settings, BenchmarkArgs)
+
+        if valid_set_envs:
+            console.print_update(
+                title=(
+                    "The following environment variables are set and will be used "
+                    "by GuideLLM (if not overridden by CLI arguments/config)."
+                ),
+                details=", ".join(valid_set_envs),
+                status="info",
+            )
+        if invalid_set_envs:
+            console.print_update(
+                title=(
+                    "The following environment variables are set "
+                    "but not recognized by GuideLLM. Please verify "
+                    "that the benchmark is configured correctly."
+                ),
+                details=", ".join(invalid_set_envs),
+                status="warning",
+            )
 
     try:
         args = BenchmarkScenario.create(

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -90,7 +90,9 @@ def run(**kwargs):  # noqa: C901, PLR0915
     console = Console() if not disable_console else None
 
     if console:
-        invalid_set_envs, valid_set_envs = validate_env_vars(Settings, BenchmarkArgs)
+        invalid_set_envs, valid_set_envs = validate_env_vars(
+            Settings, BenchmarkScenario
+        )
 
         if valid_set_envs:
             console.print_update(

--- a/src/guidellm/data/deserializers/synthetic.py
+++ b/src/guidellm/data/deserializers/synthetic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import math
 from collections.abc import Callable, Iterator
 from random import Random
@@ -185,6 +186,9 @@ class SyntheticTextDataArgs(DataArgs):
     @classmethod
     def _coerce_tool_call_turns(cls, v: int | list[int]) -> list[int]:
         """Convert an int N to [0, ..., N-1]; pass lists through sorted."""
+        if isinstance(v, str):
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                v = json.loads(v)
         if isinstance(v, int):
             if v < 0:
                 raise ValueError("tool_call_turns int must be >= 0")

--- a/src/guidellm/data/entrypoints.py
+++ b/src/guidellm/data/entrypoints.py
@@ -23,9 +23,11 @@ from guidellm.data.schemas import (
     DataTokenizerArgs,
 )
 from guidellm.data.tokenizers import TokenizerRegistry
+from guidellm.utils.console import Console
+from guidellm.utils.mixins import InfoMixin
 
 
-def create_data_loader(
+async def create_data_loader(
     loader_config: DataLoaderArgs,
     data_config: list[DataArgs],
     tokenizer_config: DataTokenizerArgs,
@@ -33,6 +35,7 @@ def create_data_loader(
     preprocessors_config: list[DataPreprocessorArgs],
     finalizer_config: DataFinalizerArgs,
     random_seed: int = 42,
+    console: Console | None = None,
 ) -> DataLoader:
     """
     Factory function to create a DataLoader instance based on provided configurations.
@@ -51,6 +54,12 @@ def create_data_loader(
 
     tokenizer_factory = TokenizerRegistry.create(tokenizer_config)
 
+    console_step = (
+        console.print_update_step(title="Deserializing datasets from configuration")
+        if console
+        else None
+    )
+
     datasets: list[DatasetType] = [
         DatasetDeserializerFactory.deserialize(
             config=args,
@@ -60,19 +69,75 @@ def create_data_loader(
         for args in data_config
     ]
 
+    if console_step:
+        console_step.finish(
+            title=f"{len(datasets)} datasets resolved",
+            details=[args.model_dump(mode="json") for args in data_config],
+            status_level="success",
+        )
+
+    console_step = (
+        console.print_update_step(
+            title="Initializing preprocessors from configuration",
+        )
+        if console
+        else None
+    )
+
     preproc_configs = [column_mapper_config] + preprocessors_config
     preprocessors: list[DatasetPreprocessor | DataDependentPreprocessor] = [
         PreprocessorRegistry.create(pre) for pre in preproc_configs
     ]
+
+    if console_step:
+        console_step.finish(
+            title=f"{len(preprocessors)} preprocessors resolved",
+            details=[pre.model_dump(mode="json") for pre in preproc_configs],
+            status_level="success",
+        )
+
+    console_step = (
+        console.print_update_step(
+            title="Initializing finalizer from configuration",
+        )
+        if console
+        else None
+    )
+
     finalizer: DatasetFinalizer = FinalizerRegistry.create(finalizer_config)
 
-    return DataLoaderRegistry.create(
+    if console_step:
+        console_step.finish(
+            title="Finalizer resolved",
+            details=finalizer_config.model_dump(mode="json"),
+            status_level="success",
+        )
+
+    console_step = (
+        console.print_update_step(
+            title="Initializing request loader from configuration",
+        )
+        if console
+        else None
+    )
+
+    data_loader = DataLoaderRegistry.create(
         config=loader_config,
         datasets=datasets,
         preprocessors=preprocessors,
         finalizer=finalizer,
         random_seed=rng.getrandbits(32),
     )
+
+    if console_step:
+        samples = loader_config.samples if loader_config.samples > 0 else "inf"
+        console_step.finish(
+            title=(f"Request loader resolved with {samples} unique requests"),
+            details=InfoMixin.extract_from_obj(data_loader),
+            status_level="success",
+        )
+
+    return data_loader
 
 
 def process_dataset(

--- a/src/guidellm/data/loaders/torch.py
+++ b/src/guidellm/data/loaders/torch.py
@@ -176,7 +176,7 @@ class TorchDataLoader(PyTorchDataLoader[DataT], InfoMixin, DataLoader[DataT]):
             preprocessors=preprocessors,
             finalizer=finalizer,
         )
-        self._info: dict[str, Any] = config.model_dump()
+        self._info: dict[str, Any] = config.model_dump(mode="json")
         self.epoch = 0
 
         gen = torch.Generator()

--- a/src/guidellm/utils/env_validator.py
+++ b/src/guidellm/utils/env_validator.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from typing import cast, get_args, get_origin
+from typing import Any, get_args
 
 import click
 from more_itertools import partition
@@ -23,17 +23,20 @@ def validate_env_vars(
     Checks if the environment variable is in the set of valid environment variables
     extracted from the Click context and Pydantic Settings.
 
-    :param env_var: The environment variable name to validate.
-    :return: True if the environment variable is valid, False otherwise.
+    :param models: Pydantic model classes to extract valid env var names from.
+    :param ctx: Click context for extracting Click option env vars.
+    :return: Tuple of (invalid env vars, valid env vars) that are currently set.
     """
     set_vars = list_set_env()
-    valid_vars = get_valid_env_vars(*models, ctx=ctx)
+    valid_vars, valid_prefixes = get_valid_env_vars(*models, ctx=ctx)
 
-    invaild_set_vars, valid_set_vars = partition(
-        lambda e: e in valid_vars,
-        set_vars,
-    )
-    return set(invaild_set_vars), set(valid_set_vars)
+    def _is_valid(env_var: str) -> bool:
+        return env_var in valid_vars or any(
+            env_var.startswith(p) for p in valid_prefixes
+        )
+
+    invalid_set_vars, valid_set_vars = partition(_is_valid, set_vars)
+    return set(invalid_set_vars), set(valid_set_vars)
 
 
 def list_set_env(prefix: str = "GUIDELLM_") -> set[str]:
@@ -49,25 +52,28 @@ def list_set_env(prefix: str = "GUIDELLM_") -> set[str]:
 def get_valid_env_vars(
     *models: type[BaseModel],
     ctx: click.Context | None = None,
-) -> set[str]:
+) -> tuple[set[str], set[str]]:
     """
     Get all valid environment variable names from Click context and Settings.
 
     Collects environment variable names that are recognized by the application.
 
+    :param models: Pydantic model classes to extract valid env var names from.
     :param ctx: Click context for extracting Click option env vars.
-    :param include_settings: If True, include Settings env vars (default: True).
-    :return: Set of valid environment variable names.
+    :return: Tuple of (exact env var names, valid env var prefixes).
     """
-    valid_envs = set()
+    valid_envs: set[str] = set()
+    valid_prefixes: set[str] = set()
 
     if ctx is not None:
         valid_envs.update(_extract_click_env_vars(ctx))
 
     for model in models:
-        valid_envs.update(_extract_model_env_vars(model))
+        envs, prefixes = _extract_model_env_vars(model)
+        valid_envs.update(envs)
+        valid_prefixes.update(prefixes)
 
-    return valid_envs
+    return valid_envs, valid_prefixes
 
 
 def _extract_click_env_vars(ctx: click.Context) -> set[str]:
@@ -106,78 +112,78 @@ def _extract_click_env_vars(ctx: click.Context) -> set[str]:
     return env_vars
 
 
-def _extract_model_env_vars(model_class: type[BaseModel]) -> set[str]:
+def _extract_model_env_vars(
+    model_class: type[BaseModel],
+) -> tuple[set[str], set[str]]:
     """
-    Extract all environment variable names from Pydantic Settings.
+    Extract all environment variable names from a Pydantic model.
 
-    Uses the global settings instance from guidellm.settings.
-
-    :return: Set of environment variable names.
+    :param model_class: Pydantic model class to extract env var names from.
+    :return: Tuple of (exact env var names, valid env var prefixes).
     """
     config = model_class.model_config
     env_prefix = str(config.get("env_prefix", ""))
     env_delimiter = str(config.get("env_nested_delimiter", "__"))
 
-    # Walk the settings model fields recursively
-    return _walk_model_fields(
-        model_class,
-        env_prefix,
-        env_delimiter,
-    )
+    return _walk_model_fields(model_class, env_prefix, env_delimiter)
+
+
+def _resolve_model_type(annotation: Any) -> type[BaseModel] | None:
+    """
+    Recursively unwrap a type annotation to find a BaseModel subclass.
+
+    Handles Optional, Union, list, and other generic types.
+
+    :param annotation: The type annotation to resolve.
+    :return: The BaseModel subclass if found, otherwise None.
+    """
+    if annotation is None:
+        return None
+    with contextlib.suppress(TypeError):
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return annotation
+    for arg in get_args(annotation) or ():
+        if arg is type(None):
+            continue
+        result = _resolve_model_type(arg)
+        if result is not None:
+            return result
+    return None
 
 
 def _walk_model_fields(
     model_class: type[BaseModel],
     prefix: str,
     delimiter: str,
-) -> set[str]:
+) -> tuple[set[str], set[str]]:
     """
-    Recursively walk Pydantic model fields to build env var names.
+    Recursively walk Pydantic model fields to build env var names and prefixes.
+
+    For leaf fields, the exact env var name is added. For nested BaseModel
+    fields, the prefix is added to allow any env var under that prefix,
+    consistent with pydantic-settings' lenient ``explode_env_vars`` behavior.
 
     :param model_class: Pydantic model class to walk.
     :param prefix: Current environment variable prefix.
     :param delimiter: Delimiter for nested fields.
-    :return: Set of environment variable names.
+    :return: Tuple of (exact env var names, valid env var prefixes).
     """
-    env_vars = set()
+    env_vars: set[str] = set()
+    prefixes: set[str] = set()
 
     for field_name, field_info in model_class.model_fields.items():
-        # Build environment variable name for this field
         field_env_name = f"{prefix}{field_name.upper()}"
+        model_type = _resolve_model_type(field_info.annotation)
 
-        # Get the field type annotation
-        field_type = field_info.annotation
-
-        # Unwrap Optional/Union types to find the actual type
-        if get_origin(field_type) is type(None) or get_origin(field_type) is type(None):
-            # Handle Optional[T] which is Union[T, None]
-            args = get_args(field_type)
-            if args:
-                # Get the non-None type
-                field_type = next(
-                    (arg for arg in args if arg is not type(None)), args[0]
-                )
-
-        # Check if the field type is a nested BaseModel
-        is_base_model = False
-        with contextlib.suppress(TypeError):
-            # Attempt to check if field_type is a BaseModel subclass
-            is_base_model = isinstance(field_type, type) and issubclass(
-                field_type, BaseModel
-            )
-
-        if is_base_model:
-            # Recursively walk nested model
+        if model_type is not None:
             nested_prefix = f"{field_env_name}{delimiter}"
-            env_vars.update(
-                _walk_model_fields(
-                    cast("type[BaseModel]", field_type),
-                    nested_prefix,
-                    delimiter,
-                )
+            prefixes.add(nested_prefix)
+            sub_vars, sub_prefixes = _walk_model_fields(
+                model_type, nested_prefix, delimiter
             )
+            env_vars.update(sub_vars)
+            prefixes.update(sub_prefixes)
         else:
-            # Regular field - add to set
             env_vars.add(field_env_name)
 
-    return env_vars
+    return env_vars, prefixes

--- a/src/guidellm/utils/env_validator.py
+++ b/src/guidellm/utils/env_validator.py
@@ -6,8 +6,6 @@ import click
 from more_itertools import partition
 from pydantic import BaseModel
 
-from guidellm.settings import settings
-
 __all_ = [
     "validate_env_vars",
     "list_set_env",
@@ -15,7 +13,10 @@ __all_ = [
 ]
 
 
-def validate_env_vars(ctx: click.Context | None = None) -> tuple[set[str], set[str]]:
+def validate_env_vars(
+    *models: type[BaseModel],
+    ctx: click.Context | None = None,
+) -> tuple[set[str], set[str]]:
     """
     Validate if the given environment variable name is recognized.
 
@@ -26,7 +27,7 @@ def validate_env_vars(ctx: click.Context | None = None) -> tuple[set[str], set[s
     :return: True if the environment variable is valid, False otherwise.
     """
     set_vars = list_set_env()
-    valid_vars = get_valid_env_vars(ctx)
+    valid_vars = get_valid_env_vars(*models, ctx=ctx)
 
     invaild_set_vars, valid_set_vars = partition(
         lambda e: e in valid_vars,
@@ -46,7 +47,8 @@ def list_set_env(prefix: str = "GUIDELLM_") -> set[str]:
 
 
 def get_valid_env_vars(
-    ctx: click.Context | None = None, include_settings: bool = True
+    *models: type[BaseModel],
+    ctx: click.Context | None = None,
 ) -> set[str]:
     """
     Get all valid environment variable names from Click context and Settings.
@@ -62,8 +64,8 @@ def get_valid_env_vars(
     if ctx is not None:
         valid_envs.update(_extract_click_env_vars(ctx))
 
-    if include_settings:
-        valid_envs.update(_extract_settings_env_vars())
+    for model in models:
+        valid_envs.update(_extract_model_env_vars(model))
 
     return valid_envs
 
@@ -104,7 +106,7 @@ def _extract_click_env_vars(ctx: click.Context) -> set[str]:
     return env_vars
 
 
-def _extract_settings_env_vars() -> set[str]:
+def _extract_model_env_vars(model_class: type[BaseModel]) -> set[str]:
     """
     Extract all environment variable names from Pydantic Settings.
 
@@ -112,19 +114,19 @@ def _extract_settings_env_vars() -> set[str]:
 
     :return: Set of environment variable names.
     """
-    config = settings.model_config
+    config = model_class.model_config
     env_prefix = str(config.get("env_prefix", ""))
     env_delimiter = str(config.get("env_nested_delimiter", "__"))
 
     # Walk the settings model fields recursively
-    return _walk_settings_fields(
-        type(settings),
+    return _walk_model_fields(
+        model_class,
         env_prefix,
         env_delimiter,
     )
 
 
-def _walk_settings_fields(
+def _walk_model_fields(
     model_class: type[BaseModel],
     prefix: str,
     delimiter: str,
@@ -168,7 +170,7 @@ def _walk_settings_fields(
             # Recursively walk nested model
             nested_prefix = f"{field_env_name}{delimiter}"
             env_vars.update(
-                _walk_settings_fields(
+                _walk_model_fields(
                     cast("type[BaseModel]", field_type),
                     nested_prefix,
                     delimiter,

--- a/tests/unit/benchmark/schemas/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/test_entrypoints.py
@@ -1,8 +1,10 @@
 """
-Unit tests for backend transformation to typed BackendArgs instances.
+Unit tests for backend transformation to typed BackendArgs instances
+and BenchmarkScenario environment variable support.
 
 Tests the automatic conversion of backend configuration from dict-based
-backend into properly typed BackendArgs instances during model validation.
+backend into properly typed BackendArgs instances during model validation,
+and env var loading for BenchmarkScenario.
 
 ### WRITTEN BY AI ###
 """
@@ -14,6 +16,7 @@ from guidellm.backends.backend import BackendArgs
 from guidellm.backends.openai.http import OpenAIHTTPBackendArgs
 from guidellm.benchmark.schemas.entrypoints import (
     BenchmarkArgs,
+    BenchmarkScenario,
 )
 
 # Conditionally import VLLM backend args if available
@@ -357,3 +360,85 @@ class TestBackendArgsTransformation:
             )
             assert VLLMPythonBackendArgs is not None
             assert isinstance(args_vllm.backend, VLLMPythonBackendArgs)
+
+
+@pytest.mark.sanity
+class TestBenchmarkScenarioEnvVars:
+    """Test BenchmarkScenario environment variable loading."""
+
+    def test_backend_target_from_env(self, monkeypatch):
+        """
+        GUIDELLM__SPEC__BACKEND__TARGET sets the backend target.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__TARGET", "http://env-server:9000")
+
+        scenario = BenchmarkScenario.model_validate(
+            {"spec": {**_PIPELINE_DEFAULTS, "backend": {"kind": "openai_http"}}}
+        )
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://env-server:9000"
+
+    def test_discriminated_union_dispatch_from_env(self, monkeypatch):
+        """
+        Backend kind and variant-specific fields can be set via env vars.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__KIND", "openai_http")
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__TARGET", "http://env-server:9000")
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__MODEL", "env-model")
+
+        scenario = BenchmarkScenario.model_validate({"spec": _PIPELINE_DEFAULTS})
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://env-server:9000"
+        assert scenario.spec.backend.model == "env-model"
+
+    def test_sweep_size_string_coercion_from_env(self, monkeypatch):
+        """
+        GUIDELLM__SPEC__PROFILE__SWEEP_SIZE with string value is coerced to int.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__PROFILE__SWEEP_SIZE", "5")
+
+        scenario = BenchmarkScenario.model_validate(
+            {
+                "spec": {
+                    **_PIPELINE_DEFAULTS,
+                    "backend": {
+                        "kind": "openai_http",
+                        "target": "http://localhost:8000",
+                    },
+                    "profile": {"kind": "sweep"},
+                }
+            }
+        )
+
+        assert scenario.spec.profile.sweep_size == 5  # type: ignore[union-attr]
+
+    def test_kwargs_override_env_vars(self, monkeypatch):
+        """
+        Explicit kwargs take precedence over env var values.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__TARGET", "http://from-env:9000")
+
+        scenario = BenchmarkScenario.model_validate(
+            {
+                "spec": {
+                    **_PIPELINE_DEFAULTS,
+                    "backend": {
+                        "kind": "openai_http",
+                        "target": "http://from-kwarg:8000",
+                    },
+                }
+            }
+        )
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://from-kwarg:8000"

--- a/tests/unit/utils/test_env_validator.py
+++ b/tests/unit/utils/test_env_validator.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for environment variable validation utilities.
+
+## WRITTEN BY AI ##
+"""
+
+import pytest
+
+from guidellm.benchmark.schemas.entrypoints import BenchmarkScenario
+from guidellm.settings import Settings
+from guidellm.utils.env_validator import (
+    _resolve_model_type,
+    _walk_model_fields,
+    get_valid_env_vars,
+    validate_env_vars,
+)
+
+
+@pytest.mark.smoke
+class TestResolveModelType:
+    """Test _resolve_model_type annotation unwrapping."""
+
+    def test_returns_none_for_none(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        assert _resolve_model_type(None) is None
+
+    def test_returns_none_for_primitive(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        assert _resolve_model_type(int) is None
+        assert _resolve_model_type(str) is None
+        assert _resolve_model_type(float) is None
+
+    def test_returns_base_model_subclass(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        from pydantic import BaseModel
+
+        class MyModel(BaseModel):
+            x: int = 1
+
+        assert _resolve_model_type(MyModel) is MyModel
+
+    def test_unwraps_optional(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        from pydantic import BaseModel
+
+        class MyModel(BaseModel):
+            x: int = 1
+
+        assert _resolve_model_type(MyModel | None) is MyModel
+
+    def test_unwraps_list(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        from pydantic import BaseModel
+
+        class MyModel(BaseModel):
+            x: int = 1
+
+        assert _resolve_model_type(list[MyModel]) is MyModel
+
+
+@pytest.mark.smoke
+class TestWalkModelFields:
+    """Test _walk_model_fields field enumeration and prefix generation."""
+
+    def test_returns_prefixes_for_nested_models(self):
+        """
+        Nested BaseModel fields produce prefix entries.
+
+        ## WRITTEN BY AI ##
+        """
+        env_vars, prefixes = _walk_model_fields(BenchmarkScenario, "GUIDELLM__", "__")
+
+        assert "GUIDELLM__SPEC__" in prefixes
+        assert "GUIDELLM__SPEC__BACKEND__" in prefixes
+        assert "GUIDELLM__SPEC__PROFILE__" in prefixes
+
+    def test_returns_exact_names_for_leaf_fields(self):
+        """
+        Leaf fields (non-BaseModel) produce exact env var names.
+
+        ## WRITTEN BY AI ##
+        """
+        env_vars, prefixes = _walk_model_fields(Settings, "GUIDELLM__", "__")
+
+        assert "GUIDELLM__MAX_CONCURRENCY" in env_vars
+        assert "GUIDELLM__DEFAULT_SWEEP_NUMBER" in env_vars
+
+    def test_settings_no_false_positives(self):
+        """
+        Exact env var set does not contain prefix-style entries.
+
+        ## WRITTEN BY AI ##
+        """
+        env_vars, _prefixes = _walk_model_fields(Settings, "GUIDELLM__", "__")
+
+        for var in env_vars:
+            assert not var.endswith("__"), f"Leaf var {var} looks like a prefix"
+
+
+@pytest.mark.sanity
+class TestValidateEnvVars:
+    """Test validate_env_vars accepts/rejects env vars correctly."""
+
+    def test_accepts_exact_settings_var(self, monkeypatch):
+        """
+        Known Settings leaf env var is accepted.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__MAX_CONCURRENCY", "64")
+        invalid, valid = validate_env_vars(Settings)
+
+        assert "GUIDELLM__MAX_CONCURRENCY" in valid
+        assert "GUIDELLM__MAX_CONCURRENCY" not in invalid
+
+    def test_accepts_nested_model_prefix_var(self, monkeypatch):
+        """
+        Env var under a nested model prefix is accepted via prefix matching.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__TARGET", "http://localhost:8000")
+        invalid, valid = validate_env_vars(BenchmarkScenario)
+
+        assert "GUIDELLM__SPEC__BACKEND__TARGET" in valid
+        assert "GUIDELLM__SPEC__BACKEND__TARGET" not in invalid
+
+    def test_rejects_unknown_var(self, monkeypatch):
+        """
+        Env var that doesn't match any valid name or prefix is rejected.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__TOTALLY_BOGUS", "value")
+        invalid, valid = validate_env_vars(Settings, BenchmarkScenario)
+
+        assert "GUIDELLM__TOTALLY_BOGUS" in invalid
+        assert "GUIDELLM__TOTALLY_BOGUS" not in valid
+
+    def test_accepts_discriminated_union_variant_fields(self, monkeypatch):
+        """
+        Variant-specific fields under a discriminated union prefix are accepted.
+
+        ## WRITTEN BY AI ##
+        """
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__KIND", "openai_http")
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__TARGET", "http://localhost:8000")
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__MODEL", "gpt2")
+        monkeypatch.setenv("GUIDELLM__SPEC__BACKEND__API_KEY", "sk-test")
+
+        invalid, valid = validate_env_vars(BenchmarkScenario)
+
+        assert "GUIDELLM__SPEC__BACKEND__KIND" in valid
+        assert "GUIDELLM__SPEC__BACKEND__TARGET" in valid
+        assert "GUIDELLM__SPEC__BACKEND__MODEL" in valid
+        assert "GUIDELLM__SPEC__BACKEND__API_KEY" in valid
+        assert not invalid
+
+
+@pytest.mark.sanity
+class TestGetValidEnvVars:
+    """Test get_valid_env_vars returns both exact and prefix sets."""
+
+    def test_returns_tuple(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        result = get_valid_env_vars(Settings)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        env_vars, prefixes = result
+        assert isinstance(env_vars, set)
+        assert isinstance(prefixes, set)
+
+    def test_merges_multiple_models(self):
+        """
+        ## WRITTEN BY AI ##
+        """
+        env_vars, prefixes = get_valid_env_vars(Settings, BenchmarkScenario)
+
+        assert "GUIDELLM__MAX_CONCURRENCY" in env_vars
+        assert "GUIDELLM__SPEC__BACKEND__" in prefixes


### PR DESCRIPTION
## TODO

- [ ] Fix documentation (waiting on #814)

## Summary

(Re-)adds startup logs and fixes ENV -> CLI support

## Details

1. Adds a bunch of startup messages pertaining to benchmark component creation
2. Re-implements environment variable support for benchmark arguments using pydantic-settings rather then click. This allows for setting nested fields.

## Test Plan

Run CLI commands with various combinations of environment variables and CLI arguments.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #504

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit d969afdb01b59ad598c38f927dedb5ed395dd85c
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 18 16:53:27 2026 -0400

    Add/update resolve logs during startup
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit be7bb06abb5d875a55c83d109523d5932944a500
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 18 17:26:02 2026 -0400

    Restore ENV message
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 5fc9c99d1dab0dc43f1ea4a91e85313f8d50f0a3
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 18 18:27:53 2026 -0400

    Change BenchmarkScenario ENV deliminator
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit a58d70c169dbcc0f0b7b5aa065ae6790b502e0aa
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 22 14:07:07 2026 -0400

    Handle str values in before validators
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 9aca8d7fdea10f113070e1a543b33c28519d0234
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 22 14:09:16 2026 -0400

    Improve env validator to work with discriminated fields
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: GitHub Copilot GPT-4.1
Generated-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
