### PR TITLE
docs(developing): add a proper Logging guide (#881)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -318,6 +318,20 @@ Logging is set using the following environment variables:
 
 If logging isn't responding to the environment variables, run the `guidellm config` command to validate that the environment variables match and are being set correctly.
 
+Examples:
+
+Enable verbose console output for a single run. The interactive progress display can overwrite console log lines, so `--disable-progress` is recommended when reading console logs:
+
+```bash
+GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL=DEBUG guidellm run ... --disable-progress
+```
+
+Write structured `DEBUG` logs to a file while leaving the console at its default level:
+
+```bash
+GUIDELLM__LOGGING__LOG_FILE=guidellm.log GUIDELLM__LOGGING__LOG_FILE_LEVEL=DEBUG guidellm run ...
+```
+
 ## Additional Resources
 
 - [CONTRIBUTING.md](https://github.com/vllm-project/guidellm/blob/main/CONTRIBUTING.md): Guidelines for contributing to the project.


### PR DESCRIPTION
## Summary

`docs/guides/troubleshooting.md` (Debug Logging) links to `developer/developing.md#logging` for the full logging guide, but that anchor pointed at a bare list of environment variables nested under **Developing the Web UI** — not the standalone guide the link implies. Fixes #881.

## Changes

- Promote `### Logging` to a top-level `## Logging` section, keeping the `#logging` anchor that the two troubleshooting links depend on.
- Add an overview of GuideLLM's two logging sinks:
  - **Console** — human-readable output to `stdout`, controlled by `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL` (default `WARNING`).
  - **File** — structured JSON, enabled by `GUIDELLM__LOGGING__LOG_FILE` / `GUIDELLM__LOGGING__LOG_FILE_LEVEL` (default file `guidellm.log`, default level `INFO`).
- List all `GUIDELLM__LOGGING__*` variables with defaults taken from `LoggingSettings` in `src/guidellm/settings.py` and the sink behavior in `src/guidellm/logger.py`.
- Add console and file logging usage examples.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit 4018aa4cee079245e9b63a361e459fc27275afb3
Author: Tai An <antai12232931@outlook.com>
Date:   Tue Jul 7 18:21:28 2026 -0700

    docs(developing): add console/file logging examples
    
    Append two runnable examples to the existing Logging section: verbose
    console output (with --disable-progress) and structured DEBUG file logging.
    Keeps the maintainer's concise section intact and only adds the examples.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

---------

Signed-off-by: Tai An <antai12232931@outlook.com>
