### PR TITLE
Disable redundant auto-refresh in console progress components

### DIFF
--- a/src/guidellm/benchmark/progress.py
+++ b/src/guidellm/benchmark/progress.py
@@ -155,6 +155,7 @@ class GenerativeConsoleBenchmarkerProgress(
             TextColumn("<"),
             TimeRemainingColumn(),
             TextColumn("]"),
+            auto_refresh=False,
         )
         self.run_progress_task = self.run_progress.add_task("")
         self._sync_run_progress()
@@ -256,6 +257,7 @@ class _GenerativeProgressTasks(Progress):
             TextColumn("({task.fields[progress_status]})"),
             TextColumn(" "),
             TextColumn(summary_text),
+            auto_refresh=False,
         )
 
         for strategy_type in profile.strategy_types:


### PR DESCRIPTION


## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
Explicitly set auto_refresh=False on the internal progress instances to avoid unnecessary screen updates, as the parent Live object already manages the refresh at the configured rate.

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
The base `Live` class (from Rich) is initialized with `auto_refresh=True` and `refresh_per_second=4` in the constructor of `GenerativeConsoleBenchmarkerProgress`.

However, the child progress components (`self.run_progress` and `_GenerativeProgressTasks`) also enable `auto_refresh` by default when they are created, leading to redundant refresh triggers.

This results in more frequent redraws than intended.

## Test Plan

<!--
List the steps needed to test this PR.
-->
1. Run the following command normally:
```
guidellm run \
  --backend kind=openai_http,target=http://localhost:8000 \
  --profile kind=sweep \
  --constraint kind=max_duration,seconds=30 \
  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128
```
2. Observe that the refresh frequency is reduced.

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #913 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 4d73733506cb1a61a19f7400b2110751e0255ae2
Author: wuheng_ky <wuheng@kylinos.cn>
Date:   Wed Jul 8 13:57:11 2026 +0800

    Disable redundant auto-refresh in console progress components
    
    Explicitly set auto_refresh=False on the internal progress instances to avoid
    unnecessary screen updates, as the parent Live object already manages the
    refresh at the configured rate.
    
    Signed-off-by: wuheng <wuheng@kylinos.cn>

---------

Signed-off-by: wuheng <wuheng@kylinos.cn>
