### PR TITLE
Add auto queue rule + misc PR description fixes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -31,3 +31,4 @@ merge_protections_settings:
   auto_merge_conditions:
     - "#approved-reviews-by >= 2"
     - "#changes-requested-reviews-by = 0"
+    - "#review-threads-unresolved = 0"

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -23,7 +23,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Skip dependabot PRs
+        if: github.actor == 'dependabot[bot]'
+        run: echo "Skipping PR styling for dependabot PRs"
+
       - name: Update PR description
+        if: github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-styling.yml
+++ b/.github/workflows/pr-styling.yml
@@ -36,6 +36,7 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Fetch the PR branch since we are on base repo
+          # NOTE: DO NOT checkout the branch
           git fetch origin "refs/pull/${PR_NUMBER}/head"
 
           CURRENT_BODY="$(gh pr view "$PR_NUMBER" --json body -q .body)"


### PR DESCRIPTION
## Summary

Require that all comments are closed in a PR before auto queuing. Also bypass formatting on dependabot PRs since the commit is just a repeat of the PR description. 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 355460ce5dabc8403759d0f9638ab3dcb44a4c9f
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 17:37:40 2026 -0400

    Require that comments are closed before auto-merge
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 57895386eb92f9cac5b3da8f0bca679b18ebf3fc
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 17:52:35 2026 -0400

    Skip formatting dependabot PRs
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 19bf74c93d1220f8e40ae6e70f41cdd83f3e2875
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 18:03:31 2026 -0400

    Add a note to avoid checking out the PR branch
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Generated-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
