### PR TITLE
Fix up doc linkages

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -92,4 +92,12 @@ Whether you're interested in understanding the system architecture, exploring su
 
   [:octicons-arrow-right-24: Troubleshooting Guide](troubleshooting.md)
 
+- :material-update:{ .lg .middle } v0.7.0 Migration Guide
+
+  ______________________________________________________________________
+
+  How to migrate GuideLLM CLI commandsfrom v0.6.0 to v0.7.0.
+
+  [:octicons-arrow-right-24: v0.7.0 Migration Guide](v0.7.0_migration_guide.md)
+
 </div>

--- a/docs/guides/v0.7.0_migration_guide.md
+++ b/docs/guides/v0.7.0_migration_guide.md
@@ -1,4 +1,4 @@
-# CLI Migration Guide
+# v0.6.0 to v0.7.0 CLI Migration Guide
 
 ## `guidellm benchmark [run]`
 


### PR DESCRIPTION
## Summary

Minor doc site tweaks for the migration guide.

## Details

After looking at the nightly publication at https://vllm-project.github.io/guidellm/main I've made a few minor tweaks:

- [x] Added the migration document to the Guides index page
- [x] Changed the title of the document to clarify the context

Neither of these are probably worth delaying release on Monday morning -- but if anyone happens to review over the weekend and we can get it in, that'd be good.

## Test Plan

I built/deployed a local mkdocs server to check the appearance.

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 9eba616916e3964da785339376b1d6cb77b308f0
Author: David Butenhof <dbutenho@redhat.com>
Date:   Sat Jun 27 13:30:45 2026 -0400

    Fix up doc linkages
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
