### PR TITLE
Misc v0.7.0 Fixes

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -458,8 +458,6 @@ async def benchmark_generative_text(
         constraints=constraints,
         console=console,
         random_seed=benchmark_args.seed.value,  # type: ignore[attr-defined]
-        data=benchmark_args.data,
-        data_samples=request_loader.info.get("data_samples", -1),
     )
     output_formats = await resolve_output_formats(
         outputs=benchmark_args.outputs, console=console

--- a/src/guidellm/benchmark/profiles/replay.py
+++ b/src/guidellm/benchmark/profiles/replay.py
@@ -3,85 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
 
 from guidellm.benchmark.schemas import ProfileArgs
-from guidellm.data import DataArgs
-from guidellm.data.deserializers import TraceSyntheticDataArgs
 from guidellm.scheduler import (
     ConstraintInitializer,
-    ConstraintsInitializerFactory,
     SchedulingStrategy,
     TraceReplayStrategy,
 )
-from guidellm.scheduler.constraints.request import MaxRequestsConstraintArgs
-from guidellm.utils.trace_io import load_relative_timestamps
 
 from .profile import Profile, ProfileFactory
 
 if TYPE_CHECKING:
     from guidellm.benchmark.schemas import Benchmark
-
-
-def _normalize_data_args(data: list[Any]) -> list[DataArgs]:
-    """
-    Coerce serialized data entries back into validated ``DataArgs`` instances.
-
-    :param data: Data sources as models or serialized mappings from ``model_dump``
-    :return: Validated data argument instances
-    :raises ValueError: If an entry is not a supported data configuration type
-    """
-    normalized: list[DataArgs] = []
-    for item in data:
-        if isinstance(item, DataArgs):
-            normalized.append(item)
-        elif isinstance(item, dict):
-            normalized.append(DataArgs.model_validate(item))
-        else:
-            raise ValueError(
-                "ReplayProfile data entries must be DataArgs instances or mappings, "
-                f"got {type(item).__name__}"
-            )
-    return normalized
-
-
-def _resolve_relative_timestamps(
-    data: list[Any],
-    data_samples: int,
-) -> list[float]:
-    """
-    Load and optionally truncate relative timestamps from a trace data source.
-
-    :param data: Data sources configured for the replay profile
-    :param data_samples: Maximum number of timestamps to retain; non-positive keeps all
-    :return: Sorted timestamps relative to the first event
-    :raises ValueError: If data configuration is invalid or yields no timestamps
-    """
-    data_args = _normalize_data_args(data)
-    if len(data_args) != 1:
-        raise ValueError(
-            f"ReplayProfile requires exactly one data source, received {len(data_args)}"
-        )
-    config = data_args[0]
-    if not isinstance(config, TraceSyntheticDataArgs):
-        raise ValueError("ReplayProfile requires a trace data source")
-    if not (path := Path(config.path)).exists():
-        raise ValueError(f"Replay trace file not found: {config.path}")
-
-    relative_timestamps = load_relative_timestamps(path, config.timestamp_column)
-    if data_samples > 0:
-        relative_timestamps = relative_timestamps[:data_samples]
-
-    if not relative_timestamps:
-        raise ValueError(
-            "No timestamps remain after applying data_samples. "
-            "The trace is empty or all events were filtered out."
-        )
-
-    return relative_timestamps
 
 
 @ProfileArgs.register("replay")
@@ -124,17 +60,6 @@ class ReplayProfile(Profile):
     ):
         super().__init__(args, random_seed, constraints, **kwargs)
         self.args = args
-
-        data = kwargs.get("data", [])
-        data_samples = kwargs.get("data_samples", -1)
-        relative_timestamps = _resolve_relative_timestamps(data, data_samples)
-        new_constraints = dict(constraints or {})
-        if "max_requests" not in new_constraints:
-            constraint_args = MaxRequestsConstraintArgs(count=len(relative_timestamps))
-            new_constraints["max_requests"] = ConstraintsInitializerFactory.create(
-                constraint_args
-            )
-            self.constraints = new_constraints
 
     @property
     def strategy_types(self) -> list[str]:

--- a/src/guidellm/benchmark/profiles/sweep.py
+++ b/src/guidellm/benchmark/profiles/sweep.py
@@ -42,7 +42,7 @@ class SweepProfileArgs(ProfileArgs):
         description="Type of strategy to use for the asynchronous sweep",
     )
     max_concurrency: PositiveInt | None = Field(
-        default=None,
+        default=512,
         description="Maximum concurrent requests to schedule",
     )
 

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -99,7 +99,8 @@ class Settings(BaseSettings):
     mp_poll_interval: float = 0.1
     mp_max_pending_buffer_percent: float = 0.5
     mp_max_worker_buffer_percent: float = 0.2
