### PR TITLE
Fix ValidationError when re-exporting benchmarks with console output

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -589,7 +589,9 @@ async def reimport_benchmarks_report(
     output_args: list[BenchmarkOutputArgs] = []
     for fmt in output_formats:
         data: dict[str, Any] = {"kind": fmt}
-        data["path"] = base_path / f"benchmarks.{fmt}"
+        output_cls = BenchmarkOutputArgs.get_registered_object(fmt)
+        if output_cls is not None and "path" in output_cls.model_fields:
+            data["path"] = base_path / f"benchmarks.{fmt}"
         output_args.append(BenchmarkOutputArgs.model_validate(data))
 
     output_format_results: dict[str, Any] = {}

--- a/tests/unit/entrypoints/test_benchmark_from_file_entrypoint.py
+++ b/tests/unit/entrypoints/test_benchmark_from_file_entrypoint.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from guidellm.benchmark import reimport_benchmarks_report
+from guidellm.benchmark.schemas import BenchmarkScenario, GenerativeBenchmarksReport
 
 # Set to true to re-write the expected output.
 REGENERATE_ARTIFACTS = False
@@ -76,6 +77,40 @@ def test_reexporting_benchmark(get_test_asset_dir, cleanup):
     # The reexported file should exist and be identical to the source.
     assert exported_file.exists()
     assert filecmp.cmp(source_file, exported_file, shallow=False)
+
+
+@pytest.mark.asyncio
+async def test_reimport_with_console_format_does_not_raise(tmp_path):
+    """
+    Regression test for https://github.com/vllm-project/guidellm/issues/925
+
+    `reimport_benchmarks_report` used to unconditionally attach an output path
+    to every requested format, but console output does not accept a path,
+    raising a pydantic ValidationError.
+    """
+    config = BenchmarkScenario.model_validate(
+        {
+            "spec": {
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://localhost:8000/v1",
+                    "model": "test-model",
+                },
+                "data": [{"kind": "huggingface", "source": "test_data.jsonl"}],
+                "profile": {"kind": "constant", "rate": 10.0},
+            },
+        }
+    )
+    report = GenerativeBenchmarksReport(config=config)
+    report_file = tmp_path / "benchmarks.json"
+    report.save_file(report_file)
+
+    _, results = await reimport_benchmarks_report(
+        report_file, tmp_path, ("console", "json")
+    )
+
+    assert results["console"] == "printed to console"
+    assert results["json"].exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `reimport_benchmarks_report()` (used by `guidellm benchmark from-file`) unconditionally attached a file path to every requested output format.
- `ConsoleBenchmarkOutputArgs` forbids extra fields (no `path`), so requesting console output — the default — raised `pydantic_core.ValidationError: console.path Extra inputs are not permitted`.
- Now a path is only attached when the resolved output args class for that format actually declares a `path` field, so console output (and any future path-less format) works while file-based formats (json/yaml/html/csv) keep their paths.

Fixes #925

## Test plan
- [x] Added a regression test (`test_reimport_with_console_format_does_not_raise`) that reproduces the exact crash from the issue and asserts it no longer raises.
- [x] `ruff check` and `mypy` pass on the changed files.
- [x] `pytest tests/unit/entrypoints tests/unit/benchmark` passes (75 passed, pre-existing unrelated skips only).
- [x] Manually reproduced the crash on `main` and confirmed the fix resolves it via `guidellm benchmark from-file benchmarks.json --output-formats console`.

<!-- begin:squash-data -->

---

# git log

commit cbd16c51b9f6bcfb27414b02eaa2eb7761f8a302
Author: Martin Pfister <30149150+martin-pfister@users.noreply.github.com>
Date:   Fri Jul 10 15:11:43 2026 +0000

    Fix ValidationError when re-exporting benchmarks with console output
    
    reimport_benchmarks_report() unconditionally attached a file path to
    every requested output format, but ConsoleBenchmarkOutputArgs forbids
    extra fields since console output has no file to write to. This broke
    `guidellm benchmark from-file` whenever console was among the requested
    formats (the default).
    
    Only attach a path when the resolved output args class actually
    declares a `path` field.
    
    Fixes #925
    
    Signed-off-by: Martin Pfister <30149150+martin-pfister@users.noreply.github.com>

---------

Signed-off-by: Martin Pfister <30149150+martin-pfister@users.noreply.github.com>
