### PR TITLE
Fix explicit fill-value overwrite detection in arg parser

### DIFF
--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -27,6 +27,8 @@ __all__ = [
     "loads",
 ]
 
+_ListValuePaths = set[tuple[tuple[str, int | None], ...]]
+
 
 class ArgStringParseError(Exception):
     """Exception raised for errors during argument string parsing."""
@@ -109,6 +111,7 @@ class ArgStringParser:
             # {'items': [{'weight': 10, 'count': 5}]}
         """
         result: dict[str, Any] = {}
+        assigned_list_values: _ListValuePaths = set()
 
         if not s or not s.strip():
             return result
@@ -145,7 +148,12 @@ class ArgStringParser:
             parsed_value = yaml.safe_load(value)
 
             # Set the value in the nested structure
-            self._value_set_nested(result, segments, parsed_value)
+            self._value_set_nested(
+                result,
+                segments,
+                parsed_value,
+                assigned_list_values=assigned_list_values,
+            )
 
         return result
 
@@ -250,6 +258,8 @@ class ArgStringParser:
         name: str,
         index: int,
         value: Any,
+        *,
+        assigned: bool = False,
     ) -> None:
         """
         Set a value in a list at the given index within a dictionary.
@@ -261,6 +271,7 @@ class ArgStringParser:
         :param name: The key name for the list in the dictionary
         :param index: The list index where the value should be set
         :param value: The value to set at the specified index
+        :param assigned: Whether the list position was explicitly assigned
         :raises ArgStringParseError: If overwriting and allow_overwrite is False
         """
         if name not in current:
@@ -277,7 +288,7 @@ class ArgStringParser:
 
         # Check for overwrite of non-fill values
         existing_value = current[name][index]
-        if not self.allow_overwrite and existing_value != self.fill_value:
+        if not self.allow_overwrite and (assigned or existing_value != self.fill_value):
             raise ArgStringParseError(
                 f"Cannot overwrite existing value at '{name}[{index}]'"
             )
@@ -289,6 +300,8 @@ class ArgStringParser:
         current: dict[str, Any],
         name: str,
         index: int,
+        *,
+        assigned: bool = False,
     ) -> Any:
         """
         Navigate to or create a list element for intermediate path segments.
@@ -300,6 +313,7 @@ class ArgStringParser:
         :param current: The current dictionary context containing the list
         :param name: The key name for the list in the dictionary
         :param index: The list index to navigate to
+        :param assigned: Whether the list position was explicitly assigned
         :return: The element at the given index (creating empty dict if needed)
         :raises ArgStringParseError: If overwriting and allow_overwrite is False
         """
@@ -317,7 +331,7 @@ class ArgStringParser:
 
         # Create nested structure if needed (only for fill values)
         existing_value = current[name][index]
-        if existing_value == self.fill_value:
+        if existing_value == self.fill_value and not assigned:
             current[name][index] = {}
         elif not isinstance(existing_value, dict):
             # Trying to navigate into non-dict value
@@ -362,6 +376,8 @@ class ArgStringParser:
         result: dict[str, Any],
         segments: list[tuple[str, int | None]],
         value: Any,
+        *,
+        assigned_list_values: _ListValuePaths | None = None,
     ) -> None:
         """
         Set a value in a nested dictionary and list structure.
@@ -373,17 +389,28 @@ class ArgStringParser:
         :param result: The root dictionary to modify in place
         :param segments: List of (name, index) tuples representing the navigation path
         :param value: The value to set at the final destination
+        :param assigned_list_values: List positions explicitly assigned while decoding
         :raises ArgStringParseError: If overwriting and allow_overwrite is False
         """
         current: Any = result
 
         for i, (name, index) in enumerate(segments):
             is_last = i == len(segments) - 1
+            path = tuple(segments[: i + 1])
+            assigned = assigned_list_values is not None and path in assigned_list_values
 
             if is_last:
                 # If we are at the last segment, set the value
                 if index is not None:
-                    self._list_set_value(current, name, index, value)
+                    self._list_set_value(
+                        current,
+                        name,
+                        index,
+                        value,
+                        assigned=assigned,
+                    )
+                    if assigned_list_values is not None:
+                        assigned_list_values.add(path)
                 else:
                     if name in current and not self.allow_overwrite:
                         raise ArgStringParseError(
@@ -393,7 +420,12 @@ class ArgStringParser:
             # If not last, navigate/create intermediate structures
             elif index is not None:
                 # Intermediate segment with array access
-                current = self._list_navigate_to_element(current, name, index)
+                current = self._list_navigate_to_element(
+                    current,
+                    name,
+                    index,
+                    assigned=assigned,
+                )
             else:
                 # Intermediate segment with dict access
                 current = self._dict_navigate_to_key(current, name)

--- a/tests/unit/utils/test_arg_string.py
+++ b/tests/unit/utils/test_arg_string.py
@@ -314,6 +314,41 @@ class TestArgStringLoads:
             arg_string.loads("items[0]=first,items[0]=second")
 
     @pytest.mark.regression
+    @pytest.mark.parametrize(
+        ("value", "fill_value"),
+        [
+            ("null", None),
+            ("0", lambda: 0),
+        ],
+    )
+    def test_overwrite_error_list_value_equal_to_fill(self, value, fill_value):
+        """
+        Test that explicit values equal to the fill value cannot be overwritten.
+
+        ### WRITTEN BY AI ###
+        """
+        kwargs = {} if fill_value is None else {"fill_value": fill_value}
+
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite existing value at 'items\\[0\\]'",
+        ):
+            arg_string.loads(f"items[0]={value},items[0]=replacement", **kwargs)
+
+    @pytest.mark.regression
+    def test_overwrite_error_list_fill_value_with_dict(self):
+        """
+        Test that an explicit null list value cannot be replaced with a dictionary.
+
+        ### WRITTEN BY AI ###
+        """
+        with pytest.raises(
+            arg_string.ArgStringParseError,
+            match="Cannot overwrite non-dict value at 'items\\[0\\]' with dict",
+        ):
+            arg_string.loads("items[0]=null,items[0].field=value")
+
+    @pytest.mark.regression
     def test_mixed_value_types(self):
         """
         Test parsing with mixed value types in a single string.


### PR DESCRIPTION
## Summary
Prevent the argument-string parser from treating explicitly assigned list values as sparse padding when they equal the configured fill value.

## Details
- Track list paths explicitly assigned during a single decode separately from sparse fill values.
- Preserve overwrite protection for explicit `null` values and custom fill values such as `0`.
- Preserve assignment into list positions that are genuinely sparse padding.
- Add regression tests for duplicate assignments and scalar-to-dictionary replacement.

## Test Plan
- `tox -e test-unit -- tests/unit/utils/test_arg_string.py -q` - 53 passed
- `tox -q` - `lint-check` passed; `type-check` failed in `.tox/type-check/lib/python3.14/site-packages/numpy/__init__.pyi:737` with `Type statement is only supported in Python 3.12 and greater`

## Related Issues
- Resolves #896

<!-- begin:squash-data -->

---

# git log

commit eacde439ba11111645441f3a07b0d73b168e2ffe
Author: harivilasp <harivilasp@gmail.com>
Date:   Sun Jul 5 14:02:05 2026 -0700

    Fix fill-value overwrite detection in arg parser
    
    Track explicit list assignments separately from sparse fill values so null and custom fill values retain normal overwrite protection.
    
    Generated-by: Codex GPT-5
    Signed-off-by: harivilasp <harivilasp@gmail.com>

---------

Generated-by: Codex GPT-5
Signed-off-by: harivilasp <harivilasp@gmail.com>
