### PR TITLE
Add run metadata CLI option

### DIFF
--- a/docs/getting-started/analyze.md
+++ b/docs/getting-started/analyze.md
@@ -17,7 +17,8 @@ This section provides a high-level summary of the benchmark run, including:
 - **Server configuration**: Target URL, model name, and backend details
 - **Data configuration**: Data source, token counts, and dataset properties
 - **Profile arguments**: Rate type, maximum duration, request limits, etc.
-- **Extras**: Any additional metadata provided via the `--output-extras` argument
+- **Extras**: Any additional metadata provided via the `--metadata` argument
+  (`--output-extras` is also accepted as a legacy alias)
 
 Example:
 

--- a/docs/guides/v0.7.0_migration_guide.md
+++ b/docs/guides/v0.7.0_migration_guide.md
@@ -47,7 +47,7 @@ This command is now `guidellm run`
 
 | **NEW OPTIONS**                                                                               | **v0.7.0 new options**                                                                                                                                                        |
 | :-------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Add metadata to output reports                                                                | Specify key-value pairs of metadata labels which will be written to the output reports, for example `--label gpu=NVIDIA_Z500 --label creator=Intrepid_Adventurer`             |
+| Add metadata to output reports                                                                | Specify key-value pairs of metadata which will be written to the output reports, for example `--metadata owner=platform --metadata ticket=LLM-123`. Use `--label gpu=NVIDIA_Z500 --label creator=Intrepid_Adventurer` for metadata labels. |
 | Override concurrent profile stream count, async/constant/poisson rate, or constraint settings | Specify a list settings to override values from `--profile` or `--constraint`, for example `--override profile.rate 10,20,30` or `--override constraint[0].seconds 10,20,30`. |
 
 ## `Guidellm benchmark from-file`

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -62,8 +62,20 @@ __all__ = [
     multiple=True,
     callback=cli_tools.parse_kv_str,
     help=(
-        "Define a labels in key-value pair for the run. "
+        "Define a label key-value pair for the run. "
         "Example: `--label timestamp=1999-09-12@12:00:00 --label env=staging`"
+        "  [repeatable]"
+    ),
+)
+@click.option(
+    "--metadata",
+    "--output-extras",
+    "metadata",
+    multiple=True,
+    callback=cli_tools.parse_kv_str,
+    help=(
+        "Define a metadata key-value pair for the run. "
+        "Example: `--metadata owner=team-a --metadata ticket=LLM-123`"
         "  [repeatable]"
     ),
 )
@@ -134,10 +146,14 @@ def run(**kwargs):  # noqa: C901, PLR0915
             )
 
     try:
+        metadata = _build_metadata(
+            labels=kwargs.get("labels", []),
+            metadata=kwargs.get("metadata", []),
+        )
         args = BenchmarkScenario.create(
             spec=kwargs.get("spec", {}),
             benchmarks=kwargs.get("benchmarks") or BLANK,
-            metadata={"labels": dict(kwargs.get("labels", []))},
+            metadata=metadata,
             scenario=kwargs.get("config"),
         )
     except ValidationError as err:
@@ -155,3 +171,18 @@ def run(**kwargs):  # noqa: C901, PLR0915
             console=console,
         )
     )
+
+
+def _build_metadata(
+    labels: list[tuple[str, str]] | tuple[tuple[str, str], ...],
+    metadata: list[tuple[str, str]] | tuple[tuple[str, str], ...],
+) -> dict[str, str | dict[str, str]]:
+    metadata_dict = dict(metadata)
+    if "labels" in metadata_dict:
+        raise click.BadParameter(
+            "`labels` is reserved for --label values; use --label key=value instead.",
+            param_hint="--metadata",
+        )
+
+    metadata_dict["labels"] = dict(labels)
+    return metadata_dict

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -1,9 +1,64 @@
-"""Tests for ``guidellm run`` CLI error translation."""
+"""Tests for ``guidellm run`` CLI behavior."""
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from guidellm.__main__ import cli
+from guidellm.cli.run import _build_metadata, run
+
+
+def test_build_metadata_attaches_metadata_and_labels():
+    """Metadata and labels should be written into the benchmark scenario.
+
+    ## WRITTEN BY AI ##
+    """
+    metadata = _build_metadata(
+        labels=[("env", "staging")],
+        metadata=[("owner", "platform"), ("ticket", "LLM-123")],
+    )
+
+    assert metadata == {
+        "labels": {"env": "staging"},
+        "owner": "platform",
+        "ticket": "LLM-123",
+    }
+
+
+def test_run_registers_metadata_aliases():
+    """The run command should expose --metadata and legacy --output-extras.
+
+    ## WRITTEN BY AI ##
+    """
+    metadata_option = next(param for param in run.params if param.name == "metadata")
+
+    assert isinstance(metadata_option, click.Option)
+    assert "--metadata" in metadata_option.opts
+    assert "--output-extras" in metadata_option.opts
+
+
+def test_run_rejects_metadata_labels_key():
+    """The labels metadata field is reserved for --label values.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "run",
+            "--disable-console",
+            "--data",
+            "kind=synthetic_text,prompt_tokens=128",
+            "--constraint",
+            "kind=max_requests,max_num=1",
+            "--metadata",
+            "labels=staging",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "`labels` is reserved for --label values" in result.output
 
 
 @pytest.mark.regression


### PR DESCRIPTION
## Summary
- add repeatable `--metadata key=value` support to `guidellm run`
- keep `--output-extras` as a legacy alias for the documented old name
- preserve `--label` for `metadata.labels` and reject `--metadata labels=...` to avoid ambiguous report shape
- update docs and add CLI coverage

Closes #719.

## Non-duplicate check
- #728 attempted the older `--output-extras` shape before the CLI refactor and was closed unmerged because click/config changes were blocked at that time.
- This PR targets the current refactored `guidellm run` path and uses the maintainer-suggested clearer `--metadata` naming while retaining the legacy alias.

## Verification
- `uv run tox -e tests -- tests/unit/cli/test_run.py tests/unit/benchmark/test_serialized_output.py`
- `uv run tox -e tests -- tests/unit`
- `uv run pytest tests/unit/cli/test_run.py tests/unit/benchmark/test_serialized_output.py`
- `uv run pytest tests/unit`
- `uv run ruff check src tests`
- `uv run ruff format --check src/guidellm/cli/run.py tests/unit/cli/test_run.py`
- `git diff --check`

<!-- begin:squash-data -->

---

# git log

commit c146edb0260206d22083b5585594b5b086e9f97f
Author: harivilasp <harivilasp@gmail.com>
Date:   Mon Jul 6 20:11:23 2026 -0700

    Add run metadata CLI option
    
    Signed-off-by: harivilasp <harivilasp@gmail.com>

---------

Signed-off-by: harivilasp <harivilasp@gmail.com>