-    max_concurrency: int = 512
+    # For non-concurrent tasks, cap concurrency to avoid runaway on overloaded systems
+    max_concurrency: int = 1024 * 10  # 1Ki per worker
     max_worker_processes: int = 10
     scheduler_start_delay_non_distributed: float = 1.0
     constraint_error_window_size: float = 30

--- a/tests/unit/benchmark/test_replay_profile.py
+++ b/tests/unit/benchmark/test_replay_profile.py
@@ -4,23 +4,13 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
 
 from guidellm.benchmark.entrypoints import resolve_profile
 from guidellm.benchmark.profiles import ProfileFactory, ReplayProfile
 from guidellm.benchmark.profiles.replay import ReplayProfileArgs
-from guidellm.data.deserializers import TraceSyntheticDataArgs
 from guidellm.scheduler import (
-    MaxNumberConstraint,
-    MaxRequestsConstraintArgs,
     TraceReplayStrategy,
 )
-
-
-def _trace_path(tmp_path: Path, lines: list[str] | None = None) -> Path:
-    path = tmp_path / "trace.jsonl"
-    path.write_text("\n".join(lines or []))
-    return path
 
 
 def _replay_args(**kwargs) -> ReplayProfileArgs:
@@ -31,325 +21,15 @@ def _replay_args(**kwargs) -> ReplayProfileArgs:
 def _replay_profile(
     constraints: dict[str, Any] | None = None, random_seed: int = 42, **kwargs
 ) -> ReplayProfile:
-    data = kwargs.pop("data", None)
-    data_samples = kwargs.pop("data_samples", -1)
     args = _replay_args(**kwargs)
-    profile_kwargs: dict[str, Any] = {"data_samples": data_samples}
-    if data is not None:
-        profile_kwargs["data"] = data
     return ProfileFactory.create(
-        args, random_seed, constraints=constraints, **profile_kwargs
+        args,
+        random_seed,
+        constraints=constraints,
     )
 
 
 class TestReplayProfile:
