### PR TITLE
Remove "rate" as an alias for profile parameters

### DIFF
--- a/src/guidellm/benchmark/profiles/asynchronous.py
+++ b/src/guidellm/benchmark/profiles/asynchronous.py
@@ -44,9 +44,9 @@ class AsyncProfileArgs(ProfileArgs):
     def _coerce_rate_to_list(
         cls, value: list[PositiveFloat] | PositiveFloat
     ) -> list[PositiveFloat]:
-        """
-        Convert rates to a list from either a single number or a list of
-        numbers.
+        """Normalize rate to a list of integers.
+
+        Allow single integer or list of integers.
         """
         if isinstance(value, str):
             with contextlib.suppress(json.JSONDecodeError, ValueError):

--- a/src/guidellm/benchmark/profiles/concurrent.py
+++ b/src/guidellm/benchmark/profiles/concurrent.py
@@ -6,7 +6,7 @@ import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
+from pydantic import Field, PositiveInt, field_validator
 
 from guidellm.benchmark.schemas import ProfileArgs
 from guidellm.scheduler import (
@@ -31,34 +31,27 @@ class ConcurrentProfileArgs(ProfileArgs):
         description="Profile type discriminator for polymorphic serialization",
     )
     streams: list[PositiveInt] = Field(
-        validation_alias=AliasChoices("streams", "rate"),
         description="Concurrent stream counts to execute",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Check for duplicate rate"""
-        return cls._fail_on_duplicate_rate(data, "streams")
 
     @field_validator("streams", mode="before")
     @classmethod
     def _coerce_streams_to_list(cls, value: Any) -> Any:
-        """
-        Convert streams to a list of integers from either a single number or a list of
-        numbers.
+        """Normalize streams to a list of integers.
+
+        Allow single integer or list of integers.
         """
         if isinstance(value, str):
             with contextlib.suppress(json.JSONDecodeError, ValueError):
                 value = json.loads(value)
         if not value:
-            raise ValueError("streams (rate) requires at least one value")
+            raise ValueError("streams requires at least one value")
         if isinstance(value, list | tuple):
             return [int(stream) for stream in value]
         if isinstance(value, int | float):
             return [int(value)]
         raise ValueError(
-            "streams (rate) must be a number or a list of numeric values, "
+            "streams must be a number or a list of numeric values, "
             f"got {type(value).__name__}"
         )
 

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import MutableMapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic import Field
 
 from guidellm.benchmark.schemas import ProfileArgs
 from guidellm.data import DataArgs
@@ -19,7 +18,6 @@ from guidellm.scheduler import (
     TraceReplayStrategy,
 )
 from guidellm.scheduler.constraints.request import MaxRequestsConstraintArgs
-from guidellm.utils.imports import json
 from guidellm.utils.trace_io import load_relative_timestamps
 
 from .profile import Profile, ProfileFactory
@@ -95,39 +93,10 @@ class ReplayProfileArgs(ProfileArgs):
         description="Profile type discriminator for polymorphic serialization",
     )
     time_scale: float = Field(
-        validation_alias=AliasChoices("time_scale", "rate"),
         default=1.0,
         gt=0,
         description="Scale factor applied to relative timestamps",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Check for duplicate rate"""
-        return cls._fail_on_duplicate_rate(data, "time_scale")
-
-    @field_validator("time_scale", mode="before")
-    @classmethod
-    def _coerce_time_scale_from_rate(cls, value: Any) -> Any:
-        """
-        Accept global ``--rate`` list values as time scale.
-        """
-        if isinstance(value, str):
-            with contextlib.suppress(json.JSONDecodeError, ValueError):
-                value = json.loads(value)
-        if isinstance(value, list | tuple):
-            if not value:
-                raise ValueError(
-                    "time_scale (rate) requires at least one value when given as a list"
-                )
-            value = value[0]
-        if isinstance(value, int | float) and not isinstance(value, bool):
-            return float(value)
-        raise ValueError(
-            "time_scale (rate) must be an integer or a list of numeric values, "
-            f"got {type(value).__name__}"
-        )
 
 
 @ProfileFactory.register("replay")

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
+from pydantic import Field, PositiveInt
 
 from guidellm.benchmark.schemas import ProfileArgs
 from guidellm.scheduler import (
@@ -18,7 +17,6 @@ from guidellm.scheduler import (
     SynchronousStrategy,
     ThroughputStrategy,
 )
-from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -36,7 +34,6 @@ class SweepProfileArgs(ProfileArgs):
     )
     sweep_size: int = Field(
         default=10,
-        validation_alias=AliasChoices("sweep_size", "rate"),
         description="Number of strategies to generate for the sweep",
         ge=2,
     )
