### PR TITLE
Expose requeue delay from datasets (#871 Cont.)

### DIFF
--- a/src/guidellm/data/deserializers/synthetic.py
+++ b/src/guidellm/data/deserializers/synthetic.py
@@ -19,7 +19,7 @@ from guidellm.data.deserializers.deserializer import (
 from guidellm.data.schemas import DataArgs
 from guidellm.settings import settings
 from guidellm.utils.imports import json
-from guidellm.utils.random import IntegerRangeSampler
+from guidellm.utils.random import FloatRangeSampler, IntegerRangeSampler
 
 __all__ = [
     "SyntheticTextDataArgs",
@@ -123,6 +123,32 @@ class SyntheticTextDataArgs(DataArgs):
         gt=0,
         default=None,
         examples=[30],
+    )
+    delay: float | None = Field(
+        description='The average requeue delay, or "think time" for prompts.',
+        gt=0,
+        default=None,
+        examples=[10.0],
+    )
+    delay_stdev: float | None = Field(
+        description=(
+            'The standard deviation of requeue delays, or "think time" for prompts.'
+        ),
+        gt=0,
+        default=None,
+        examples=[1.0],
+    )
+    delay_min: float | None = Field(
+        description='The minimum requeue delay, or "think time" for prompts.',
+        gt=0,
+        default=None,
+        examples=[0.5],
+    )
+    delay_max: float | None = Field(
+        description='The maximum requeue delay, or "think time" for prompts.',
+        gt=0,
+        default=None,
+        examples=[5.0],
     )
     turns: int = Field(
         description=(
@@ -350,6 +376,20 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
             if self.config.output_tokens is not None
             else None
         )
+        delay_sampler = (
+            iter(
+                FloatRangeSampler(
+                    average=self.config.delay,
+                    variance=self.config.delay_stdev,
+                    min_value=self.config.delay_min,
+                    max_value=self.config.delay_max,
+                    # ensure diff dist from prompts and outputs
+                    random_seed=iter_random_seed + 2,
+                )
+            )
+            if self.config.delay is not None
+            else None
+        )
 
         # Create a shared prefix if specified
         rand = Random(iter_random_seed + 3)
@@ -383,6 +423,7 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
                 if output_tokens_sampler is not None
                 else None
             )
+            delay = next(delay_sampler) if delay_sampler is not None else None
 
             row: dict[str, Any] = {"prefix": next(prefix_iter)}
             for turn in range(self.config.turns):
@@ -394,6 +435,8 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
                 row[f"prompt_tokens_count_{turn}"] = prompt_tokens_count
                 if output_tokens_count is not None:
                     row[f"output_tokens_count_{turn}"] = output_tokens_count
+                if delay is not None:
+                    row[f"delay_{turn}"] = delay
 
                 if tools_defs is not None and turn in tool_call_turns_set:
                     row[f"tools_{turn}"] = json.dumps(tools_defs)
@@ -426,6 +469,8 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
             features[f"prompt_tokens_count_{i}"] = Value("int32")
             if self.config.output_tokens is not None:
                 features[f"output_tokens_count_{i}"] = Value("int32")
+            if self.config.delay is not None:
+                features[f"delay_{i}"] = Value("float")
 
             if i in set(self.config.tool_call_turns):
                 # Tools column is a JSON-serialised list; store as string

--- a/src/guidellm/data/deserializers/synthetic.py
+++ b/src/guidellm/data/deserializers/synthetic.py
@@ -140,7 +140,7 @@ class SyntheticTextDataArgs(DataArgs):
     )
     delay_min: float | None = Field(
         description='The minimum requeue delay, or "think time" for prompts.',
-        gt=0,
+        ge=0,
         default=None,
         examples=[0.5],
     )
@@ -436,7 +436,7 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
                 if output_tokens_count is not None:
                     row[f"output_tokens_count_{turn}"] = output_tokens_count
                 if delay is not None:
-                    row[f"delay_{turn}"] = delay
+                    row[f"requeue_delay_{turn}"] = delay
 
                 if tools_defs is not None and turn in tool_call_turns_set:
                     row[f"tools_{turn}"] = json.dumps(tools_defs)
@@ -470,7 +470,7 @@ class _SyntheticTextExamplesIterable(_BaseExamplesIterable):
             if self.config.output_tokens is not None:
                 features[f"output_tokens_count_{i}"] = Value("int32")
             if self.config.delay is not None:
-                features[f"delay_{i}"] = Value("float")
+                features[f"requeue_delay_{i}"] = Value("float")
 
             if i in set(self.config.tool_call_turns):
                 # Tools column is a JSON-serialised list; store as string

--- a/src/guidellm/data/finalizers/generative.py
+++ b/src/guidellm/data/finalizers/generative.py
@@ -67,11 +67,14 @@ class GenerativeRequestFinalizer(
                 request.output_metrics = UsageMetrics()
                 results.append((request, RequestSettings()))
                 results.append(
-                    (GenerationRequest(
-                        columns=injection_columns,
-                        turn_type="tool_response_injection",
-                        output_metrics=metrics_config,
-                    ), settings)
+                    (
+                        GenerationRequest(
+                            columns=injection_columns,
+                            turn_type="tool_response_injection",
+                            output_metrics=metrics_config,
+                        ),
+                        settings,
+                    )
                 )
             else:
                 results.append((request, settings))

--- a/src/guidellm/data/finalizers/generative.py
+++ b/src/guidellm/data/finalizers/generative.py
@@ -185,12 +185,26 @@ class GenerativeRequestFinalizer(
             turn_type=turn_type,
             input_metrics=input_metrics,
             output_metrics=output_metrics,
-        ), self._request_settings_from_columns(columns)
+        ), RequestSettings(
+            relative_timestamp=self._get_optional_column_value(
+                columns, "relative_timestamp_column"
+            ),
+            requeue_delay=self._get_optional_column_value(
+                columns, "requeue_delay_column"
+            ),
+        )
 
-    def _request_settings_from_columns(
-        self, columns: dict[str, Any]
-    ) -> RequestSettings:
-        relative_values = columns.get("relative_timestamp_column", [])
-        if relative_values and relative_values[0] is not None:
-            return RequestSettings(relative_timestamp=float(relative_values[0]))
-        return RequestSettings()
+    @staticmethod
+    def _get_optional_column_value(
+        columns: dict[str, Any],
+        column_name: str,
+    ) -> Any | None:
+        """
+        Retrieve the first value from a specified column in the columns dictionary.
+
+        :param columns: A dictionary containing columns.
+        :param column_name: The name of the column to retrieve the value from.
+        :return: The first value from the specified column
+        """
+        values = columns.get(column_name, [])
+        return values[0] if values else None

--- a/src/guidellm/data/finalizers/generative.py
+++ b/src/guidellm/data/finalizers/generative.py
@@ -38,7 +38,9 @@ class GenerativeRequestFinalizerArgs(DataFinalizerArgs):
 
 
 @FinalizerRegistry.register("generative")
-class GenerativeRequestFinalizer(DatasetFinalizer[Iterable[GenerationRequest]]):
+class GenerativeRequestFinalizer(
+    DatasetFinalizer[Iterable[tuple[GenerationRequest, RequestSettings]]]
+):
     """
     Finalizer that converts dataset rows into GenerationRequest objects,
     aggregating usage metrics from the provided columns.
@@ -47,10 +49,12 @@ class GenerativeRequestFinalizer(DatasetFinalizer[Iterable[GenerationRequest]]):
     def __init__(self, config: GenerativeRequestFinalizerArgs) -> None:
         self.config = config
 
-    def __call__(self, items: list[dict[str, Any]]) -> list[GenerationRequest]:
-        results: list[GenerationRequest] = []
+    def __call__(
+        self, items: list[dict[str, Any]]
+    ) -> list[tuple[GenerationRequest, RequestSettings]]:
+        results: list[tuple[GenerationRequest, RequestSettings]] = []
         for item in items:
-            request = self.finalize_turn(item)
+            request, settings = self.finalize_turn(item)
             if request.turn_type == "client_tool_call":
                 # Split tool-calling turns: the tool_response_column moves
                 # to a separate injection turn that follows the tool call.
@@ -61,21 +65,21 @@ class GenerativeRequestFinalizer(DatasetFinalizer[Iterable[GenerationRequest]]):
                 # Move output metrics to next turn
                 metrics_config = request.output_metrics
                 request.output_metrics = UsageMetrics()
-                results.append(request)
+                results.append((request, RequestSettings()))
                 results.append(
-                    GenerationRequest(
+                    (GenerationRequest(
                         columns=injection_columns,
                         turn_type="tool_response_injection",
                         output_metrics=metrics_config,
-                    )
+                    ), settings)
                 )
             else:
-                results.append(request)
+                results.append((request, settings))
         return results
 
     def finalize_turn(  # noqa: C901 PLR0912
         self, columns: dict[str, Any]
-    ) -> GenerationRequest:
+    ) -> tuple[GenerationRequest, RequestSettings]:
         input_metrics = UsageMetrics()
         output_metrics = UsageMetrics()
 
@@ -181,8 +185,7 @@ class GenerativeRequestFinalizer(DatasetFinalizer[Iterable[GenerationRequest]]):
             turn_type=turn_type,
             input_metrics=input_metrics,
             output_metrics=output_metrics,
-            settings=self._request_settings_from_columns(columns),
-        )
+        ), self._request_settings_from_columns(columns)
 
     def _request_settings_from_columns(
         self, columns: dict[str, Any]

--- a/src/guidellm/data/preprocessors/mappers.py
+++ b/src/guidellm/data/preprocessors/mappers.py
@@ -118,6 +118,7 @@ class GenerativeColumnMapper(DataDependentPreprocessor):
             "tool_output",
         ],
         "relative_timestamp_column": ["relative_timestamp"],
+        "requeue_delay_column": ["requeue_delay"],
     }
     column_name_pattern: str = (
         r"^(?P<full_name>(?P<match_name>({name})(es|s)?)([-_](?P<turn>\d+))?)$"

--- a/src/guidellm/scheduler/schemas.py
+++ b/src/guidellm/scheduler/schemas.py
@@ -16,7 +16,7 @@ from typing import Any, Generic, Literal, Protocol, TypeVar
 from pydantic import Field
 from typing_extensions import TypeAliasType
 
-from guidellm.schemas import RequestInfo, StandardBaseModel
+from guidellm.schemas import RequestInfo, RequestSettings, StandardBaseModel
 from guidellm.utils.registry import RegistryMixin, RegistryObjT
 
 __all__ = [
@@ -62,7 +62,9 @@ HistoryT = TypeAliasType(
 
 # NOTE: This is the interface between data and scheduler.
 DatasetIterT = TypeAliasType(
-    "DatasetIterT", Iterable[Iterable[RequestT]], type_params=(RequestT,)
+    "DatasetIterT",
+    Iterable[Iterable[tuple[RequestT, RequestSettings]]],
+    type_params=(RequestT,),
 )
 """
 Output of data loader, an iterable of batches,

--- a/src/guidellm/scheduler/strategies.py
+++ b/src/guidellm/scheduler/strategies.py
@@ -241,17 +241,6 @@ class SchedulingStrategy(PydanticClassRegistryMixin["SchedulingStrategy"], InfoM
         _ = (worker_index, settings)
         return provisional_start
 
-    def requeue_delay(self) -> float:
-        """
-        Calculate delay before requeuing a conversation.
-
-        Default implementation returns zero delay. Strategies can override
-        to implement custom requeue timing logic.
-
-        :return: Delay in seconds before the conversation should be requeued.
-        """
-        return 0.0
-
 
 StrategyT = TypeVar("StrategyT", bound=SchedulingStrategy)
 "Type variable bound to SchedulingStrategy for generic strategy operations"

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -426,7 +426,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             # Record Turn
             history.append((request, response))
 
-            response = request = request_info = None
+            response = request = None
         except asyncio.CancelledError:
             premature_exit = True
             # Handle cancellation

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -40,7 +40,7 @@ from guidellm.scheduler.schemas import (
     ResponseT,
 )
 from guidellm.scheduler.strategies import SchedulingStrategy
-from guidellm.schemas import RequestInfo
+from guidellm.schemas import RequestInfo, RequestSettings
 from guidellm.utils.messaging import InterProcessMessaging
 from guidellm.utils.synchronous import (
     wait_for_sync_barrier,
@@ -313,12 +313,13 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                         raise exception
 
                     history, conversation, info = task.result()
+                    settings = info.settings if info is not None else RequestSettings()
                     if conversation:
                         requeue_task = asyncio.create_task(
                             self._wait_then_requeue(
                                 history,
                                 conversation,
-                                self.strategy.requeue_delay(),
+                                settings,
                             )
                         )
                         pending_tasks.add(requeue_task)
@@ -480,11 +481,11 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         self,
         history: HistoryT[RequestT, ResponseT],
         conversation: ConversationT[RequestT],
-        requeue_delay: float,
+        settings: RequestSettings,
     ):
         try:
-            if requeue_delay > 0:
-                await asyncio.sleep(requeue_delay)
+            if settings.requeue_delay:
+                await asyncio.sleep(settings.requeue_delay)
         finally:
             # Always requeue so that if we were cancelled during sleep
             # the whole conversation can be cancelled properly later

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -39,7 +39,7 @@ from guidellm.scheduler.schemas import (
 )
 from guidellm.scheduler.strategies import SchedulingStrategy
 from guidellm.scheduler.worker import WorkerProcess
-from guidellm.schemas import GenerationRequest, RequestInfo, RequestSettings
+from guidellm.schemas import RequestInfo, RequestSettings
 from guidellm.settings import settings
 from guidellm.utils.messaging import (
     InterProcessMessaging,
@@ -546,16 +546,6 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         else:
             return str(uuid.uuid4())
 
-    @staticmethod
-    def _request_settings_from_request(request: RequestT) -> RequestSettings:
-        if isinstance(request, GenerationRequest):
-            return request.settings
-        if isinstance(request, dict):
-            settings = request.get("settings")
-            if isinstance(settings, RequestSettings):
-                return settings
-        return RequestSettings()
-
     def requests_generator(
         self,
         requests: DatasetIterT[RequestT],
@@ -576,12 +566,12 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             stop_queueing: bool = False
 
             def _turn_iter(
-                requests_chain: Iterable[RequestT],
+                requests_chain: Iterable[tuple[RequestT, RequestSettings]],
             ) -> Generator[RequestDataT[RequestT], None, None]:
                 nonlocal count, stop_queueing
                 # NOTE: This allows users to correlate requests in post-processing
                 conv_id = str(uuid.uuid4())
-                for i, request in enumerate(requests_chain):
+                for i, (request, setting) in enumerate(requests_chain):
                     count += 1
 
                     request_id = self._find_request_id(request)
@@ -592,7 +582,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                         status="queued",
                         scheduler_process_id=0,
                         scheduler_start_time=self.start_time,
-                        settings=self._request_settings_from_request(request),
+                        settings=setting,
                     )
                     state_update = self._locked_update(request_info)
                     request_info.timings.queued = time.time()

--- a/src/guidellm/schemas/info.py
+++ b/src/guidellm/schemas/info.py
@@ -124,11 +124,20 @@ class RequestSettings(StandardBaseDict):
 
     relative_timestamp: float | None = Field(
         default=None,
+        ge=0,
         description=(
             "Trace offset in seconds from the first event after sorting (0 for the "
             "earliest event). Trace replay converts this to an absolute start time "
             "at dequeue: start_time + time_scale * relative_timestamp. When null, "
             "trace replay uses benchmark start time only."
+        ),
+    )
+    requeue_delay: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Delay in seconds before requeueing the conversation. This number is a "
+            "lower bound on the delay, subject to scheduling."
         ),
     )
 

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -32,12 +32,14 @@ class IntegerRangeSampler:
                 self.average + 5 * self.variance if self.variance else self.average
             )
 
