### PR TITLE
Fix: Exclude computed fields during pydantic MP serialization

### DIFF
--- a/src/guidellm/utils/encoding.py
+++ b/src/guidellm/utils/encoding.py
@@ -431,7 +431,7 @@ class Serializer:
             "*PYD*": True,
             "typ": item.__class__.__name__,
             "mod": item.__class__.__module__,
-            "dat": item.model_dump(mode="python"),
+            "dat": item.model_dump(mode="python", exclude_computed_fields=True),
         }
 
     def from_dict_pydantic(self, item: dict[str, Any]) -> Any:
@@ -572,7 +572,9 @@ class Serializer:
         """
         class_name: str = obj.__class__.__name__
         class_module: str = obj.__class__.__module__
-        json_data = obj.__pydantic_serializer__.to_json(obj)
+        json_data = obj.__pydantic_serializer__.to_json(
+            obj, exclude_computed_fields=True
+        )
 
         return class_name.encode() + b"|" + class_module.encode() + b"|" + json_data
 

--- a/tests/unit/utils/test_encoding.py
+++ b/tests/unit/utils/test_encoding.py
@@ -201,7 +201,6 @@ class TestMessageEncoding:
         else:
             assert decoded == obj
 
-    @pytest.mark.xfail(reason="old and broken", run=False)
     @pytest.mark.smoke
     @pytest.mark.parametrize(
         "obj",


### PR DESCRIPTION
## Summary
See the linked issue for more details. In short, fields with the`@computed_field` decorator are included in `model_dump` (and similar) by default, but are then treated as extra fields when passed to `model_validate`, leading to duplicates appearing in the final deserialized object.

## Details
- Set `exclude_computed_fields=True` in `Serializer.to_dict_pydantic` and `.to_sequence_pydantic`
- Remove pytest.mark.xfail from `test_encode_decode_generative`

## Test Plan
`tox -e test-unit -- tests/unit/utils/test_encoding.py`

## Related Issues
- Resolves #446
  - Alternative solution to #448

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 4c59acb978d7fa3264d95d99a52873ec977e36c8
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jun 24 15:02:04 2026 -0400

    Exclude computed fields during pydantic model dump
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

---------

Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>