@@ -45,37 +42,6 @@ class SweepProfileArgs(ProfileArgs):
         default=None,
         description="Maximum concurrent requests to schedule",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Check for duplicate rate"""
-        return cls._fail_on_duplicate_rate(data, "sweep_size")
-
-    @field_validator("sweep_size", mode="before")
-    @classmethod
-    def _coerce_sweep_size_from_rate(cls, value: Any) -> Any:
-        """
-        Accept global ``--rate`` list values as sweep size.
-
-        The CLI passes ``rate`` as a list of floats; sweep uses the first entry
-        as the number of strategies to run.
-        """
-        if isinstance(value, str):
-            with contextlib.suppress(json.JSONDecodeError, ValueError):
-                value = json.loads(value)
-        if isinstance(value, list | tuple):
-            if not value:
-                raise ValueError(
-                    "sweep_size (rate) requires at least one value when given as a list"
-                )
-            value = value[0]
-        if isinstance(value, int | float) and not isinstance(value, bool):
-            return int(value)
-        raise ValueError(
-            "sweep_size (rate) must be an integer or a list of numeric values, "
-            f"got {type(value).__name__}"
-        )
 
 
 @ProfileFactory.register("sweep")

--- a/src/guidellm/benchmark/profiles/synchronous.py
+++ b/src/guidellm/benchmark/profiles/synchronous.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from guidellm.benchmark.schemas import ProfileArgs
 from guidellm.scheduler import (
@@ -28,14 +28,6 @@ class SynchronousProfileArgs(ProfileArgs):
         default="synchronous",
         description="Profile type discriminator for polymorphic serialization",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ensure_no_rate(cls, data: Any) -> Any:
-        """Validate that user didn't provide a rate."""
-        if isinstance(data, dict) and data.get("rate"):
-            raise ValueError("Synchonous profile does not accept a rate parameter.")
-        return data
 
 
 @ProfileFactory.register("synchronous")

