### PR TITLE
fix(openai): recognize reasoning_content key for TTFT calculation

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -985,7 +985,9 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
         choice: dict[str, dict] = choices[0] if choices else {}
         message = choice.get("message", {})
         text = message.get("content")
-        reasoning_text = message.get("reasoning") or None
+        reasoning_text = (
+            message.get("reasoning") or message.get("reasoning_content") or None
+        )
         raw_tool_calls = message.get("tool_calls")
         if text is None and not raw_tool_calls:
             text = ""  # Edge case: null content and no tools
@@ -1036,7 +1038,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         # Reasoning tokens trigger TTFT (updated=True) but are not
         # considered "content" for the TTFOT metric.
-        if reasoning := delta.get("reasoning"):
+        if reasoning := (delta.get("reasoning") or delta.get("reasoning_content")):
             self.streaming_reasoning_texts.append(reasoning)
             updated = True
         if content := delta.get("content"):


### PR DESCRIPTION
## Summary

llama.cpp returns model reasoning under the "reasoning_content" key instead of "reasoning", so reasoning-only streaming chunks were ignored and TTFT was never recorded (reported as 0). Accept either key in both the streaming and non-streaming chat completion paths.

## Details

vLLM also used to return reasoning with "reasoning_content" in the past and then switch to "reasoning".

## Test Plan

Verified that `guidellm` correctly measures TTFT with a llama.cpp server

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit b1ae037074d2ae10085427ddf5059886f2589169
Author: Radoslav Gerganov <rgerganov@gmail.com>
Date:   Tue Jun 23 15:34:26 2026 +0300

    fix(openai): recognize reasoning_content key for TTFT calculation
    
    llama.cpp returns model reasoning under the "reasoning_content" key
    instead of "reasoning", so reasoning-only streaming chunks were ignored
    and TTFT was never recorded (reported as 0). Accept either key in both
    the streaming and non-streaming chat completion paths.
    
    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
    Signed-off-by: Radoslav Gerganov <rgerganov@gmail.com>

---------

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Radoslav Gerganov <rgerganov@gmail.com>
