### PR TITLE
Handle repeated `--output` specifications consistently across run and from-file

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -291,21 +291,22 @@ async def resolve_profile(
 async def resolve_output_formats(
     outputs: list[BenchmarkOutputArgs],
     console: Console | None = None,
-) -> dict[str, GenerativeBenchmarkerOutput]:
+) -> list[GenerativeBenchmarkerOutput]:
     """
     Resolve output format specifications into configured output handler instances.
 
     :param outputs: List of BenchmarkOutputArgs specifying output kind and path
     :param console: Console instance for progress reporting, or None
-    :return: Dictionary mapping format names to configured output handler instances
+    :return: Ordered list of configured output handler instances, one per input
+        specification (repeated kinds are preserved as separate entries)
     """
     console_step = (
         console.print_update_step(title="Resolving output formats") if console else None
     )
 
-    resolved: dict[str, GenerativeBenchmarkerOutput] = {}
+    resolved: list[GenerativeBenchmarkerOutput] = []
     for output_arg in outputs:
-        resolved[output_arg.kind] = GenerativeBenchmarkerOutput.resolve(output_arg)
+        resolved.append(GenerativeBenchmarkerOutput.resolve(output_arg))
 
     if console_step:
         console_step.finish(
@@ -458,7 +459,7 @@ async def benchmark_generative_text(
     progress: GenerativeConsoleBenchmarkerProgress | None = None,
     console: Console | None = None,
     **constraints: str | ConstraintInitializer | Any,
-) -> tuple[GenerativeBenchmarksReport, dict[str, Any]]:
+) -> tuple[GenerativeBenchmarksReport, list[tuple[str, Any]]]:
     """
     Execute a comprehensive generative text benchmarking workflow.
 
@@ -539,10 +540,9 @@ async def benchmark_generative_text(
         if benchmark:
             report.benchmarks.append(benchmark)
 
-    output_format_results = {}
-    for key, output in output_formats.items():
-        output_result = await output.finalize(report)
-        output_format_results[key] = output_result
+    output_format_results: list[tuple[str, Any]] = []
+    for output_arg, output in zip(benchmark_args.outputs, output_formats, strict=True):
+        output_format_results.append((output_arg.kind, await output.finalize(report)))
 
     if console:
         await GenerativeBenchmarkerConsole(console=console).finalize(report)
@@ -554,8 +554,8 @@ async def benchmark_generative_text(
             ),
             status="success",
         )
-        for key, value in output_format_results.items():
-            console.print_update(title=f"  {key:<8}: {value}", status="debug")
+        for kind, value in output_format_results:
+            console.print_update(title=f"  {kind:<8}: {value}", status="debug")
 
     return report, output_format_results
 
@@ -563,7 +563,7 @@ async def benchmark_generative_text(
 async def reimport_benchmarks_report(
     file: Path,
     outputs: tuple[BenchmarkOutputArgs, ...] | list[dict[str, Any]],
-) -> tuple[GenerativeBenchmarksReport, dict[str, Any]]:
+) -> tuple[GenerativeBenchmarksReport, list[tuple[str, Any]]]:
     """
     Load and re-export an existing benchmarks report in specified output formats.
 
