### PR TITLE
Allow TODO and HACK comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,8 @@ ignore = [
     "TC001",   # ignore imports used only for type checking
     "TC002",   # ignore imports used only for type checking
     "TC003",   # ignore imports used only for type checking
+    "FIX002",  # Allow TODO comments
+    "FIX004",  # Allow HACK comments
 ]
 select = [
     # Rules reference: https://docs.astral.sh/ruff/rules/


### PR DESCRIPTION
## Summary

This rule has driven me crazy since the moment we added it. Disallowing `TODO` means there is no common way to indicate planned but incomplete sections of code. Even with the rule disallowing these comments sometimes still happen but end up being marked as `NOTE` or unmarked.

This PR also drops the restriction on `HACK` with the idea that `HACK` can be used for temporary workarounds. It leaves the restrictions on `FIXME` and `XXX` so a contributor can use them to remind themselves of in-progress pieces in a way that is caught by CI.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 7ee7c2d9255fd0550f890e88b35e304aa882fa87
Author: Samuel Monson <smonson@redhat.com>
Date:   Tue Jul 7 13:34:21 2026 -0400

    Allow TODO and HACK comments
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
