### PR TITLE
Fix for being unable to specify "benchmarks" in a config

### DIFF
--- a/src/guidellm/benchmark/schemas/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/entrypoints.py
@@ -23,7 +23,6 @@ from pydantic import (
     Field,
     model_validator,
 )
-from pydantic.utils import deep_update
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from guidellm.backends import BackendArgs
@@ -46,6 +45,7 @@ from guidellm.schemas import (
     standard_model_config,
 )
 from guidellm.utils.arg_string import ArgStringParser
+from guidellm.utils.dict import deep_update
 
 __all__ = [
     "BenchmarkArgs",
@@ -285,9 +285,7 @@ class BenchmarkScenario(ReloadableBaseModel, BaseSettings):
     )
 
     @classmethod
-    def create(
-        cls, scenario: Path | str | None, **kwargs: dict[str, Any]
-    ) -> BenchmarkScenario:
+    def create(cls, scenario: Path | str | None, **kwargs: Any) -> BenchmarkScenario:
         """
         Create benchmark args from scenario file and keyword arguments.
 
@@ -330,7 +328,7 @@ class BenchmarkScenario(ReloadableBaseModel, BaseSettings):
         # NOTE In the future replace deep_update with a more intelligent merging
         #      strategy that accounts for changes to `kind`.
         # Apply overrides from kwargs
-        constructor_kwargs = deep_update(constructor_kwargs, kwargs)
+        deep_update(constructor_kwargs, kwargs)
 
         return cls.model_validate(constructor_kwargs)
 

--- a/src/guidellm/benchmark/schemas/entrypoints.py
+++ b/src/guidellm/benchmark/schemas/entrypoints.py
@@ -320,9 +320,11 @@ class BenchmarkScenario(ReloadableBaseModel, BaseSettings):
                     raise ValueError(
                         f"Unsupported scenario file format: {scenario_path.suffix}"
                     )
-            if "args" in scenario_data:
+            # NOTE: If the scenario file is a report, it contains a "config" key with
+            # the benchmark configuration. This is a hack and should be replaced.
+            if "config" in scenario_data:
                 # loading from a report file
-                scenario_data = scenario_data["args"]
+                scenario_data = scenario_data["config"]
             constructor_kwargs.update(scenario_data)
 
         # NOTE In the future replace deep_update with a more intelligent merging

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -21,6 +21,7 @@ from guidellm.utils.click_pydantic import (
 )
 from guidellm.utils.console import Console
 from guidellm.utils.env_validator import validate_env_vars
+from guidellm.utils.typing import BLANK
 
 __all__ = [
     "run",
@@ -135,7 +136,7 @@ def run(**kwargs):  # noqa: C901, PLR0915
     try:
         args = BenchmarkScenario.create(
             spec=kwargs.get("spec", {}),
-            benchmarks=kwargs.get("benchmarks", []),
+            benchmarks=kwargs.get("benchmarks") or BLANK,
             metadata={"labels": dict(kwargs.get("labels", []))},
             scenario=kwargs.get("config"),
         )

--- a/src/guidellm/utils/cli.py
+++ b/src/guidellm/utils/cli.py
@@ -4,15 +4,10 @@ from typing import Any
 import click
 import yaml
 
-# NOTE: Sentinel is sentinel in newer (unreleased) version of typing_extensions
-# which matches the accepted version of PEP 661 in Python 3.15+
-# NOTE: Not sure why but mypy doesn't recognize Sentinel as a type
-from typing_extensions import Sentinel  # type: ignore[attr-defined]
-
 from guidellm.utils import arg_string
+from guidellm.utils.typing import BLANK
 
 __all__ = [
-    "BLANK",
     "Union",
     "decode_escaped_str",
     "overrides_to_benchmarks",
@@ -21,8 +16,6 @@ __all__ = [
     "parse_overrides",
     "set_if_not_default",
 ]
-
-BLANK = Sentinel("BLANK")
 
 
 def parse_list(ctx, param, value) -> list[str] | None:

--- a/src/guidellm/utils/dict.py
+++ b/src/guidellm/utils/dict.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from collections.abc import Callable, Hashable
 from typing import Any
 
+from guidellm.utils.typing import BLANK
+
+__all__ = [
+    "deep_filter",
+    "deep_update",
+    "recursive_key_update",
+]
+
 
 def recursive_key_update(d, key_update_func):
     if not isinstance(d, dict) and not isinstance(d, list):
@@ -39,6 +47,8 @@ def deep_update(dict1: dict, dict2: dict) -> None:
     Does not copy values. Does not merge lists.
     """
     for key, val in dict2.items():
+        if val is BLANK:
+            continue  # Skip updating this key if the value is BLANK
         if isinstance(val, dict) and key in dict1 and isinstance(dict1[key], dict):
             deep_update(dict1[key], val)
         else:

--- a/src/guidellm/utils/typing.py
+++ b/src/guidellm/utils/typing.py
@@ -4,6 +4,11 @@ from collections.abc import Iterator
 from types import UnionType
 from typing import Annotated, Literal, Union, get_args, get_origin
 
+# NOTE: Sentinel is sentinel in newer (unreleased) version of typing_extensions
+# which matches the accepted version of PEP 661 in Python 3.15+
+# NOTE: Not sure why but mypy doesn't recognize Sentinel as a type
+from typing_extensions import Sentinel  # type: ignore[attr-defined]
+
 # Backwards compatibility for Python <3.12
 try:
     from typing import TypeAliasType  # type: ignore[attr-defined]
@@ -11,7 +16,10 @@ except ImportError:
     from typing_extensions import TypeAliasType
 
 
-__all__ = ["get_literal_vals"]
+__all__ = ["BLANK", "get_literal_vals"]
+
+
+BLANK = Sentinel("BLANK")
 
 
 def get_literal_vals(alias) -> frozenset[str]:

--- a/tests/unit/benchmark/schemas/test_entrypoints.py
+++ b/tests/unit/benchmark/schemas/test_entrypoints.py
@@ -11,6 +11,7 @@ loading for BenchmarkScenario.
 """
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from guidellm.backends.backend import BackendArgs
@@ -22,6 +23,7 @@ from guidellm.benchmark.schemas.entrypoints import (
     GenerativeMetricsArgs,
     MetricsArgs,
 )
+from guidellm.utils.typing import BLANK
 
 # Conditionally import VLLM backend args if available
 try:
@@ -394,6 +396,151 @@ class TestBackendArgsTransformation:
             )
             assert VLLMPythonBackendArgs is not None
             assert isinstance(args_vllm.backend, VLLMPythonBackendArgs)
+
+
+class TestBenchmarkScenario:
+    """Test BenchmarkScenario validation and defaults."""
+
+    @pytest.mark.sanity
+    def test_create_scenario_with_minimal_spec(self):
+        """
+        Test creating a BenchmarkScenario with minimal spec.
+
+        ## WRITTEN BY AI ##
+        """
+        scenario = BenchmarkScenario.create(
+            spec={
+                **_PIPELINE_DEFAULTS,
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+            },
+            scenario=None,
+        )
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://localhost:8000"
+        assert scenario.spec.profile.kind == "sweep"
+        assert scenario.spec.profile.sweep_size == 10  # type: ignore[union-attr]
+
+    @pytest.mark.sanity
+    def test_create_from_file(self, tmp_path):
+        """
+        Test creating a BenchmarkScenario from a YAML file.
+
+        ## WRITTEN BY AI ##
+        """
+        scenario = yaml.dump(
+            {
+                "spec": {
+                    **_PIPELINE_DEFAULTS,
+                    "backend": {
+                        "kind": "openai_http",
+                        "target": "http://localhost:8000",
+                    },
+                },
+                "benchmarks": [],
+            }
+        )
+
+        yaml_file = tmp_path / "scenario.yaml"
+        yaml_file.write_text(scenario)
+
+        scenario = BenchmarkScenario.create(scenario=yaml_file)
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://localhost:8000"
+        assert scenario.spec.profile.kind == "sweep"
+
+    @pytest.mark.regression
+    def test_create_from_file_without_overrides(self, tmp_path):
+        """
+        Test creating a BenchmarkScenario from a YAML file with overrides.
+
+        ## WRITTEN BY AI ##
+        """
+        scenario = yaml.dump(
+            {
+                "spec": {
+                    **_PIPELINE_DEFAULTS,
+                    "backend": {
+                        "kind": "openai_http",
+                        "target": "http://localhost:8000",
+                    },
+                    "profile": {"kind": "concurrent"},
+                },
+                "benchmarks": [
+                    {"profile.streams": 1},
+                    {"profile.streams": 2},
+                    {"profile.streams": 4},
+                ],
+            }
+        )
+
+        yaml_file = tmp_path / "scenario.yaml"
+        yaml_file.write_text(scenario)
+
+        scenario = BenchmarkScenario.create(
+            scenario=yaml_file,
+            spec={
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://override-server:9000",
+                },
+            },
+            benchmarks=BLANK,
+        )
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://override-server:9000"
+        assert len(scenario.benchmarks) == 3, "Expected 3 benchmarks from file"
+
+    @pytest.mark.regression
+    def test_create_from_file_with_overrides(self, tmp_path):
+        """
+        Test creating a BenchmarkScenario from a YAML file with overrides.
+
+        ## WRITTEN BY AI ##
+        """
+        scenario = yaml.dump(
+            {
+                "spec": {
+                    **_PIPELINE_DEFAULTS,
+                    "backend": {
+                        "kind": "openai_http",
+                        "target": "http://localhost:8000",
+                    },
+                    "profile": {"kind": "concurrent"},
+                },
+                "benchmarks": [
+                    {"profile.streams": 1},
+                    {"profile.streams": 2},
+                    {"profile.streams": 4},
+                ],
+            }
+        )
+
+        yaml_file = tmp_path / "scenario.yaml"
+        yaml_file.write_text(scenario)
+
+        scenario = BenchmarkScenario.create(
+            scenario=yaml_file,
+            spec={
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://override-server:9000",
+                },
+            },
+            benchmarks=[
+                {"profile.streams": 8},
+                {"profile.streams": 16},
+            ],
+        )
+
+        assert isinstance(scenario.spec.backend, OpenAIHTTPBackendArgs)
+        assert scenario.spec.backend.target == "http://override-server:9000"
+        assert len(scenario.benchmarks) == 2, "Expected 2 benchmarks from overrides"
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
## Summary

The CLI was overriding a configs "benchmarks" with an empty list. This PR fixes it. Also restores the ability to provide a `benchmarks.json` to the config option.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 744dc9f7271dce1167d0bea542d0703f30b2adaf
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 11:37:28 2026 -0400

    Fix specifying `benchmarks` in config
    
    When the config and CLI arguments were merged the default list of
    benchmarks from the CLI was `[]` which alawys overrode the config since
    we do not merge lists. Here we add a special sentinel value that is used
    by the CLI to indicate no input.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 229d80bb388c620b42eaee69aa97367a57d81ca3
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 11:50:50 2026 -0400

    Fix running a json output as a benchmark
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 726d2ce7c75c2adf7518dc7b2c7900c455098b8a
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 14:10:57 2026 -0400

    Add some regression tests
    
    Assisted-by: GitHub Copilot GPT-4.1
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: GitHub Copilot GPT-4.1
Signed-off-by: Samuel Monson <smonson@redhat.com>
