### PR TITLE
Add a setting to configure the default working dir

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -68,9 +68,9 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
 USER 1001:0
 
 # Add guidellm bin to PATH
-# Argument defaults can be set with GUIDELLM_<ARG>
+# Change the default save directory for results
 ENV HOME="/home/guidellm" \
-    GUIDELLM_OUTPUT_DIR="/results"
+    GUIDELLM__WORKING_DIRECTORY="/results"
 
 # Create the user home dir
 WORKDIR $HOME

--- a/Containerfile
+++ b/Containerfile
@@ -70,7 +70,7 @@ USER 1001:0
 # Add guidellm bin to PATH
 # Change the default save directory for results
 ENV HOME="/home/guidellm" \
-    GUIDELLM__WORKING_DIRECTORY="/results"
+    GUIDELLM__DEFAULT_RESULTS_DIR="/results"
 
 # Create the user home dir
 WORKDIR $HOME

--- a/Containerfile.vllm
+++ b/Containerfile.vllm
@@ -36,7 +36,7 @@ LABEL io.k8s.display-name="GuideLLM" \
       org.opencontainers.image.license="Apache-2.0"
 
 ENV HOME="/home/guidellm" \
-    GUIDELLM_OUTPUT_DIR="/results"
+    GUIDELLM__WORKING_DIRECTORY="/results"
 
 WORKDIR $HOME
 

--- a/Containerfile.vllm
+++ b/Containerfile.vllm
@@ -36,7 +36,7 @@ LABEL io.k8s.display-name="GuideLLM" \
       org.opencontainers.image.license="Apache-2.0"
 
 ENV HOME="/home/guidellm" \
-    GUIDELLM__WORKING_DIRECTORY="/results"
+    GUIDELLM__DEFAULT_RESULTS_DIR="/results"
 
 WORKDIR $HOME
 

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -42,7 +42,7 @@ class CSVBenchmarkOutputArgs(BenchmarkOutputArgs):
         description="The kind of output.",
     )
     path: Path = Field(
-        default_factory=lambda: settings.working_directory / "benchmarks.csv",
+        default_factory=lambda: settings.default_results_dir / "benchmarks.csv",
         description="The file to save the output to.",
     )
 

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -24,6 +24,7 @@ from guidellm.benchmark.schemas import (
     GenerativeBenchmarksReport,
 )
 from guidellm.schemas import DistributionSummary, StatusDistributionSummary
+from guidellm.settings import settings
 from guidellm.utils.functions import safe_format_timestamp
 
 __all__ = [
@@ -41,7 +42,7 @@ class CSVBenchmarkOutputArgs(BenchmarkOutputArgs):
         description="The kind of output.",
     )
     path: Path = Field(
-        default=Path("./benchmarks.csv"),
+        default_factory=lambda: settings.working_directory / "benchmarks.csv",
         description="The file to save the output to.",
     )
 

--- a/src/guidellm/benchmark/outputs/html.py
+++ b/src/guidellm/benchmark/outputs/html.py
@@ -51,7 +51,7 @@ class HTMLBenchmarkOutputArgs(BenchmarkOutputArgs):
         description="The kind of output.",
     )
     path: Path = Field(
-        default_factory=lambda: settings.working_directory / "benchmarks.html",
+        default_factory=lambda: settings.default_results_dir / "benchmarks.html",
         description="The file to save the output to.",
     )
 

--- a/src/guidellm/benchmark/outputs/html.py
+++ b/src/guidellm/benchmark/outputs/html.py
@@ -51,7 +51,7 @@ class HTMLBenchmarkOutputArgs(BenchmarkOutputArgs):
         description="The kind of output.",
     )
     path: Path = Field(
-        default=Path("./benchmarks.html"),
+        default_factory=lambda: settings.working_directory / "benchmarks.html",
         description="The file to save the output to.",
     )
 

--- a/src/guidellm/benchmark/outputs/serialized.py
+++ b/src/guidellm/benchmark/outputs/serialized.py
@@ -16,6 +16,7 @@ from pydantic import Field
 
 from guidellm.benchmark.outputs.output import GenerativeBenchmarkerOutput
 from guidellm.benchmark.schemas import BenchmarkOutputArgs, GenerativeBenchmarksReport