@@ -587,12 +587,12 @@ async def reimport_benchmarks_report(
     for fmt in outputs:
         output_args.append(BenchmarkOutputArgs.model_validate(fmt))
 
-    output_results: dict[str, Any] = {}
+    output_results: list[tuple[str, Any]] = []
     for args in output_args:
         output = GenerativeBenchmarkerOutput.resolve(args)
-        output_results[args.kind] = await output.finalize(report)
+        output_results.append((args.kind, await output.finalize(report)))
 
-    for key, value in output_results.items():
-        console.print_update(title=f"  {key:<8}: {value}", status="debug")
+    for kind, value in output_results:
+        console.print_update(title=f"  {kind:<8}: {value}", status="debug")
 
     return report, output_results

--- a/tests/unit/benchmark/test_entrypoints.py
+++ b/tests/unit/benchmark/test_entrypoints.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from guidellm.benchmark.entrypoints import resolve_output_formats
+from guidellm.benchmark.outputs import GenerativeBenchmarkerOutput
+from guidellm.benchmark.outputs.serialized import JSONBenchmarkOutputArgs
+
+
+@pytest.mark.asyncio
+@pytest.mark.sanity
+async def test_resolve_output_formats_preserves_duplicate_kinds(tmp_path: Path):
+    """
+    resolve_output_formats returns one resolved output per arg, in order,
+    without collapsing repeated kinds into a single entry.
+
+    ## WRITTEN BY AI ##
+    """
+    outputs = [
+        JSONBenchmarkOutputArgs(path=tmp_path / "first.json"),
+        JSONBenchmarkOutputArgs(path=tmp_path / "second.json"),
+    ]
+
+    resolved = await resolve_output_formats(outputs)
+
+    assert isinstance(resolved, list)
+    assert len(resolved) == 2
+    assert all(isinstance(o, GenerativeBenchmarkerOutput) for o in resolved)
+    assert resolved[0] is not resolved[1]
+    assert [o.output_path for o in resolved] == [
+        tmp_path / "first.json",
+        tmp_path / "second.json",
+    ]

--- a/tests/unit/entrypoints/test_benchmark_from_file_entrypoint.py
+++ b/tests/unit/entrypoints/test_benchmark_from_file_entrypoint.py
@@ -87,7 +87,7 @@ async def test_loads_json_report(
     """
     report, output_results = await reimport_benchmarks_report(saved_json_report, [])
 
-    assert output_results == {}
+    assert output_results == []
     assert report.config == sample_report.config
     assert report.benchmarks == []
     assert report.metadata.version == 2
@@ -105,7 +105,7 @@ async def test_loads_yaml_report(
     """
     report, output_results = await reimport_benchmarks_report(saved_yaml_report, [])
 
-    assert output_results == {}
+    assert output_results == []
     assert report.config == sample_report.config
     assert report.benchmarks == []
 
@@ -122,7 +122,7 @@ async def test_loads_report_from_directory(
     """
     report, output_results = await reimport_benchmarks_report(report_directory, [])
 
-    assert output_results == {}
+    assert output_results == []
     assert report.config == sample_report.config
 
 
@@ -145,7 +145,7 @@ async def test_console_output(capfd, saved_json_report: Path):
     combined = out + err
     assert "Import of old benchmarks complete" in combined
     assert "Run Summary Info" in combined
-    assert output_results == {"console": "printed to console"}
+    assert output_results == [("console", "printed to console")]
 
 
 @pytest.mark.asyncio
@@ -164,7 +164,7 @@ async def test_reexports_json(saved_json_report: Path, tmp_path: Path):
     )
 
     assert exported_file.exists()
-    assert output_results["json"] == exported_file
+    assert output_results == [("json", exported_file)]
     assert filecmp.cmp(saved_json_report, exported_file, shallow=False)
 
     reloaded = GenerativeBenchmarksReport.load_file(exported_file)
@@ -188,7 +188,7 @@ async def test_reexports_yaml(saved_yaml_report: Path, tmp_path: Path):
     )
 
     assert exported_file.exists()
-    assert output_results["yaml"] == exported_file
+    assert output_results == [("yaml", exported_file)]
     assert filecmp.cmp(saved_yaml_report, exported_file, shallow=False)
 
     reloaded = GenerativeBenchmarksReport.load_file(exported_file)
@@ -216,10 +216,11 @@ async def test_multiple_output_formats(saved_json_report: Path, tmp_path: Path):
         ],
     )
 
-    assert set(output_results) == {"console", "json", "yaml"}
-    assert output_results["console"] == "printed to console"
-    assert output_results["json"] == exported_json
-    assert output_results["yaml"] == exported_yaml
+    assert [kind for kind, _ in output_results] == ["console", "json", "yaml"]
+    results_by_kind = dict(output_results)
+    assert results_by_kind["console"] == "printed to console"
+    assert results_by_kind["json"] == exported_json
+    assert results_by_kind["yaml"] == exported_yaml
     assert exported_json.exists()
     assert exported_yaml.exists()
     assert json.loads(exported_json.read_text()) == json.loads(
@@ -249,6 +250,33 @@ async def test_outputs_accepts_tuple_of_args(saved_json_report: Path, tmp_path: 
         ),
     )
 
-    assert set(output_results) == {"json", "yaml"}
+    assert [kind for kind, _ in output_results] == ["json", "yaml"]
     assert exported_file.exists()
     assert (tmp_path / "benchmarks.yaml").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_duplicate_output_kind_generates_and_reports_all(
+    saved_json_report: Path, tmp_path: Path
+):
+    """
+    Two outputs of the same kind with different paths are both generated and
+    both appear, in order, in the returned results (regression for #933).
+
+    ## WRITTEN BY AI ##
+    """
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+
+    _, output_results = await reimport_benchmarks_report(
+        saved_json_report,
+        [
+            {"kind": "json", "path": first},
+            {"kind": "json", "path": second},
+        ],
+    )
+
+    assert first.exists()
+    assert second.exists()
+    assert output_results == [("json", first), ("json", second)]


### PR DESCRIPTION
## Summary

`--output` may be specified multiple times, but two specs of the *same kind* were handled inconsistently and lossily. Both entrypoints collected outputs/results in a `dict` keyed by output `kind`, which cannot hold two outputs of the same kind:

- `guidellm run` overwrote at resolve time, so a repeated kind (e.g. `--output kind=json,path=a.json --output kind=json,path=b.json`) was **never generated** — only the last survived.
- `guidellm benchmark from-file` generated both files but **reported only the last**.

This is most visible with the new `plot` output from the issue, e.g. `--output kind=plot,dpi=72,path=plot.png --output kind=plot,dpi=300,path=plot.pdf`.

This change resolves, generates, and reports outputs from an ordered list in both paths, so every `--output` is generated and reported, consistently.

## Details

- `resolve_output_formats` now returns an ordered `list[GenerativeBenchmarkerOutput]` (one entry per spec, repeated kinds preserved) instead of a `dict[str, GenerativeBenchmarkerOutput]` keyed by kind.
- `benchmark_generative_text` (run) and `reimport_benchmarks_report` (from-file) finalize and report over that list, collecting an ordered `list[tuple[str, Any]]` of `(kind, result)`.
- Both entrypoints' second return value changes from `dict[str, Any]` to `list[tuple[str, Any]]`. This is a public-API shape change, but unavoidable: a dict keyed by kind cannot represent duplicate kinds. The only in-repo consumers of the return value are tests (updated here); the two CLI callers discard it, and user-facing reporting happens inside the functions.
- Scope kept tight: only `src/guidellm/benchmark/entrypoints.py` and its tests; no new public types.

## Test Plan

- New `tests/unit/benchmark/test_entrypoints.py`: `resolve_output_formats` preserves duplicate kinds as an ordered list.
- Updated `tests/unit/entrypoints/test_benchmark_from_file_entrypoint.py` to the list-shaped results and added a regression test: two same-kind outputs with different paths are both generated **and** both reported, in order.
- `tox -e lint-check` and `tox -e type-check` pass.
- `tox -e test-unit` passes for these changes (the only failure observed locally was an unrelated, pre-existing `MaxDurationConstraint` timing test that passes in isolation).
- Manual CLI smoke: `guidellm benchmark from-file benchmarks.json --output kind=json,path=a.json --output kind=json,path=b.json` → both `a.json` and `b.json` are created and both are reported in the console summary.

## Related Issues

- Fixes #933

<!-- begin:squash-data -->

---

# git log

commit bfffc67b13f7a8be30753a6450edf6e7ecb1cf7a
Author: Pragadeesh122 <pragan189@gmail.com>
Date:   Fri Jul 17 11:21:15 2026 -0500

    fix: handle repeated --output specs consistently (#933)
    
    Both `guidellm run` and `benchmark from-file` collected outputs in a dict
    keyed by output kind, so repeating a kind (two json specs, two plot specs,
    etc.) overwrote earlier entries: run never generated the duplicate, and
    from-file generated both files but reported only the last.
    
    Resolve, generate, and report outputs from an ordered list in both paths
    so every --output is generated and reported.
    
    Signed-off-by: Pragadeesh122 <pragan189@gmail.com>

---------

Signed-off-by: Pragadeesh122 <pragan189@gmail.com>
