### PR TITLE
Add `--label` argument 

### DIFF
--- a/src/guidellm/benchmark/schemas/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/entrypoints.py
@@ -239,7 +239,8 @@ class BenchmarkMetadata(StandardBaseModel):
     purposes but does not affect benchmark execution.
     """
 
-    model_config = args_model_config()
+    # Allow arbitrary metadata fields
+    model_config = args_model_config() | ConfigDict(extra="allow")
 
     labels: dict[str, str] = Field(
         default_factory=dict,

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -61,6 +61,12 @@ __all__ = [
     nargs=2,
     callback=cli_tools.parse_overrides,
     multiple=True,
+    help=(
+        "Define overrides for each sub-benchmark. "
+        "Currently this only supports `profile.streams` or `profile.rate`. "
+        "Example: `--profile kind=concurrent --override 'profile.streams' 1,2,4,8,16`"
+        "  [repeatable]"
+    ),
 )
 @click.option(
     "--disable-console",

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -54,6 +54,18 @@ __all__ = [
         "CLI options override scenario settings."
     ),
 )
+@click.option(
+    "--label",
+    "-l",
+    "labels",
+    multiple=True,
+    callback=cli_tools.parse_kv_str,
+    help=(
+        "Define a labels in key-value pair for the run. "
+        "Example: `--label timestamp=1999-09-12@12:00:00 --label env=staging`"
+        "  [repeatable]"
+    ),
+)
 @registry_options_from_model(model=BenchmarkArgs, group_key="spec")
 @click.option(
     "--override",
@@ -124,6 +136,7 @@ def run(**kwargs):  # noqa: C901, PLR0915
         args = BenchmarkScenario.create(
             spec=kwargs.get("spec", {}),
             benchmarks=kwargs.get("benchmarks", []),
+            metadata={"labels": dict(kwargs.get("labels", []))},
             scenario=kwargs.get("config"),
         )
     except ValidationError as err:

--- a/src/guidellm/utils/cli.py
+++ b/src/guidellm/utils/cli.py
@@ -222,3 +222,27 @@ def parse_overrides(ctx, param, value):
         overrides.append((k, values_parsed))
 
     return overrides_to_benchmarks(*overrides)
+
+
+def parse_kv_str(
+    ctx: click.Context, param: click.Parameter, value: str | tuple[str, ...] | list[str]
+):
+    """
+    Parse a key=value string into a dictionary.
+
+    :param ctx: Click context
+    :param param: Click parameter
+    :param value: The input string to parse
+    :return: Dictionary with the parsed key-value pair, or None if input is None
+    :raises click.BadParameter: When parsing fails or the format is invalid
+    """
+    if isinstance(value, list | tuple):
+        return [parse_kv_str(ctx, param, v) for v in value]
+
+    try:
+        key, val = value.split("=", 1)
+        return key, val
+    except ValueError as e:
+        raise click.BadParameter(
+            f"Invalid key=value format for '{value}'. Expected format is 'key=value'."
+        ) from e


### PR DESCRIPTION
## Summary

Handles a bunch of missing pieces from the refactor. See individual commits below.

## Test Plan

<!--
List the steps needed to test this PR.
-->
- Check that `--label`s are applied to output
- ~Verify `--profile ...,sample_requests=#` results in a downsampling of requests in output~ Dropped in favor of #863
- Check `guidellm run --help` to ensure that the new help messages exists and are helpful.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #728

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit bd350543ce855145596921cc7cf78c6acd00b17d
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 24 14:20:06 2026 -0400

    Add help message to --override
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit be469044350839138e1b5d0c8ddec423b124e01b
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jun 24 15:18:41 2026 -0400

    Add label CLI option
    
    Wires the label metadata field to the CLI.
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: GitHub Copilot GPT-4.1
Signed-off-by: Samuel Monson <smonson@redhat.com>