-    @pytest.mark.smoke
-    def test_requires_data(self):
-        """
-        Replay profile requires a trace data source.
-
-        ## WRITTEN BY AI ##
-        """
-        args = _replay_args()
-        with pytest.raises(ValueError, match="exactly one data source"):
-            ProfileFactory.create(args, 42)
-
-    @pytest.mark.smoke
-    def test_rejects_multiple_data_sources(self, tmp_path: Path):
-        """
-        Replay profile rejects more than one data source.
-
-        ## WRITTEN BY AI ##
-        """
-        args = _replay_args()
-        with pytest.raises(ValueError, match="exactly one data source"):
-            ProfileFactory.create(
-                args,
-                42,
-                data=[
-                    TraceSyntheticDataArgs(path=tmp_path / "trace-a.jsonl"),
-                    TraceSyntheticDataArgs(path=tmp_path / "trace-b.jsonl"),
-                ],
-            )
-
-    @pytest.mark.smoke
-    def test_rejects_missing_or_empty_trace(self, tmp_path: Path):
-        """
-        Replay profile rejects missing files and empty traces.
-
-        ## WRITTEN BY AI ##
-        """
-        missing = tmp_path / "missing.jsonl"
-        args = _replay_args()
-        with pytest.raises(ValueError, match="not found"):
-            ProfileFactory.create(args, 42, data=[TraceSyntheticDataArgs(path=missing)])
-
-        empty = _trace_path(tmp_path)
-        with pytest.raises(ValueError, match="empty|No timestamps"):
-            ProfileFactory.create(args, 42, data=[TraceSyntheticDataArgs(path=empty)])
-
-    @pytest.mark.smoke
-    @pytest.mark.parametrize(
-        ("time_scale", "expected_scale"),
-        [
-            (None, 1.0),
-            (2.0, 2.0),
-        ],
-    )
-    def test_profile_create_resolves_time_scale_and_default_max_requests(
-        self, tmp_path: Path, time_scale, expected_scale
-    ):
-        """
-        Profile.create resolves time scale and default max_requests from trace data.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"timestamp": 5.0, "input_length": 1, "output_length": 1}',
-                '{"timestamp": 2.0, "input_length": 2, "output_length": 2}',
-                '{"timestamp": 8.0, "input_length": 3, "output_length": 3}',
-            ],
-        )
-
-        payload: dict = {
-            "data": [TraceSyntheticDataArgs(path=trace)],
-        }
-        if time_scale is not None:
-            payload["time_scale"] = time_scale
-
-        profile = _replay_profile(**payload)
-
-        assert isinstance(profile, ReplayProfile)
-        assert profile.args.time_scale == expected_scale
-        assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(count=3), current_index=-1
-        )
-
-    @pytest.mark.sanity
-    def test_non_positive_time_scale_is_rejected(self, tmp_path: Path):
-        """
-        Non-positive time scale values are rejected during argument validation.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            ['{"timestamp": 0, "input_length": 1, "output_length": 1}'],
-        )
-
-        with pytest.raises(ValidationError):
-            _replay_profile(
-                time_scale=0.0,
-                data=[TraceSyntheticDataArgs(path=trace)],
-            )
-
-    @pytest.mark.smoke
-    def test_custom_timestamp_column_via_data_args(self, tmp_path: Path):
-        """
-        Custom timestamp columns are honored when loading trace timestamps.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"ts": 5.0, "input_length": 100, "output_length": 10}',
-                '{"ts": 2.0, "input_length": 200, "output_length": 20}',
-                '{"ts": 8.0, "input_length": 300, "output_length": 30}',
-            ],
-        )
-
-        profile = _replay_profile(
-            data=[TraceSyntheticDataArgs(path=trace, timestamp_column="ts")],
-        )
-
-        assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(count=3), current_index=-1
-        )
-
-    @pytest.mark.smoke
-    def test_large_bursty_trace_sets_default_request_constraint(self, tmp_path: Path):
-        """
-        Default max_requests matches the number of loaded trace events.
-
-        ## WRITTEN BY AI ##
-        """
-        prompt_lengths = [
-            6755,
-            7319,
-            7234,
-            2287,
-            9013,
-            6506,
-            4824,
-            3119,
-            23090,
-            3135,
-            26874,
-            10487,
-            17448,
-            6253,
-            6725,
-            13538,
-            87162,
-            6166,
-            6320,
-            2007,
-            3174,
-            3131,
-            3159,
-            6820,
-            3154,
-            9416,
-            7460,
-        ]
-        timestamps = [
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            0.5,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            2.0,
-            2.0,
-            2.0,
-            2.0,
-        ]
-        trace = _trace_path(
-            tmp_path,
-            [
-                (
-                    f'{{"timestamp": {timestamp}, '
-                    f'"input_length": {prompt_length}, "output_length": 1}}'
-                )
-                for timestamp, prompt_length in zip(
-                    timestamps, prompt_lengths, strict=True
-                )
-            ],
-        )
-
-        profile = _replay_profile(data=[TraceSyntheticDataArgs(path=trace)])
-
-        assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(count=27), current_index=-1
-        )
-
-    @pytest.mark.smoke
-    @pytest.mark.parametrize("invalid_value", [None, 123, False, []])
-    def test_non_string_timestamp_column_rejected_by_pydantic(
-        self, tmp_path: Path, invalid_value
-    ):
-        """
-        Trace data args reject invalid timestamp column types.
-
-        ## WRITTEN BY AI ##
-        """
-        with pytest.raises(ValidationError):
-            TraceSyntheticDataArgs(
-                path=tmp_path / "trace.jsonl",
-                timestamp_column=invalid_value,
-            )
-
-    @pytest.mark.smoke
-    @pytest.mark.parametrize("invalid_col", ["", "   "])
-    def test_blank_timestamp_column_raises_error(self, tmp_path: Path, invalid_col):
-        """
-        Blank timestamp column names fail when loading trace timestamps.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"timestamp": 10.0, "input_length": 1, "output_length": 1}',
-                '{"timestamp": 12.0, "input_length": 2, "output_length": 2}',
-            ],
-        )
-
-        with pytest.raises((KeyError, ValueError)):
-            _replay_profile(
-                data=[TraceSyntheticDataArgs(path=trace, timestamp_column=invalid_col)],
-            )
-
-    @pytest.mark.smoke
-    def test_data_samples_truncates_after_sorting_and_preserves_constraints(
-        self, tmp_path: Path
-    ):
-        """
-        data_samples truncates timestamps while preserving explicit constraints.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"timestamp": 5.0, "input_length": 1, "output_length": 1}',
-                '{"timestamp": 2.0, "input_length": 2, "output_length": 2}',
-                '{"timestamp": 8.0, "input_length": 3, "output_length": 3}',
-                '{"timestamp": 1.0, "input_length": 4, "output_length": 4}',
-            ],
-        )
-
-        profile = _replay_profile(
-            data=[TraceSyntheticDataArgs(path=trace)],
-            data_samples=3,
-            constraints={
-                "max_requests": {"max_num": 10},
-                "max_duration": {"max_duration": 0.25},
-            },
-        )
-
-        assert profile.constraints == {
-            "max_requests": {"max_num": 10},
-            "max_duration": {"max_duration": 0.25},
-        }
-
-    @pytest.mark.smoke
-    @pytest.mark.parametrize("data_samples", [0, -1])
-    def test_non_positive_data_samples_do_not_truncate(
-        self, tmp_path: Path, data_samples: int
-    ):
-        """
-        Non-positive data_samples values keep the full trace.
-
-        ## WRITTEN BY AI ##
-        """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"timestamp": 0, "input_length": 1, "output_length": 1}',
-                '{"timestamp": 1.0, "input_length": 2, "output_length": 2}',
-            ],
-        )
-
-        profile = _replay_profile(
-            data=[TraceSyntheticDataArgs(path=trace)],
-            data_samples=data_samples,
-        )
-
-        assert profile.constraints["max_requests"] == MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(count=2), current_index=-1
-        )
-
     @pytest.mark.smoke
     @pytest.mark.asyncio
     async def test_resolve_profile_passes_replay_specific_kwargs(self, tmp_path: Path):
@@ -358,23 +38,12 @@ class TestReplayProfile:
 
         ## WRITTEN BY AI ##
         """
