### PR TITLE
Rename "config" CLI command to "env"

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -316,7 +316,7 @@ Logging is set using the following environment variables:
 - `GUIDELLM__LOGGING__LOG_FILE`: Path to the log file for file logging (default: guidellm.log if log file level set else none)
 - `GUIDELLM__LOGGING__LOG_FILE_LEVEL`: Log level for file logging (default: INFO if log file set else none).
 
-If logging isn't responding to the environment variables, run the `guidellm config` command to validate that the environment variables match and are being set correctly.
+If logging isn't responding to the environment variables, run the `guidellm env` command to validate that the environment variables match and are being set correctly.
 
 ## Additional Resources
 

--- a/src/guidellm/cli/__init__.py
+++ b/src/guidellm/cli/__init__.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import click
 
 from .benchmark import benchmark
-from .config import config
+from .env import env
 from .mock_server import mock_server
 from .preprocess import preprocess
 from .run import run
@@ -41,7 +41,7 @@ def cli():
 
 
 # Register all commands and groups
-cli.add_command(config)
+cli.add_command(env)
 cli.add_command(mock_server)
 cli.add_command(preprocess)
 cli.add_command(run)

--- a/src/guidellm/cli/env.py
+++ b/src/guidellm/cli/env.py
@@ -1,4 +1,4 @@
-"""Configuration display command."""
+"""Environment configuration display command."""
 
 from __future__ import annotations
 
@@ -6,12 +6,12 @@ import click
 
 from guidellm.settings import print_config
 
-__all__ = ["config"]
+__all__ = ["env"]
 
 
 @click.command(
-    short_help="Show configuration settings.",
+    short_help="Show environment variable settings.",
     help="Display environment variables for configuring GuideLLM behavior.",
 )
-def config():
+def env():
     print_config()

--- a/src/guidellm/logger.py
+++ b/src/guidellm/logger.py
@@ -16,7 +16,7 @@ Environment Variables:
     - GUIDELLM__LOGGING__LOG_FILE_LEVEL: Log level for file logging
         (default: INFO if log file set else none).
 
-If logging isn't responding to the environment variables, run the `guidellm config`
+If logging isn't responding to the environment variables, run the `guidellm env`
 command to validate that the environment variables match and are being set correctly.
 
 Usage:


### PR DESCRIPTION
## Summary

This does the pre-planned renaming of the `config` command to the `env` command.

## Details

- Doesn't really change much except the names.

## Test Plan

- Run the env command

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 7879abf8fd53d84ae809d861281f7f09b8742508
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Jun 24 18:18:34 2026 -0400

    Rename "config" CLI command to "env"
    
    Generated-by: Cursor AI Claude Opus 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Claude Opus 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
