### PR TITLE
Support for per sub-benchmark constraints 

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -317,8 +317,15 @@ async def resolve_output_formats(
     return resolved
 
 
-_SKIP_FIELDS: frozenset[str] = frozenset({"profile"})
+_SKIP_FIELDS: frozenset[str] = frozenset({"profile", "constraints"})
 _PROFILE_RATE_FIELDS: frozenset[str] = frozenset({"rate", "streams"})
+_CONSTRAINT_LIST_FIELDS: frozenset[str] = frozenset(
+    {
+        "seconds",
+        "count",
+        "rate",
+    }
+)
 
 
 def _assert_fields_equal(
@@ -345,7 +352,7 @@ def _assert_fields_equal(
             if other.__dict__[field_name] != base_val:
                 raise NotImplementedError(
                     f"Differing {context} field '{field_name}' cannot be merged. "
-                    "Currently only rate can be modified with overrides."
+                    "All sub-benchmarks must share the same value for this field."
                 )
 
 
@@ -359,12 +366,13 @@ def resolve_to_single_benchmark(benchmarks: list[BenchmarkArgs]) -> BenchmarkArg
 
     Temporary adapter that bridges the new multi-benchmark configuration format
     to the old single-benchmark internal pipeline.  All fields must be equal
-    across the provided benchmarks except for recognised rate-like profile
-    fields (see ``_PROFILE_RATE_FIELDS``), which are flattened into one list.
+    across the provided benchmarks except for recognised list-capable fields
+    (see ``_PROFILE_RATE_FIELDS`` and ``_CONSTRAINT_LIST_FIELDS``), which are
+    flattened into a single list.
 
     :param benchmarks: One or more benchmark argument instances to merge
     :return: A single, merged ``BenchmarkArgs`` ready for execution
-    :raises NotImplementedError: If any non-rate field differs across benchmarks
+    :raises NotImplementedError: If any non-mergeable field differs across benchmarks
     """
     if len(benchmarks) == 1:
         return benchmarks[0]
@@ -389,23 +397,57 @@ def resolve_to_single_benchmark(benchmarks: list[BenchmarkArgs]) -> BenchmarkArg
         (f for f in _PROFILE_RATE_FIELDS if f in profile_cls.model_fields),
         None,
     )
-    if rate_field is None:
-        return base
+    merged_profile = base.profile
+    if rate_field is not None:
+        merged_rates: list[Any] = []
+        for bench in benchmarks:
+            val = bench.profile.__dict__[rate_field]
+            if isinstance(val, list | tuple):
+                merged_rates.extend(val)
+            else:
+                merged_rates.append(val)
 
-    merged_rates: list[Any] = []
-    for bench in benchmarks:
-        val = bench.profile.__dict__[rate_field]
-        if isinstance(val, list | tuple):
-            merged_rates.extend(val)
-        else:
-            merged_rates.append(val)
-
-    profile_dump = base.profile.model_dump()
-    profile_dump[rate_field] = merged_rates
-    merged_profile = profile_cls.model_validate(profile_dump)
+        profile_dump = base.profile.model_dump()
+        profile_dump[rate_field] = merged_rates
+        merged_profile = profile_cls.model_validate(profile_dump)
     # END: profile hack
 
-    return base.model_copy(update={"profile": merged_profile})
+    # BEGIN: constraints hack
+    merged_constraints: list[Any] = []
+    for idx in range(len(base.constraints)):
+        constraints_at_idx = [b.constraints[idx] for b in benchmarks]
+        constraint_cls = type(constraints_at_idx[0])
+        _assert_fields_equal(
+            constraints_at_idx,
+            constraint_cls.model_fields,
+            _CONSTRAINT_LIST_FIELDS,
+            "constraint",
+        )
+
+        list_field = next(
+            (f for f in _CONSTRAINT_LIST_FIELDS if f in constraint_cls.model_fields),
+            None,
+        )
+        if list_field is None:
+            merged_constraints.append(constraints_at_idx[0])
+            continue
+
+        merged_values: list[Any] = []
+        for constraint in constraints_at_idx:
+            val = constraint.__dict__[list_field]
+            if isinstance(val, list | tuple):
+                merged_values.extend(val)
+            else:
+                merged_values.append(val)
+
+        constraint_dump = constraints_at_idx[0].model_dump()
+        constraint_dump[list_field] = merged_values
+        merged_constraints.append(constraint_cls.model_validate(constraint_dump))
+    # END: constraints hack
+
+    return base.model_copy(
+        update={"profile": merged_profile, "constraints": merged_constraints}
+    )
 
 
 # Main Entrypoints Functions

--- a/src/guidellm/scheduler/constraints/factory.py
+++ b/src/guidellm/scheduler/constraints/factory.py
@@ -110,10 +110,10 @@ class ConstraintsInitializerFactory(RegistryMixin[ConstraintInitializer]):
         constraints = {}
 
         for key, val in initializers.items():
-            if isinstance(val, Constraint):
-                constraints[key] = val
-            elif isinstance(val, ConstraintInitializer):
+            if isinstance(val, ConstraintInitializer):
                 constraints[key] = val.create_constraint()
+            elif isinstance(val, Constraint):
+                constraints[key] = val
             else:
                 raise TypeError(
                     f"Constraint '{key}' has unsupported value type "

--- a/src/guidellm/scheduler/environments.py
+++ b/src/guidellm/scheduler/environments.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import Generic
 
-from guidellm.scheduler.constraints import Constraint
+from guidellm.scheduler.constraints import Constraint, ConstraintInitializer
 from guidellm.scheduler.schemas import (
     DatasetIterT,
     RequestT,
@@ -53,11 +53,11 @@ class Environment(ABC, Generic[RequestT, ResponseT], InfoMixin):
         self,
         requests: DatasetIterT[RequestT],
         strategy: SchedulingStrategy,
-        constraints: dict[str, Constraint],
+        constraints: dict[str, Constraint | ConstraintInitializer],
     ) -> tuple[
         DatasetIterT[RequestT],
         SchedulingStrategy,
-        dict[str, Constraint],
+        dict[str, Constraint | ConstraintInitializer],
     ]:
         """
         Synchronize execution parameters across nodes and resolve local scope.
@@ -176,11 +176,11 @@ class NonDistributedEnvironment(Environment[RequestT, ResponseT]):
         self,
         requests: DatasetIterT[RequestT],
         strategy: SchedulingStrategy,
-        constraints: dict[str, Constraint],
+        constraints: dict[str, Constraint | ConstraintInitializer],
     ) -> tuple[
         DatasetIterT[RequestT],
         SchedulingStrategy,
-        dict[str, Constraint],
+        dict[str, Constraint | ConstraintInitializer],
     ]:
         """
         Return parameters unchanged for single-node execution.

--- a/src/guidellm/scheduler/scheduler.py
+++ b/src/guidellm/scheduler/scheduler.py
@@ -15,7 +15,6 @@ from typing import Generic
 from guidellm.scheduler.constraints import (
     Constraint,
     ConstraintInitializer,
-    ConstraintsInitializerFactory,
 )
 from guidellm.scheduler.environments import Environment, NonDistributedEnvironment
 from guidellm.scheduler.schemas import (
@@ -111,21 +110,18 @@ class Scheduler(
             # and will ensure clean up before raising the error.
             try:
                 # Setup local run parameters, sync with the environment
-                resolved_constraints = ConstraintsInitializerFactory.resolve(
-                    constraints
-                )
                 (
                     local_requests,
                     local_strategy,
                     local_constraints,
-                ) = await env.sync_run_params(requests, strategy, resolved_constraints)
+                ) = await env.sync_run_params(requests, strategy, constraints)
 
                 # Setup the worker group, sync start with the environment
                 worker_group = WorkerProcessGroup[RequestT, ResponseT](
                     requests=local_requests,
                     backend=backend,
                     strategy=local_strategy,
-                    **local_constraints,
+                    **local_constraints,  # type: ignore[arg-type]
                 )
                 await worker_group.create_processes()
                 local_start_time = await env.sync_run_start()

--- a/tests/unit/scheduler/test_constraints.py
+++ b/tests/unit/scheduler/test_constraints.py
@@ -1196,28 +1196,6 @@ class TestConstraintsInitializerFactory:
         ):
             ConstraintsInitializerFactory.create(FakeArgs(kind=unregistered_key))
 
-    @pytest.mark.smoke
-    def test_resolve_mixed_types(self):
-        """Test resolve method with constraint and initializer instances."""
-        max_num_constraint = MaxNumberConstraint(
-            args=MaxRequestsConstraintArgs(count=25)
-        )
-        max_duration_initializer = MaxDurationConstraint(
-            args=MaxDurationConstraintArgs(seconds=120.0)
-        )
-
-        mixed_spec = {
-            "max_requests": max_num_constraint,
-            "max_duration": max_duration_initializer,
-        }
-
-        resolved = ConstraintsInitializerFactory.resolve(mixed_spec)
-
-        assert len(resolved) == 2
-        assert all(isinstance(c, Constraint) for c in resolved.values())
-        assert resolved["max_requests"] is max_num_constraint
-        assert isinstance(resolved["max_duration"], MaxDurationConstraint)
-
     @pytest.mark.sanity
     def test_resolve_with_invalid_type(self):
         """Test that resolve raises TypeError for unsupported value types."""


### PR DESCRIPTION
## Summary

Support for per sub-benchmark constraints for a subset of the constraints.

## Details

`max_requests`, `max_duration`, `max_errors`, and `max_error_rate` have all had hidden support for being specified per sub-benchmark. This PR wires that support up to the new CLI. Currently the entrypoint code is all an ugly hack so that will have to be replaced in an upcoming release.

## Test Plan

Test with multiple different constraint values:

```sh
# Duration
guidellm run ... --constraint kind=max_duration --override 'constraints[0].seconds' 5,10,15,20

# Requests
guidellm run ... --constraint kind=max_requests --override 'constraints[0].count' 5,10,15,20

# Errors
guidellm run ... --constraint kind=max_error --override 'constraints[0].count' 5,10,15,20
```

and in combination with other overrides:

```sh
guidellm run ... \
    --profile kind=constant \
    --constraint kind=max_duration \
    --override "profile.rate" 1,2,4,5 \
    --override "constraints[0].seconds" 5,10,15,20
```

and multi constraint:

```sh
guidellm run ... \
    --constraint kind=max_error \
    --override "constraints[0].count" 5,10,15,20 \
    --constraint kind=max_duration \
    --override "constraints[1].seconds" 5,10,15,20
```

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #451 
- Resolves #253 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 6e399864bf4b21f39dca95268b2c77daac94845e
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 15:23:28 2026 -0400

    Fix constraint resolve ordering
    
    Assisted-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit f6c8c315402271e9238fe0911325d02953a4c57f
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 15:24:54 2026 -0400

    Add adaptor from multivalue capable constraints
    
    Generated-by: claude-code Opus 4.6
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit e4f6aafe0c031f265a721f90f46fd1d07247e931
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 1 16:36:39 2026 -0400

    Drop constraint resolve from core scheduler
    
    Because some constraints tick up an internal counter for each resolve
    and treat that as an index for the current benchmark, resolving in the
    scheduler desyncs this counter from the current benchmark.
    
    The original behavior is not even necessary without distributed
    benchmarking, and may not be necessary even for that. So just drop the
    resolve for now and pass through the constraints untouched.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Assisted-by: claude-code Opus 4.6
Generated-by: claude-code Opus 4.6
Signed-off-by: Samuel Monson <smonson@redhat.com>