-        while True:
-            if calc_min == calc_max:
+        if calc_min == calc_max:
+            while True:
                 yield calc_min
-            elif not self.variance:
-                yield self.rng.randint(calc_min, calc_max)
-            else:
+        elif not self.variance:
+            while True:
+                yield self.rng.uniform(calc_min, calc_max)
+        else:
+            while True:
                 rand = self.rng.gauss(self.average, self.variance)
                 yield round(max(calc_min, min(calc_max, rand)))
 

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -70,11 +70,13 @@ class FloatRangeSampler:
                 self.average + 5 * self.variance if self.variance else self.average
             )
 
-        while True:
-            if calc_min == calc_max:
+        if calc_min == calc_max:
+            while True:
                 yield calc_min
-            elif not self.variance:
+        elif not self.variance:
+            while True:
                 yield self.rng.uniform(calc_min, calc_max)
-            else:
+        else:
+            while True:
                 rand = self.rng.gauss(self.average, self.variance)
                 yield round(max(calc_min, min(calc_max, rand)))

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -1,7 +1,7 @@
 import random
 from collections.abc import Iterator
 
-__all__ = ["IntegerRangeSampler"]
+__all__ = ["FloatRangeSampler", "IntegerRangeSampler"]
 
 
 class IntegerRangeSampler:
@@ -37,6 +37,44 @@ class IntegerRangeSampler:
                 yield calc_min
             elif not self.variance:
                 yield self.rng.randint(calc_min, calc_max)
+            else:
+                rand = self.rng.gauss(self.average, self.variance)
+                yield round(max(calc_min, min(calc_max, rand)))
+
+
+class FloatRangeSampler:
+    def __init__(
+        self,
+        average: float,
+        variance: float | None,
+        min_value: float | None,
+        max_value: float | None,
+        random_seed: int,
+    ):
+        self.average = average
+        self.variance = variance
+        self.min_value = min_value
+        self.max_value = max_value
+        self.seed = random_seed
+        self.rng = random.Random(random_seed)  # noqa: S311
+
+    def __iter__(self) -> Iterator[float]:
+        calc_min = self.min_value
+        if calc_min is None:
+            calc_min = max(
+                1, self.average - 5 * self.variance if self.variance else self.average
+            )
+        calc_max = self.max_value
+        if calc_max is None:
+            calc_max = (
+                self.average + 5 * self.variance if self.variance else self.average
+            )
+
+        while True:
+            if calc_min == calc_max:
+                yield calc_min
+            elif not self.variance:
+                yield self.rng.uniform(calc_min, calc_max)
             else:
                 rand = self.rng.gauss(self.average, self.variance)
                 yield round(max(calc_min, min(calc_max, rand)))

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -64,7 +64,7 @@ class FloatRangeSampler:
         calc_min = self.min_value
         if calc_min is None:
             calc_min = max(
-                1, self.average - 5 * self.variance if self.variance else self.average
+                0.0, self.average - 5 * self.variance if self.variance else self.average
             )
         calc_max = self.max_value
         if calc_max is None:

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -81,4 +81,4 @@ class FloatRangeSampler:
         else:
             while True:
                 rand = self.rng.gauss(self.average, self.variance)