-        trace = _trace_path(
-            tmp_path,
-            [
-                '{"ts": 5.0, "input_length": 1, "output_length": 1}',
-                '{"ts": 2.0, "input_length": 2, "output_length": 2}',
-                '{"ts": 8.0, "input_length": 3, "output_length": 3}',
-            ],
-        )
-
         profile = await resolve_profile(
             profile=ReplayProfileArgs.model_validate(
                 {"kind": "replay", "time_scale": 2.0}
             ),
             constraints={"max_requests": {"max_num": 2}},
             random_seed=42,
-            data=[TraceSyntheticDataArgs(path=trace, timestamp_column="ts")],
-            data_samples=2,
         )
 
         assert isinstance(profile, ReplayProfile)
@@ -388,14 +57,7 @@ class TestReplayProfile:
 
         ## WRITTEN BY AI ##
         """
-        trace = _trace_path(
-            tmp_path,
-            ['{"timestamp": 0, "input_length": 1, "output_length": 1}'],
-        )
-        profile = _replay_profile(
-            time_scale=2.0,
-            data=[TraceSyntheticDataArgs(path=trace)],
-        )
+        profile = _replay_profile(time_scale=2.0)
 
         strategy = profile.next_strategy(None, None)
         assert profile.strategy_types == ["trace"]


### PR DESCRIPTION
## Summary

Fixes a couple smaller issues.

## Details

### 1. Bump max_concurrency

See more details in the commit description, but the primary reason to bump it now is because the replay profile is also subjected to it.

### 2. Drop the max-request modifier from replay

This code never made sense to have and was just a holdover from when the profile was responsible for trace timing. There is an automatic constraint that ends the benchmark when the dataset is exhausted that serves the same purpose.

## Test Plan

For replays a longer dataset can be provided and limited to a smaller number of samples:

```sh
guidellm run \
    --backend kind=openai_http,target=https://localhost:8000 \
    --profile kind=replay,time_scale=0.01 \
    --data-loader kind=pytorch,samples=30 \
    --data kind=trace_synthetic,path=./data.jsonl
```

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 78b401453b2ab7c4fd6b6b076aefb93773f0c0ff
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 24 13:52:57 2026 -0400

    Bump max_concurrency
    
    The max_concurrency limit applies to all non-concurrency workloads. The
    current lmit is way too low and was kept that way because it is also the
    default for sweep. This chnage splits the two.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 850e8f31141c3773d48274c28de4b0543598876b
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 25 15:07:50 2026 -0400

    Remove timestamps injection from replay profile
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 522b457fa91863a532230a705305b8d7a4332981
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jun 25 15:23:31 2026 -0400

    Drop unneeded tests
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