+from guidellm.settings import settings
 
 __all__ = [
     "GenerativeBenchmarkerSerialized",
@@ -34,7 +35,7 @@ class JSONBenchmarkOutputArgs(BenchmarkOutputArgs):
         examples=["json"],
     )
     path: Path = Field(
-        default=Path("./benchmarks.json"),
+        default_factory=lambda: settings.working_directory / "benchmarks.json",
         description="The file to save the output to.",
         examples=["./benchmarks.json"],
     )
@@ -50,7 +51,7 @@ class YAMLBenchmarkOutputArgs(BenchmarkOutputArgs):
         examples=["yaml"],
     )
     path: Path = Field(
-        default=Path("./benchmarks.yaml"),
+        default_factory=lambda: settings.working_directory / "benchmarks.yaml",
         description="The file to save the output to.",
         examples=["./benchmarks.yaml"],
     )

--- a/src/guidellm/benchmark/outputs/serialized.py
+++ b/src/guidellm/benchmark/outputs/serialized.py
@@ -35,7 +35,7 @@ class JSONBenchmarkOutputArgs(BenchmarkOutputArgs):
         examples=["json"],
     )
     path: Path = Field(
-        default_factory=lambda: settings.working_directory / "benchmarks.json",
+        default_factory=lambda: settings.default_results_dir / "benchmarks.json",
         description="The file to save the output to.",
         examples=["./benchmarks.json"],
     )
@@ -51,7 +51,7 @@ class YAMLBenchmarkOutputArgs(BenchmarkOutputArgs):
         examples=["yaml"],
     )
     path: Path = Field(
-        default_factory=lambda: settings.working_directory / "benchmarks.yaml",
+        default_factory=lambda: settings.default_results_dir / "benchmarks.yaml",
         description="The file to save the output to.",
         examples=["./benchmarks.yaml"],
     )

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -114,8 +114,10 @@ class Settings(BaseSettings):
     default_synthetic_tool_response: str = '{"status": "ok"}'
 
     # Report settings
-    working_directory: Path = Field(
-        description="Working directory. Used as the default path for report outputs.",
+    default_results_dir: Path = Field(
+        description=(
+            "Results save directory. Used as the default path for report outputs."
+        ),
         default_factory=Path.cwd,
     )
     report_generation: ReportGenerationSettings = ReportGenerationSettings()

--- a/src/guidellm/settings.py
+++ b/src/guidellm/settings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -74,6 +75,8 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
+        # TODO: We also use `GUIDELLM__` as the prefix for config arguments
+        #       so we should probably change this prefix to avoid clashes
         env_prefix="GUIDELLM__",
         env_nested_delimiter="__",
         extra="ignore",
@@ -111,6 +114,10 @@ class Settings(BaseSettings):
     default_synthetic_tool_response: str = '{"status": "ok"}'
 
     # Report settings
+    working_directory: Path = Field(
+        description="Working directory. Used as the default path for report outputs.",
+        default_factory=Path.cwd,
+    )
     report_generation: ReportGenerationSettings = ReportGenerationSettings()
 
     # Output settings


### PR DESCRIPTION
## Summary

The Containerfiles are still using the `GUIDELLM_OUTPUT_DIR` environment variable which no longer exists. There is still a valid use-case for having a separate default directory from the current one so this PR adds back that functionality. Individual outputs will still override the path in its entirety.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit be587bc4b2152ef5b14cf3bedf4360a1fc821060
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 8 13:45:52 2026 -0400

    Add a setting to configure the default working dir
    
    Previously it was possible set the output directory for all outputs with
    a single environment variable. This was removed with the v0.7.0 refactor
    as now each output manages its own path. However, its still useful to
    set a default output directory for special environments such as
    containers where we may want to redirect all outputs to a volume by
    default.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit dd4ed2fbd97b0ce6631ddfcca2b3f7d95a302bfb
Author: Samuel Monson <smonson@redhat.com>
Date:   Wed Jul 8 14:07:09 2026 -0400

    Fix WD setting in Containerfiles
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

commit 48b7cae59bb6f91c2c0569866c7c57733d7a190d
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Jul 9 14:48:59 2026 -0400

    Rename WD control to default_results_dir
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
