### PR TITLE
Move tox runner setting back into tests env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,9 @@
 min_version = 4.22
 env_list = {lint,type}-check,test-{unit,integration,e2e}
 
-[testenv]
-runner = uv-venv-lock-runner
-
 [testenv:tests]
 description = Run all tests
+runner = uv-venv-lock-runner
 dependency_groups = dev
 commands =
     python -m pytest {posargs:tests/}


### PR DESCRIPTION


## Summary

Last minute I moved this out of the tests env and into a section for the base runner class but apparently that doesn't work.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 87168927190926f20015e28e9448e2ea864f8373
Author: Samuel Monson <smonson@redhat.com>
Date:   Tue Jul 7 13:08:34 2026 -0400

    Move tox runner setting back into tests env
    
    Last minute I moved this out of the tests env and into a section for the
    base runner class but apparently that doesn't work.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
