### PR TITLE
Fix: Add relative_timestamp column to output in Mooncake deserializer

### DIFF
--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -223,6 +223,7 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
         row_idx = 0
         hash_id_table: list[Any] = []
         sibling_token_blocks: dict[Any, list[list[int]]] = {}
+        timestamps = self.trace_rows[self.config.timestamp_column]
         while True:
             try:
                 row = self.trace_rows[row_idx]
@@ -246,7 +247,6 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                     )
                     sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
             prompt = _create_prompt_from_hash_ids(ids, hash_id_table, self.processor)
-            timestamps = self.trace_rows[self.config.timestamp_column]
             relative_timestamp = timestamps[row_idx] - timestamps[0]
             yield (
                 row_idx,

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -246,12 +246,15 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                     )
                     sibling_token_blocks[prev_id].append(hash_id_table[hash_id])
             prompt = _create_prompt_from_hash_ids(ids, hash_id_table, self.processor)
+            timestamps = self.trace_rows[self.config.timestamp_column]
+            relative_timestamp = timestamps[row_idx] - timestamps[0]
             yield (
                 row_idx,
                 {
                     "prompt_tokens_count": row[self.config.prompt_tokens_column],
                     "output_tokens_count": row[self.config.output_tokens_column],
                     "prompt": prompt,
+                    "relative_timestamp": relative_timestamp,
                 },
             )
             row_idx += 1
@@ -267,6 +270,7 @@ class _TraceMooncakeExamplesIterable(_BaseExamplesIterable):
                 "prompt": Value("string"),
                 "prompt_tokens_count": Value("int32"),
                 "output_tokens_count": Value("int32"),
+                "relative_timestamp": Value("float"),
             }
         )
 


### PR DESCRIPTION
## Summary
This is a separate PR for the bug fix contained in #829, if we instead wish to just get the bug fix in for v0.7.0. This will be closed if the trace file refactor is merged, or after the release of v0.7.0.

## Details
- Fixed a bug with Mooncake format not working with multiprocessing

## Related Issues
- This is also fixed with #829 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3b89ec2888c9156348eea83fc613639c29872fea
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 25 11:54:24 2026 -0400

    Hotfix: Add relative_timestamp column to output in Mooncake deserializer
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 8d2cba0528b556919f876230d847138d9b271e79
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Jun 25 12:59:10 2026 -0400

    Move `timestamps` outside the loop
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

---------

Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>