--- a/src/guidellm/benchmark/profiles/throughput.py
+++ b/src/guidellm/benchmark/profiles/throughput.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, Field, PositiveInt, field_validator, model_validator
+from pydantic import Field, PositiveInt
 
 from guidellm.benchmark.schemas import ProfileArgs
 from guidellm.scheduler import (
@@ -14,7 +13,6 @@ from guidellm.scheduler import (
     SchedulingStrategy,
     ThroughputStrategy,
 )
-from guidellm.utils.imports import json
 
 from .profile import Profile, ProfileFactory
 
@@ -31,38 +29,8 @@ class ThroughputProfileArgs(ProfileArgs):
         description="Profile type discriminator for polymorphic serialization",
     )
     max_concurrency: PositiveInt | None = Field(
-        validation_alias=AliasChoices("max_concurrency", "rate"),
         description="Maximum concurrent requests to schedule",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _ensure_no_duplicate_rate(cls, data: Any) -> Any:
-        """Check for duplicate rate"""
-        return cls._fail_on_duplicate_rate(data, "max_concurrency")
-
-    @field_validator("max_concurrency", mode="before")
-    @classmethod
-    def _coerce_max_concurrency_from_rate(cls, value: Any) -> Any:
-        """
-        Accept global ``--rate`` list values as max concurrency.
-
-        The CLI passes ``rate`` as a list of floats; throughput uses the first entry
-        as the maximum concurrency.
-        """
-        if isinstance(value, str):
-            with contextlib.suppress(json.JSONDecodeError, ValueError):
-                value = json.loads(value)
-        if not value:
-            raise ValueError("max_concurrency (rate) requires at least one value")
-        if isinstance(value, list | tuple):
-            return int(value[0])
-        if isinstance(value, int | float) and not isinstance(value, bool):
-            return int(value)
-        raise ValueError(
-            "max_concurrency (rate) must be an integer or a list of numeric values, "
-            f"got {type(value).__name__}"
-        )
 
 
 @ProfileFactory.register("throughput")

--- a/src/guidellm/benchmark/schemas/profiles.py
+++ b/src/guidellm/benchmark/schemas/profiles.py
@@ -53,28 +53,6 @@ class ProfileArgs(PydanticClassRegistryMixin["ProfileArgs"], ABC):
 
         return ProfileArgs
 
-    @classmethod
-    def _fail_on_duplicate_rate(cls, data: Any, key: str) -> Any:
-        """Fail if both "rate" and <key> are specified.
-
-        Some profile alias "rate" and a more specific key; if the user enters
-        both, either directly or via the global "--rate" option, we should fail.
-
-        for example:
-
-            "--profile kind=concurrent,streams=2.0 --rate 3"
-            "--profile kind=concurrent,streams=2,rate=3"
-
-        Pydantic won't resolve all cases consistently, so we need to fail explicitly.
-
-        :param data: The data to validate
-        :param key: The key to check for duplicate rate
-        :return: The data
-        """
-        if isinstance(data, dict) and all(key in data for key in ("rate", key)):
-            raise ValueError(f"Both 'rate' and '{key}' cannot be specified.")
-        return data
-
     kind: str = Field(
         description="Profile type discriminator for polymorphic serialization",
     )

--- a/tests/unit/benchmark/schemas/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/test_entrypoints.py
@@ -37,7 +37,7 @@ _PIPELINE_DEFAULTS = {
     "data_preprocessors": [],
     "data_finalizer": {"kind": "generative"},
     "data_loader": {"kind": "pytorch"},
-    "profile": {"kind": "sweep", "rate": [10.0]},
+    "profile": {"kind": "sweep", "sweep_size": 10},
 }
 
 

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -90,14 +90,14 @@ class TestReplayProfile:
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(
-        ("rate", "expected_scale"),
+        ("time_scale", "expected_scale"),
         [
             (None, 1.0),
-            ([2.0], 2.0),
+            (2.0, 2.0),
         ],
     )
     def test_profile_create_resolves_time_scale_and_default_max_requests(
-        self, tmp_path: Path, rate, expected_scale
+        self, tmp_path: Path, time_scale, expected_scale
     ):
         """
         Profile.create resolves time scale and default max_requests from trace data.
@@ -116,8 +116,8 @@ class TestReplayProfile:
         payload: dict = {
             "data": [TraceSyntheticDataArgs(path=trace)],
         }
-        if rate is not None:
-            payload["rate"] = rate
+        if time_scale is not None:
+            payload["time_scale"] = time_scale
 
         profile = _replay_profile(**payload)
 
@@ -141,7 +141,7 @@ class TestReplayProfile:
 
         with pytest.raises(ValidationError):
             _replay_profile(
-                rate=[0.0],
+                time_scale=0.0,
                 data=[TraceSyntheticDataArgs(path=trace)],
             )
 
@@ -354,7 +354,7 @@ class TestReplayProfile:
     @pytest.mark.asyncio
     async def test_resolve_profile_passes_replay_specific_kwargs(self, tmp_path: Path):
         """
-        resolve_profile wires replay data, samples, and rate into the profile.
+        resolve_profile wires replay data, samples, and time_scale into the profile.
 
         ## WRITTEN BY AI ##
         """
@@ -368,7 +368,9 @@ class TestReplayProfile:
         )
 
         profile = await resolve_profile(
-            profile=ReplayProfileArgs.model_validate({"kind": "replay", "rate": [2.0]}),
+            profile=ReplayProfileArgs.model_validate(
+                {"kind": "replay", "time_scale": 2.0}
+            ),
             constraints={"max_requests": {"max_num": 2}},
             random_seed=42,
             data=[TraceSyntheticDataArgs(path=trace, timestamp_column="ts")],
@@ -391,7 +393,7 @@ class TestReplayProfile:
             ['{"timestamp": 0, "input_length": 1, "output_length": 1}'],
         )
         profile = _replay_profile(
-            rate=[2.0],
+            time_scale=2.0,
             data=[TraceSyntheticDataArgs(path=trace)],
         )
 

--- a/tests/unit/benchmark/test_sweep_profile.py
+++ b/tests/unit/benchmark/test_sweep_profile.py
@@ -16,14 +16,14 @@ class TestSweepProfileArgs:
         ("payload", "expected"),
         [
             ({"kind": "sweep", "sweep_size": 5}, 5),
-            ({"kind": "sweep", "rate": [8.0]}, 8),
-            ({"kind": "sweep", "rate": [12]}, 12),
-            ({"kind": "sweep", "rate": [10.0, 20.0]}, 10),
+            ({"kind": "sweep", "sweep_size": 8}, 8),
+            ({"kind": "sweep", "sweep_size": 12}, 12),
+            ({"kind": "sweep", "sweep_size": 10}, 10),
         ],
     )
-    def test_sweep_size_accepts_scalar_or_rate_list(self, payload, expected):
+    def test_sweep_size_validates(self, payload, expected):
         """
-        Validate sweep_size from sweep_size or global rate list.
+        Validate sweep_size from explicit sweep_size field.
 
         ## WRITTEN BY AI ##
         """
@@ -31,14 +31,14 @@ class TestSweepProfileArgs:
         assert args.sweep_size == expected
 
     @pytest.mark.smoke
-    def test_profile_create_from_rate_list(self):
+    def test_profile_create_from_sweep_size(self):
         """
-        Create sweep profile when resolve_profile passes rate as a list.
+        Create sweep profile when sweep_size is provided explicitly.
 
         ## WRITTEN BY AI ##
         """
         profile = ProfileFactory.create(
-            SweepProfileArgs.model_validate({"kind": "sweep", "rate": [6.0]}),
+            SweepProfileArgs.model_validate({"kind": "sweep", "sweep_size": 6}),
             42,
             {},
         )
@@ -47,30 +47,18 @@ class TestSweepProfileArgs:
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
-    async def test_resolve_profile_coerces_rate_list(self):
+    async def test_resolve_profile_passes_sweep_size(self):
         """
-        End-to-end resolve_profile passes list rate into sweep_size.
+        End-to-end resolve_profile passes sweep_size into the profile.
 
         ## WRITTEN BY AI ##
         """
         profile = await resolve_profile(
-            profile=SweepProfileArgs.model_validate(
-                {"kind": "sweep", "rate": [7.0, 8.0]}
-            ),
+            profile=SweepProfileArgs.model_validate({"kind": "sweep", "sweep_size": 7}),
             constraints={},
         )
         assert isinstance(profile, SweepProfile)
         assert profile.args.sweep_size == 7
-
-    @pytest.mark.smoke
-    def test_sweep_size_rejects_empty_rate_list(self):
-        """
-        Reject empty rate list for sweep profile.
-
-        ## WRITTEN BY AI ##
-        """
-        with pytest.raises(ValidationError):
-            SweepProfileArgs.model_validate({"kind": "sweep", "rate": []})
 
     @pytest.mark.smoke
     def test_sweep_size_enforces_minimum(self):
@@ -80,4 +68,4 @@ class TestSweepProfileArgs:
         ## WRITTEN BY AI ##
         """
         with pytest.raises(ValidationError):
-            SweepProfileArgs.model_validate({"kind": "sweep", "rate": [1.0]})
+            SweepProfileArgs.model_validate({"kind": "sweep", "sweep_size": 1})


### PR DESCRIPTION
## Summary

Remove the "rate" alias for profile parameters.

## Details

The profiles that used to process the global `--rate` value (async, concurrent, replay, sweep, throughput) accepted "rate" as an alias for the native internal parameter, and those which don't accept lists mapped from the rate list to a single value.

Now that the global `--rate` option no longer exists, this logic has no value. We remove it, accepting only the "native" parameter, and letting Pydantic handle validation errors if a user attempts to pass a list for a scalar value. (For convenience, we still map a specified scalar into a list for async and concurrent profiles.)

## Test Plan

- [x] Unit tests
- [x] Integration tests
- [x] e2e tests
- [x] Assorted manual test runs

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

Assisted-by: Cursor
<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 1ae1ddcf3416cf5810edf911ee0383c516a8c83a
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jun 23 08:42:04 2026 -0400

    Remove "rate" as an alias for profile parameters
    
    We no longer have a global --rate, so no further purpose is served by allowing
    the name "rate" as an alias for "streams", "max_concurrency", and "sweep_size"
    in the relevant profiles. Remove the alias, and with it the "adapter"
    validators that allowed applying rate lists to scalar parameters.
    
    Assisted-by: Cursor
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Assisted-by: Cursor
Signed-off-by: David Butenhof <dbutenho@redhat.com>
