### PR TITLE
test: register `slow` pytest marker to silence PytestUnknownMarkWarning (#840)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,4 +290,5 @@ markers = [
     "smoke: quick tests to check basic functionality",
     "sanity: detailed tests to ensure major functions work correctly",
     "regression: tests to ensure that new changes do not break existing functionality",
+    "slow: marks tests that are slow to run, e.g. those that download or load real models/tokenizers",
 ]


### PR DESCRIPTION
## Summary

`tests/unit/data/tokenizers/test_huggingface.py` applies `@pytest.mark.slow` to three tokenizer-loading tests, but the `slow` marker is never declared in `[tool.pytest.ini_options].markers` in `pyproject.toml`. As a result, every `tox -e test-unit` run emits:

```
PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?
```

## Fix

Register `slow` alongside the existing `smoke` / `sanity` / `regression` markers. This silences the warning while preserving the intent of the marker (categorizing tests that download/load real tokenizers), so the marker can still be used for selection/deselection (`-m "not slow"`).

Registering — rather than removing the decorators — keeps the existing test categorization intact.

Fixes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit bf0c3314fff534fd36c31ce996d8a0639abcab32
Author: Tai An <antai12232931@outlook.com>
Date:   Tue Jun 23 21:14:41 2026 -0700

    test: register `slow` pytest marker to silence PytestUnknownMarkWarning (#840)
    
    The `slow` marker is applied to tokenizer-loading tests in
    tests/unit/data/tokenizers/test_huggingface.py but was never declared in
    [tool.pytest.ini_options].markers, so pytest emits PytestUnknownMarkWarning.
    Register it alongside the existing smoke/sanity/regression markers,
    preserving the intent to categorize slow tokenizer-download tests.
    
    Fixes #840
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

---------

Signed-off-by: Tai An <antai12232931@outlook.com>
