### PR TITLE
Correct the CSV report format

### DIFF
--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -9,7 +9,7 @@ provide a standard interface for distributed execution across worker processes.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import Field
 
@@ -125,6 +125,14 @@ class Backend(
         :param type_: The backend type identifier
         """
         self.kind = args.kind
+        self._args = args
+
+    @property
+    def info(self) -> dict[str, Any]:
+        """
+        Return a snapshot of backend configuration for logging or debugging.
+        """
+        return self._args.model_dump(mode="json")
 
     @property
     def processes_limit(self) -> int | None:

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -122,17 +122,17 @@ class Backend(
         """
         Initialize a backend instance.
 
-        :param type_: The backend type identifier
+        :param args: The backend arguments object
         """
         self.kind = args.kind
-        self._args = args
 
     @property
     def info(self) -> dict[str, Any]:
         """
         Return a snapshot of backend configuration for logging or debugging.
         """
-        return self._args.model_dump(mode="json")
+        args = getattr(self, "_args", None)
+        return args.model_dump(mode="json") if args else {}
 
     @property
     def processes_limit(self) -> int | None:

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -96,6 +96,8 @@ class Backend(
         backend = Backend.create(args)
     """
 
+    _args: BackendArgs
+
     @classmethod
     def create(cls, args: BackendArgs) -> Backend:
         """
@@ -125,14 +127,14 @@ class Backend(
         :param args: The backend arguments object
         """
         self.kind = args.kind
+        self._args = args
 
     @property
     def info(self) -> dict[str, Any]:
         """
         Return a snapshot of backend configuration for logging or debugging.
         """
-        args = getattr(self, "_args", None)
-        return args.model_dump(mode="json") if args else {}
+        return self._args.model_dump(mode="json") if self._args else {}
 
     @property
     def processes_limit(self) -> int | None:

--- a/src/guidellm/backends/openai/common.py
+++ b/src/guidellm/backends/openai/common.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pydantic import SecretStr
+
 from guidellm.utils.imports import json
 
 __all__ = [
@@ -18,7 +20,7 @@ FALLBACK_TIMEOUT = 5.0
 
 
 def build_headers(
-    api_key: str | None,
+    api_key: SecretStr | str | None,
     existing_headers: dict[str, str] | None = None,
 ) -> dict[str, str] | None:
     """
@@ -33,6 +35,8 @@ def build_headers(
     """
     headers: dict[str, str] = {}
     if api_key:
+        if isinstance(api_key, SecretStr):
+            api_key = api_key.get_secret_value()
         headers["Authorization"] = f"Bearer {api_key}"
     if existing_headers:
         headers = {**headers, **existing_headers}

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -255,7 +255,7 @@ class OpenAIHTTPBackend(Backend):
 
         :return: Dictionary containing backend configuration details
         """
-        return self._args.model_dump()
+        return self._args.model_dump(mode="json")
 
     async def process_startup(self):
         """

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -242,6 +242,7 @@ class OpenAIHTTPBackend(Backend):
         Initialize OpenAI HTTP backend with server configuration.
         """
         super().__init__(arguments)
+        self._args = arguments
 
         # Runtime state
         self._in_process = False

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -234,6 +234,8 @@ class OpenAIHTTPBackend(Backend):
         await backend.process_shutdown()
     """
 
+    _args: OpenAIHTTPBackendArgs
+
     def __init__(
         self,
         arguments: OpenAIHTTPBackendArgs,
@@ -242,7 +244,6 @@ class OpenAIHTTPBackend(Backend):
         Initialize OpenAI HTTP backend with server configuration.
         """
         super().__init__(arguments)
-        self._args = arguments
 
         # Runtime state
         self._in_process = False

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -242,20 +242,10 @@ class OpenAIHTTPBackend(Backend):
         Initialize OpenAI HTTP backend with server configuration.
         """
         super().__init__(arguments)
-        self._args = arguments
 
         # Runtime state
         self._in_process = False
         self._async_client: httpx.AsyncClient | None = None
-
-    @property
-    def info(self) -> dict[str, Any]:
-        """
-        Get backend configuration details.
-
-        :return: Dictionary containing backend configuration details
-        """
-        return self._args.model_dump(mode="json")
 
     async def process_startup(self):
         """

--- a/src/guidellm/backends/openai/websocket.py
+++ b/src/guidellm/backends/openai/websocket.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import ParseResult, urlparse
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator
 from websockets.asyncio.client import connect as ws_connect
 
 if TYPE_CHECKING:
@@ -141,7 +141,9 @@ class OpenAIWebSocketBackendArgs(BackendArgs):
         ge=1,
         description="PCM16 frames per input_audio_buffer.append chunk (16 kHz).",
     )
-    api_key: str | None = Field(default=None, description="Bearer token if required.")
+    api_key: SecretStr | None = Field(
+        default=None, description="Bearer token if required."
+    )  # noqa: F821
     verify: bool = Field(default=False, description="Verify TLS certificates.")
     timeout: float | None = Field(
         default=None,
@@ -207,7 +209,6 @@ class OpenAIWebSocketBackend(Backend):
         :param arguments: Typed configuration including target, model, and paths.
         """
         super().__init__(arguments)
-        self._args = arguments
         self._resolved_model = (arguments.model or "").strip()
         self.validate_backend: dict[str, Any] | None = resolve_validate_kwargs(
             arguments.validate_backend,
@@ -278,7 +279,10 @@ class OpenAIWebSocketBackend(Backend):
         self, existing_headers: dict[str, str] | None = None
     ) -> dict[str, str] | None:
         """Merge bearer auth and optional headers for HTTP and WebSocket handshakes."""
-        return build_headers(self._args.api_key, existing_headers)
+        return build_headers(
+            self._args.api_key.get_secret_value() if self._args.api_key else None,
+            existing_headers,
+        )  # noqa: E501
 
     async def process_startup(self) -> None:
         """

--- a/src/guidellm/backends/openai/websocket.py
+++ b/src/guidellm/backends/openai/websocket.py
@@ -209,6 +209,7 @@ class OpenAIWebSocketBackend(Backend):
         :param arguments: Typed configuration including target, model, and paths.
         """
         super().__init__(arguments)
+        self._args = arguments
         self._resolved_model = (arguments.model or "").strip()
         self.validate_backend: dict[str, Any] | None = resolve_validate_kwargs(
             arguments.validate_backend,
@@ -279,10 +280,7 @@ class OpenAIWebSocketBackend(Backend):
         self, existing_headers: dict[str, str] | None = None
     ) -> dict[str, str] | None:
         """Merge bearer auth and optional headers for HTTP and WebSocket handshakes."""
-        return build_headers(
-            self._args.api_key.get_secret_value() if self._args.api_key else None,
-            existing_headers,
-        )  # noqa: E501
+        return build_headers(self._args.api_key, existing_headers)
 
     async def process_startup(self) -> None:
         """

--- a/src/guidellm/backends/openai/websocket.py
+++ b/src/guidellm/backends/openai/websocket.py
@@ -202,6 +202,8 @@ class OpenAIWebSocketBackend(Backend):
         await backend.process_shutdown()
     """
 
+    _args: OpenAIWebSocketBackendArgs
+
     def __init__(self, arguments: OpenAIWebSocketBackendArgs):
         """
         Initialize the WebSocket backend from validated args.
@@ -209,7 +211,6 @@ class OpenAIWebSocketBackend(Backend):
         :param arguments: Typed configuration including target, model, and paths.
         """
         super().__init__(arguments)
-        self._args = arguments
         self._resolved_model = (arguments.model or "").strip()
         self.validate_backend: dict[str, Any] | None = resolve_validate_kwargs(
             arguments.validate_backend,

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -161,6 +161,7 @@ class VLLMPythonBackend(Backend):
         Initialize VLLM Python backend with model and configuration.
         """
         super().__init__(arguments)
+        self._args = arguments
 
         # Runtime state
         self._in_process = False

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -161,7 +161,6 @@ class VLLMPythonBackend(Backend):
         Initialize VLLM Python backend with model and configuration.
         """
         super().__init__(arguments)
-        self._args = arguments
 
         # Runtime state
         self._in_process = False
@@ -175,15 +174,6 @@ class VLLMPythonBackend(Backend):
         VLLM engine.
         """
         return 1
-
-    @property
-    def info(self) -> dict[str, Any]:
-        """
-        Get backend configuration details.
-
-        :return: Dictionary containing backend configuration details
-        """
-        return self._args.model_dump()
 
     async def process_startup(self):
         """

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -148,6 +148,8 @@ class VLLMPythonBackend(Backend):
         await backend.process_shutdown()
     """
 
+    _args: VLLMPythonBackendArgs
+
     @classmethod
     def backend_args(cls) -> type[BackendArgs]:
         """Return the Pydantic model for this backend's creation arguments."""
@@ -161,7 +163,6 @@ class VLLMPythonBackend(Backend):
         Initialize VLLM Python backend with model and configuration.
         """
         super().__init__(arguments)
-        self._args = arguments
 
         # Runtime state
         self._in_process = False


### PR DESCRIPTION
## Summary

Once again fix `api_key` serialization (this time for CSV).

## Details

The root problem stems from attempts to serialize the Pydantic `SecretStr`.

This was resolved for JSON format by serializing `BenchmarkConfig` using `model_dump(mode="json")`, but the CSV serialization breaks up the context very differently, leading to solutions that are either very specific or rather sweeping.

It appears the simplest and least invasive fix is to call `model_dump(mode="json")` on the `OpenAIHTTPBackend.info` method. This is the only place we use `SecretStr`, and feeds the JSON we serialize to CSV. `info` is only intended for "informational" serialization, so the masked password we receive is expected and correct.

We could benefit in the future from some refactoring. For example, it's odd that we convert the `Backend` to a `dict` when creating `BenchmarkConfig`, but then reconstruct the `Backend` when we call the benchmarker `run` method for each strategy.

## Test Plan

- [x] test suite
- [x] manually run CSV output with `--backend kind=openai_http,api_key=<value>`

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #764 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit e99d9a3792d9e5836048dae59a04c920419d75c8
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jul 7 14:08:50 2026 -0400

    Correct the CSV report format
    
    The root problem stems from attempts to serialize the Pydantic `SecretStr`.
    
    This was resolved for JSON format by serializing `BenchmarkConfig`
    using `model_dump(mode="json")`, but the CSV serialization breaks up the
    context very differently, leading to solutions that are either very specific
    or rather sweeping.
    
    It appears the simplest and least invasive fix is to call
    `model_dump(mode="json")` on the `OpenAIHTTPBackend.info` method, which is the
    only place we use `SecretStr`.
    
    We could benefit in the future from some refactoring. For example, it's odd
    that we convert the `Backend` to a `dict` when creating `BenchmarkConfig`,
    but then reconstruct the `Backend` when we call the benchmarker `run` method
    for each strategy.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit ba2aa233d8de95f7b58880b9b4c2f056e83edadf
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jul 7 15:40:27 2026 -0400

    Generalize the change
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit 33ed889dfd3628969d59ab464def308c9c51e430
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jul 7 16:09:14 2026 -0400

    Yeah, that confused ruff
    
    Rather than annotate every args field access, we need to set `_args` as the
    proper type to support static type checking. (For some reason I keep thinking
    I'm writing in Python, when I'm actually writing in ruff...)
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

commit 3b8e599ccd4a2a83cd72cfbc4261ca4282bc76fd
Author: David Butenhof <dbutenho@redhat.com>
Date:   Tue Jul 7 16:44:26 2026 -0400

    Use the type hint, Luke!
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