-                yield round(max(calc_min, min(calc_max, rand)))
+                yield max(calc_min, min(calc_max, rand))

--- a/src/guidellm/utils/random.py
+++ b/src/guidellm/utils/random.py
@@ -37,7 +37,7 @@ class IntegerRangeSampler:
                 yield calc_min
         elif not self.variance:
             while True:
-                yield self.rng.uniform(calc_min, calc_max)
+                yield self.rng.randint(calc_min, calc_max)
         else:
             while True:
                 rand = self.rng.gauss(self.average, self.variance)

--- a/tests/integration/scheduler/test_scheduler.py
+++ b/tests/integration/scheduler/test_scheduler.py
@@ -22,7 +22,7 @@ from guidellm.scheduler import (
     SynchronousStrategy,
 )
 from guidellm.scheduler.constraints import MaxRequestsConstraintArgs
-from guidellm.schemas import RequestInfo
+from guidellm.schemas import RequestInfo, RequestSettings
 
 
 def async_timeout(delay: float):
@@ -129,7 +129,10 @@ async def test_scheduler_run_integration(
     num_requests = 100
 
     async for resp, req, info, state in scheduler.run(
-        requests=[[MockRequest(payload=f"req_{ind}")] for ind in range(num_requests)],
+        requests=[
+            [(MockRequest(payload=f"req_{ind}"), RequestSettings())]
+            for ind in range(num_requests)
+        ],
         backend=MockBackend(),
         strategy=strategy,
         env=env,

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -61,7 +61,7 @@ def _write_trace(path: Path, lines: list[str]) -> Path:
 
 def _requests_from_trace(
     trace_path: Path,
-) -> tuple[list[list[GenerationRequest]], list[float]]:
+) -> tuple[list[list[tuple[GenerationRequest, RequestSettings]]], list[float]]:
     deserializer = TraceDatasetDeserializer()
     dataset = deserializer(
         config=MinimalTraceFormatArgs(path=trace_path),
@@ -73,16 +73,16 @@ def _requests_from_trace(
     mapper.setup_data([dataset])
     finalizer = GenerativeRequestFinalizer(GenerativeRequestFinalizerArgs())
 
-    conversations: list[list[GenerationRequest]] = []
+    conversations: list[list[tuple[GenerationRequest, RequestSettings]]] = []
     relative_timestamps: list[float] = []
     for idx, row in enumerate(dataset):
         mapped = mapper([{"dataset": row}])
         requests = finalizer(mapped)
         assert len(requests) == 1
-        request = requests[0]
+        request, settings = requests[0]
         request.request_id = f"req_{idx}"
-        conversations.append([request])
-        offset = request.settings.relative_timestamp
+        conversations.append([(request, settings)])
+        offset = settings.relative_timestamp
         assert offset is not None
         relative_timestamps.append(offset)
 

--- a/tests/integration/test_tool_call_pipeline.py
+++ b/tests/integration/test_tool_call_pipeline.py
@@ -12,10 +12,12 @@ from typing import Any
 import pytest
 
 from guidellm.data.finalizers import GenerativeRequestFinalizer
-from guidellm.schemas import GenerationRequest
+from guidellm.schemas import GenerationRequest, RequestSettings
 
 
-def _run_row_through_pipeline(row: dict[str, Any]) -> list[GenerationRequest]:
+def _run_row_through_pipeline(
+    row: dict[str, Any],
+) -> list[tuple[GenerationRequest, RequestSettings]]:
     """Push a single dataset row through the column mapper and finalizer.
 
     ## WRITTEN BY AI ##
@@ -67,9 +69,10 @@ class TestJsonlMultiTurnToolCallPipeline:
             "output_tokens_count_2": 100,
         }
 
-        requests = _run_row_through_pipeline(row)
+        rows = _run_row_through_pipeline(row)
 
-        assert len(requests) == 5
+        assert len(rows) == 5
+        requests = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert requests[0].turn_type == "client_tool_call"
         assert "tools_column" in requests[0].columns
@@ -113,9 +116,10 @@ class TestJsonlMultiTurnToolCallPipeline:
             "tool_response_3": '{"price": 150}',
         }
 
-        requests = _run_row_through_pipeline(row)
+        rows = _run_row_through_pipeline(row)
 
-        assert len(requests) == 6
+        assert len(rows) == 6
+        requests = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert requests[0].turn_type == "client_tool_call"
         assert "tools_column" in requests[0].columns

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -5103,7 +5103,8 @@ class TestChatCompletionsToolChoiceOverride:
                 "output_tokens_count_column": [100],
             },
         ]
-        requests = finalizer(items)
+        rows = finalizer(items)
+        requests = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(requests) == 2
         tool_call_req, injection_req = requests

--- a/tests/unit/data/deserializers/test_synthetic.py
+++ b/tests/unit/data/deserializers/test_synthetic.py
@@ -136,6 +136,10 @@ class TestSyntheticDatasetConfig:
             output_tokens_stdev=5,
             output_tokens_min=20,
             output_tokens_max=40,
+            delay=1.2,
+            delay_stdev=0.5,
+            delay_min=0.1,
+            delay_max=2.4,
         )
 
         assert config.prefix_buckets[0].prefix_tokens == 5  # type: ignore [index]
@@ -147,6 +151,10 @@ class TestSyntheticDatasetConfig:
         assert config.output_tokens_stdev == 5
         assert config.output_tokens_min == 20
         assert config.output_tokens_max == 40
+        assert config.delay == 1.2
+        assert config.delay_stdev == 0.5
+        assert config.delay_min == 0.1
+        assert config.delay_max == 2.4
 
     @pytest.mark.regression
     def test_parse_json_string(self):
@@ -158,6 +166,7 @@ class TestSyntheticDatasetConfig:
             {
                 "prompt_tokens": 75,
                 "output_tokens": 25,
+                "delay": 1.2,
                 "prefix_buckets": [
                     {"bucket_weight": 100, "prefix_count": 1, "prefix_tokens": 10}
                 ],
@@ -168,6 +177,7 @@ class TestSyntheticDatasetConfig:
 
         assert config.prompt_tokens == 75
         assert config.output_tokens == 25
+        assert config.delay == 1.2
         assert config.prefix_buckets[0].prefix_tokens == 10  # type: ignore [index]
 
     @pytest.mark.sanity
@@ -182,9 +192,19 @@ class TestSyntheticDatasetConfig:
         with pytest.raises(ValueError):
             SyntheticTextDataArgs(prompt_tokens=20, output_tokens=0)
 
+        with pytest.raises(ValueError):
+            SyntheticTextDataArgs(prompt_tokens=20, output_tokens=20, delay=0.0)
+
         # Test negative prefix tokens via PrefixBucketConfig validation
         with pytest.raises(ValueError):
             SyntheticTextPrefixBucketConfig(prefix_tokens=-1)
+
+    @pytest.mark.sanity
+    def test_validation_positive_or_zero(self):
+        """`delay_min` will take 0.0 as a valid value."""
+        SyntheticTextDataArgs(prompt_tokens=20, delay=1.2, delay_min=0.0)
+        with pytest.raises(ValueError):
+            SyntheticTextDataArgs(prompt_tokens=20, delay=1.2, delay_min=-0.1)
 
     @pytest.mark.regression
     def test_validation_optional_positive_values(self):
@@ -605,6 +625,7 @@ class TestSyntheticTextDatasetMultiturn:
         config = SyntheticTextDataArgs(
             prompt_tokens=50,
             output_tokens=25,
+            delay=3.0,
             turns=1,
         )
         dataset = SyntheticTextDataset(config, mock_tokenizer, random_seed=42)
@@ -617,6 +638,7 @@ class TestSyntheticTextDatasetMultiturn:
         assert "prompt_0" in item
         assert "prompt_tokens_count_0" in item
         assert "output_tokens_count_0" in item
+        assert "requeue_delay_0" in item
 
         # Should not have prompt_1, etc
         assert "prompt_1" not in item
@@ -631,6 +653,7 @@ class TestSyntheticTextDatasetMultiturn:
         config = SyntheticTextDataArgs(
             prompt_tokens=50,
             output_tokens=25,
+            delay=3.0,
             turns=3,
         )
         dataset = SyntheticTextDataset(config, mock_tokenizer, random_seed=42)
@@ -643,6 +666,7 @@ class TestSyntheticTextDatasetMultiturn:
             assert f"prompt_{turn}" in item
             assert f"prompt_tokens_count_{turn}" in item
             assert f"output_tokens_count_{turn}" in item
+            assert f"requeue_delay_{turn}" in item
 
         # Should not have prompt_3
         assert "prompt_3" not in item

--- a/tests/unit/data/test_finalizers.py
+++ b/tests/unit/data/test_finalizers.py
@@ -39,10 +39,11 @@ class TestGenerativeRequestFinalizerTokenAggregation:
         instance = valid_instances
         columns = {"prompt_tokens_count_column": [100]}
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.input_metrics.text_tokens == 100
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.input_metrics.text_tokens == 100
 
     @pytest.mark.smoke
     def test_finalize_multi_turn_prompt_tokens(self, valid_instances):
@@ -53,10 +54,11 @@ class TestGenerativeRequestFinalizerTokenAggregation:
         instance = valid_instances
         columns = {"prompt_tokens_count_column": [50, 75, 100]}
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.input_metrics.text_tokens == 225  # 50 + 75 + 100
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.input_metrics.text_tokens == 225  # 50 + 75 + 100
 
     @pytest.mark.smoke
     def test_finalize_multi_turn_output_tokens(self, valid_instances):
@@ -67,10 +69,11 @@ class TestGenerativeRequestFinalizerTokenAggregation:
         instance = valid_instances
         columns = {"output_tokens_count_column": [20, 30, 40]}
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.output_metrics.text_tokens == 90  # 20 + 30 + 40
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.output_metrics.text_tokens == 90  # 20 + 30 + 40
 
     @pytest.mark.sanity
     def test_finalize_with_none_values_in_list(self, valid_instances):
@@ -81,10 +84,11 @@ class TestGenerativeRequestFinalizerTokenAggregation:
         instance = valid_instances
         columns = {"prompt_tokens_count_column": [50, None, 100]}
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.input_metrics.text_tokens == 150  # 50 + 100, skips None
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.input_metrics.text_tokens == 150  # 50 + 100, skips None
 
     @pytest.mark.regression
     def test_finalize_with_empty_column_lists(self, valid_instances):
@@ -98,11 +102,12 @@ class TestGenerativeRequestFinalizerTokenAggregation:
             "output_tokens_count_column": [],
         }
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.input_metrics.text_tokens is None
-        assert result.output_metrics.text_tokens is None
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.input_metrics.text_tokens is None
+        assert gen_req.output_metrics.text_tokens is None
 
 
 class TestGenerativeRequestFinalizerMultimodal:
@@ -134,12 +139,13 @@ class TestGenerativeRequestFinalizerMultimodal:
             ],
         }
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
         # Should accumulate metrics from all text values
-        assert result.input_metrics.text_words > 0
-        assert result.input_metrics.text_characters > 0
+        assert gen_req.input_metrics.text_words > 0
+        assert gen_req.input_metrics.text_characters > 0
 
     @pytest.mark.sanity
     def test_finalize_multi_value_image_columns(self, valid_instances):
@@ -156,11 +162,12 @@ class TestGenerativeRequestFinalizerMultimodal:
             ],
         }
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
-        assert result.input_metrics.image_pixels == 4500  # 1000 + 2000 + 1500
-        assert result.input_metrics.image_bytes == 22500  # 5000 + 10000 + 7500
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
+        assert gen_req.input_metrics.image_pixels == 4500  # 1000 + 2000 + 1500
+        assert gen_req.input_metrics.image_bytes == 22500  # 5000 + 10000 + 7500
 
     @pytest.mark.regression
     def test_finalize_preserves_columns(self, valid_instances):
@@ -175,14 +182,15 @@ class TestGenerativeRequestFinalizerMultimodal:
             "output_tokens_count_column": [25],
         }
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
         # Original columns should be preserved
-        assert result.columns == columns
+        assert gen_req.columns == columns
         # And metrics should be set
-        assert result.input_metrics.text_tokens == 50
-        assert result.output_metrics.text_tokens == 25
+        assert gen_req.input_metrics.text_tokens == 50
+        assert gen_req.output_metrics.text_tokens == 25
 
 
 class TestFinalizerTopLevel:
@@ -216,7 +224,12 @@ class TestFinalizerTopLevel:
 
         assert isinstance(result, list)
         assert len(result) == 3
-        assert all(isinstance(r, GenerationRequest) for r in result)
+        assert all(
+            isinstance(r, tuple)
+            and isinstance(r[0], GenerationRequest)
+            and isinstance(r[1], RequestSettings)
+            for r in result
+        )
 
     @pytest.mark.sanity
     def test_finalizer_handles_empty_list(self, valid_instances):
@@ -250,26 +263,27 @@ class TestFinalizerTopLevel:
             ],
         }
 
-        result = instance.finalize_turn(columns)
+        gen_req, req_settings = instance.finalize_turn(columns)
 
-        assert isinstance(result, GenerationRequest)
+        assert isinstance(gen_req, GenerationRequest)
+        assert isinstance(req_settings, RequestSettings)
         # Text metrics
-        assert result.input_metrics.text_words == 2
-        assert result.input_metrics.text_characters == 11
+        assert gen_req.input_metrics.text_words == 2
+        assert gen_req.input_metrics.text_characters == 11
 
         # Image metrics
-        assert result.input_metrics.image_pixels == 1920 * 1080
-        assert result.input_metrics.image_bytes == 50000
+        assert gen_req.input_metrics.image_pixels == 1920 * 1080
+        assert gen_req.input_metrics.image_bytes == 50000
 
         # Video metrics
-        assert result.input_metrics.video_frames == 120
-        assert result.input_metrics.video_seconds == 4.0
-        assert result.input_metrics.video_bytes == 1000000
+        assert gen_req.input_metrics.video_frames == 120
+        assert gen_req.input_metrics.video_seconds == 4.0
+        assert gen_req.input_metrics.video_bytes == 1000000
 
         # Audio metrics
-        assert result.input_metrics.audio_samples == 48000
-        assert result.input_metrics.audio_seconds == 1.0
-        assert result.input_metrics.audio_bytes == 96000
+        assert gen_req.input_metrics.audio_samples == 48000
+        assert gen_req.input_metrics.audio_seconds == 1.0
+        assert gen_req.input_metrics.audio_bytes == 96000
 
 
 class TestFinalizerRegistry:
@@ -336,7 +350,8 @@ class TestFinalizerTurnType:
             },
             {"text_column": ["world"]},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 3
         assert results[0].turn_type == "client_tool_call"
@@ -357,7 +372,8 @@ class TestFinalizerTurnType:
             {"text_column": ["hello"], "tools_column": ['[{"type": "function"}]']},
             {"text_column": ["world"], "tools_column": ['[{"type": "function"}]']},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 4
         assert results[0].turn_type == "client_tool_call"
@@ -375,7 +391,8 @@ class TestFinalizerTurnType:
             {"text_column": ["hello"]},
             {"text_column": ["world"]},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 2
         assert results[0].turn_type == "standard"
@@ -390,7 +407,9 @@ class TestFinalizerTurnType:
         items = [
             {"text_column": ["hello"], "tools_column": ['[{"type": "function"}]']},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
+
         assert len(results) == 2
         assert results[0].turn_type == "client_tool_call"
         assert results[1].turn_type == "tool_response_injection"
@@ -421,7 +440,8 @@ class TestFinalizerTurnTypeColumn:
                 "turn_type_column": ["server_tool_call"],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 1
         assert results[0].turn_type == "server_tool_call"
@@ -439,7 +459,8 @@ class TestFinalizerTurnTypeColumn:
                 "turn_type_column": ["server_tool_call"],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 1
         assert results[0].turn_type == "server_tool_call"
@@ -459,7 +480,8 @@ class TestFinalizerTurnTypeColumn:
                 "text_column": ["world"],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 2
         assert results[0].turn_type == "server_tool_call"
@@ -478,7 +500,8 @@ class TestFinalizerTurnTypeColumn:
                 "tools_column": ['[{"type": "function"}]'],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 2
         assert results[0].turn_type == "client_tool_call"
@@ -516,7 +539,8 @@ class TestFinalizerToolCallMode:
                 "tool_response_column": ['{"status": "ok"}'],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 2
         assert results[0].turn_type == "client_tool_call"
@@ -538,7 +562,8 @@ class TestFinalizerToolCallMode:
                 "tool_response_column": ['{"status": "ok"}'],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 1
         assert results[0].turn_type == "server_tool_call"
@@ -559,7 +584,8 @@ class TestFinalizerToolCallMode:
                 "tool_response_column": ['{"status": "ok"}'],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 1
         assert "tools_column" not in results[0].columns
@@ -577,7 +603,8 @@ class TestFinalizerToolCallMode:
         items = [
             {"text_column": ["hello"]},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 1
         assert results[0].turn_type == "standard"
@@ -598,7 +625,8 @@ class TestFinalizerToolCallMode:
             },
             {"text_column": ["standard turn"]},
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         assert len(results) == 2
         assert results[0].turn_type == "server_tool_call"
@@ -620,7 +648,8 @@ class TestFinalizerToolCallMode:
                 "turn_type_column": ["client_tool_call"],
             },
         ]
-        results = finalizer(items)
+        rows = finalizer(items)
+        results = [r[0] for r in rows]  # Extract GenerationRequest from each tuple
 
         # turn_type_column says client_tool_call, so it should create
         # a client_tool_call + injection pair despite server mode
@@ -643,20 +672,24 @@ class TestGenerativeRequestFinalizerRequestSettings:
     @pytest.mark.smoke
     def test_relative_timestamp_column_sets_settings(self, finalizer):
         """### WRITTEN BY AI ###"""
-        result = finalizer.finalize_turn({"relative_timestamp_column": [2.5]})
+        _gen_req, req_settings = finalizer.finalize_turn(
+            {"relative_timestamp_column": [2.5]}
+        )
 
-        assert result.settings == RequestSettings(relative_timestamp=2.5)
+        assert req_settings == RequestSettings(relative_timestamp=2.5)
 
     @pytest.mark.smoke
     def test_missing_relative_timestamp_column_uses_empty_settings(self, finalizer):
         """### WRITTEN BY AI ###"""
-        result = finalizer.finalize_turn({"text_column": ["hello"]})
+        _gen_req, req_settings = finalizer.finalize_turn({"text_column": ["hello"]})
 
-        assert result.settings == RequestSettings()
+        assert req_settings == RequestSettings()
 
     @pytest.mark.smoke
     def test_none_relative_timestamp_column_uses_empty_settings(self, finalizer):
         """### WRITTEN BY AI ###"""
-        result = finalizer.finalize_turn({"relative_timestamp_column": [None]})
+        _gen_req, req_settings = finalizer.finalize_turn(
+            {"relative_timestamp_column": [None]}
+        )
 
-        assert result.settings == RequestSettings()
+        assert req_settings == RequestSettings()

--- a/tests/unit/scheduler/test_scheduler.py
+++ b/tests/unit/scheduler/test_scheduler.py
@@ -22,7 +22,7 @@ from guidellm.scheduler.constraints import (
     MaxDurationConstraintArgs,
     MaxRequestsConstraintArgs,
 )
-from guidellm.schemas import RequestInfo
+from guidellm.schemas import RequestInfo, RequestSettings
 from guidellm.utils.singleton import ThreadSafeSingletonMixin
 from tests.unit.testing_utils import async_timeout
 
@@ -178,7 +178,10 @@ class TestScheduler:
     ):
         """Test Scheduler.run basic functionality with various parameters."""
         instance, _ = valid_instances
-        requests = [[MockRequest(payload=f"req_{i}")] for i in range(num_requests)]
+        requests = [
+            [(MockRequest(payload=f"req_{i}"), RequestSettings())]
+            for i in range(num_requests)
+        ]
         backend = MockBackend(error_rate=0.0, response_delay=0.001)
         strategy = SynchronousStrategy()
         env = NonDistributedEnvironment()
@@ -204,7 +207,9 @@ class TestScheduler:
     async def test_run_with_errors(self, valid_instances):
         """Test Scheduler.run error handling."""
         instance, _ = valid_instances
-        requests = [MockRequest(payload=f"req_{i}") for i in range(5)]
+        requests = [
+            [(MockRequest(payload=f"req_{i}"), RequestSettings())] for i in range(5)
+        ]
         backend = MockBackend(error_rate=1.0)  # Force all requests to error
         strategy = SynchronousStrategy()
         env = NonDistributedEnvironment()
@@ -247,7 +252,9 @@ class TestScheduler:
     async def test_run_constraint_variations(self, valid_instances):
         """Test Scheduler.run with different constraint types."""
         instance, _ = valid_instances
-        requests = [MockRequest(payload=f"req_{i}") for i in range(3)]
+        requests = [
+            [(MockRequest(payload=f"req_{i}"), RequestSettings())] for i in range(3)
+        ]
         backend = MockBackend(error_rate=0.0, response_delay=0.001)
         strategy = SynchronousStrategy()
         env = NonDistributedEnvironment()

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -19,7 +19,7 @@ from guidellm.scheduler import (
     SynchronousStrategy,
     WorkerProcess,
 )
-from guidellm.schemas import RequestInfo, RequestTimings
+from guidellm.schemas import RequestInfo, RequestSettings, RequestTimings
 from guidellm.utils.messaging import InterProcessMessagingQueue
 from tests.unit.testing_utils import async_timeout
 
@@ -875,15 +875,15 @@ class TestWorkerProcessMultiturn:
         """
         history = [("req1", "resp1")]
         conversation = [("req2", RequestInfo(request_id="req2"))]
-        delay = 0.1
+        settings = RequestSettings(requeue_delay=0.1)
 
         start = time.time()
-        await worker_instance._wait_then_requeue(history, conversation, delay)
+        await worker_instance._wait_then_requeue(history, conversation, settings)
         elapsed = time.time() - start
 
         # Should have slept for approximately the delay time
-        assert elapsed >= delay
-        assert elapsed < delay + 0.5  # Allow some tolerance
+        assert elapsed >= 0.1
+        assert elapsed < 0.1 + 0.5  # Allow some tolerance
 
         # Should have appended to turns_queue
         assert len(worker_instance.turns_queue) == 1
@@ -899,10 +899,10 @@ class TestWorkerProcessMultiturn:
         """
         history = [("req1", "resp1")]
         conversation = [("req2", RequestInfo(request_id="req2"))]
-        delay = 0
+        settings = RequestSettings()
 
         start = time.time()
-        await worker_instance._wait_then_requeue(history, conversation, delay)
+        await worker_instance._wait_then_requeue(history, conversation, settings)
         elapsed = time.time() - start
 
         # Should not have slept (very quick)
@@ -922,11 +922,11 @@ class TestWorkerProcessMultiturn:
         """
         history = [("req1", "resp1")]
         conversation = [("req2", RequestInfo(request_id="req2"))]
-        delay = 1.0  # Long delay
+        settings = RequestSettings(requeue_delay=1.0)  # Long delay
 
         # Create the requeue task
         requeue_task = asyncio.create_task(
-            worker_instance._wait_then_requeue(history, conversation, delay)
+            worker_instance._wait_then_requeue(history, conversation, settings)
         )
 
         # Cancel it immediately
@@ -956,7 +956,9 @@ class TestWorkerProcessMultiturn:
         ]
         conversation = [("req4", RequestInfo(request_id="req4"))]
 
-        await worker_instance._wait_then_requeue(history, conversation, 0)
+        await worker_instance._wait_then_requeue(
+            history, conversation, RequestSettings()
+        )
 
         # History should be preserved exactly
         assert worker_instance.turns_queue[0][0] == history
@@ -977,9 +979,9 @@ class TestWorkerProcessMultiturn:
         conv2 = ([], [("req2", RequestInfo(request_id="req2"))])
         conv3 = ([], [("req3", RequestInfo(request_id="req3"))])
 
-        await worker_instance._wait_then_requeue(*conv1, 0)
-        await worker_instance._wait_then_requeue(*conv2, 0)
-        await worker_instance._wait_then_requeue(*conv3, 0)
+        await worker_instance._wait_then_requeue(*conv1, RequestSettings())
+        await worker_instance._wait_then_requeue(*conv2, RequestSettings())
+        await worker_instance._wait_then_requeue(*conv3, RequestSettings())
 
         # Should maintain FIFO order
         assert len(worker_instance.turns_queue) == 3


### PR DESCRIPTION
## Summary
Continuation of PR #871.

## Details
- Add `requeue_delay_column` to the column mapper
- Add `synthetic_text` dataset support for requeue delay
- Add basic tests in `test_synthetic.py`

## Test Plan
- `tox`

## Related Issues
- Resolves #871 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 254da7adbdb0334833646f87b8f5899d4c3951b1
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 14:45:28 2026 -0400

    Fix interface between data and scheduler
    
    The scheduler has no concept of a GenerationRequest so move the request
    settings out as a separate object in a tuple.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit e69d65e7387826854414e145317c4ef8b76b7cd1
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 15:48:32 2026 -0400

    Move requeue delay to request settings
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit a12e1351aeafcebdc8dcda922c44d7cac07acc14
Author: Samuel Monson <smonson@redhat.com>
Date:   Mon Jun 29 16:19:12 2026 -0400

    Fixup Tests
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 873245942bb4cc7bde8e13296783edbdef47c886
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jul 1 14:56:34 2026 -0400

    Add requeue_delay_column to column mapper
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit f600d71479aa9c6efe4591c0f45c08708c9f6b1b
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jul 1 15:26:06 2026 -0400

    synthetic text dataset support for requeue delay
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit a24430b0945fb3399fa626af2ef5f5b0fd0c9a36
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Jul 1 16:25:51 2026 -0400

    Add basic tests
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 0a1a2a52c21e268582434e6ce3b474820c8a1f43
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 17:44:40 2026 -0400

    Don't clear request_info after _process_next_request
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 97a6076b07516033d4dbb5667d34a710a1a1ee0b
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jul 2 15:18:32 2026 -0400

    Rework random number generation logic
    
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

commit 738257bef1e4137a589a0668de6dbbfb87c8da46
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jul 2 15:20:55 2026 -0400

    Rework random number generation logic x2
    
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

commit 6a2dea36ee543dc036d806290356b4f07fea6f16
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jul 2 15:29:52 2026 -0400

    fix: Call correct random generator
    
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

commit 25048e972261695fb58dc252f1e46b3ec68d0090
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jul 2 15:33:36 2026 -0400

    Don't round in FloatRangeSampler
    
    Co-authored-by: Samuel Monson <smonson@irbash.net>
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

commit 8b68f6766e6a7b6c56d93b456a70bfefc21de65a
Author: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
Date:   Thu Jul 2 15:38:09 2026 -0400

    Set minimum val of calc_min to 0.0 instead of 1
    
    Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>

---------

Co-authored-by: Samuel Monson <smonson@irbash.net>
Generated-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>
Signed-off-by: SkiHatDuckie <63932363+SkiHatDuckie@users.noreply.github.com>
