### PR TITLE
Minor logging cleanup

### DIFF
--- a/src/guidellm/benchmark/benchmarker.py
+++ b/src/guidellm/benchmark/benchmarker.py
@@ -156,7 +156,7 @@ class Benchmarker(
                             )
                     except Exception as err:  # noqa: BLE001
                         logger.error(
-                            f"Error updating benchmark estimate/progress: {err}"
+                            "Error updating benchmark estimate/progress: {}", err
                         )
 
                 benchmark = benchmark_class.compile(

--- a/src/guidellm/data/builders.py
+++ b/src/guidellm/data/builders.py
@@ -222,7 +222,9 @@ def process_dataset(
     Main method to process and save a dataset with sampled prompt/output token counts.
     """
     _validate_output_suffix(output_path)
-    logger.info(f"Starting dataset conversion | Input: {data} | Output: {output_path}")
+    logger.info(
+        "Starting dataset conversion | Input: {} | Output: {}", data, output_path
+    )
 
     # Parse config
     config_obj = parse_synthetic_config(config)
@@ -515,15 +517,15 @@ def _finalize_processed_dataset(
         logger.error("No prompts remained after processing")
         return
 
-    logger.info(f"Generated processed dataset with {len(processed_prompts)} prompts")
+    logger.info("Generated processed dataset with {} prompts", len(processed_prompts))
 
     processed_dataset = Dataset.from_list(processed_prompts)
     save_dataset_to_file(processed_dataset, output_path)
-    logger.info(f"Conversion completed. Dataset saved to: {output_path}")
+    logger.info("Conversion completed. Dataset saved to: {}", output_path)
 
     if push_to_hub:
         push_dataset_to_hub(hub_dataset_id, processed_dataset)
-        logger.info(f"Pushed dataset to: {hub_dataset_id}")
+        logger.info("Pushed dataset to: {}", hub_dataset_id)
 
 
 def push_dataset_to_hub(

--- a/src/guidellm/mock_server/server.py
+++ b/src/guidellm/mock_server/server.py
@@ -204,7 +204,7 @@ class MockServer:
 
         @self.app.exception(Exception)
         async def generic_error_handler(_request: Request, exception: Exception):
-            logger.error(f"Unhandled exception: {exception}")
+            logger.error("Unhandled exception: {}", exception)
             return response.json(
                 {
                     "error": {

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -616,7 +616,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             )
             self.stop_send_requests_event.set()
         except Exception as err:
-            logger.error(f"Error generating requests: {err}")
+            logger.error("Error generating requests: {}", err)
             self.error_event.set()
             raise err
 
@@ -674,7 +674,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             ):
                 self.shutdown_event.set()
         except Exception as err:
-            logger.error(f"Error processing received update: {err}")
+            logger.error("Error processing received update: {}", err)
             self.error_event.set()
             raise err
 


### PR DESCRIPTION
## Summary

Trivial logging cleanup I've meant to do for a while.

## Details

This just makes sure we're not logging pre-formatted messages where we can use the logger's deferred formatting.

There were several messages where I considered adding additional context; for now, I've resisted that temptation.

## Test Plan

- Several of the modified messages are in `guidellm preprocess dataset` and straightforward to verify manually.
- Ran all automated tests

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 24dbae394d79e7bd09b508cecc7946a1ee52d60f
Author: David Butenhof <dbutenho@redhat.com>
Date:   Mon Jul 6 13:49:01 2026 -0400

    Minor logging cleanup
    
    This mostly just makes sure we're not logging pre-formatted messages where we
    can use the logger's deferred formatting.
    
    There were several messages where I considered adding addional context; for
    now, I've resisted that temptation.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
