### PR TITLE
Fix SecretStr JSON serialization in CSV output

### DIFF
--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 import csv
 import json
+from json import JSONEncoder
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from guidellm.benchmark.outputs.output import GenerativeBenchmarkerOutput
 from guidellm.benchmark.schemas import (
@@ -31,6 +32,13 @@ __all__ = [
     "CSVBenchmarkOutputArgs",
     "GenerativeBenchmarkerCSV",
 ]
+
+
+class _SecretStrEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, SecretStr):
+            return obj.get_secret_value()
+        return super().default(obj)
 
 
 @BenchmarkOutputArgs.register("csv")
@@ -306,7 +314,14 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
             json.dumps(benchmark.config.requests),
         )
         self._add_field(
-            headers, values, "Run Info", "Backend", json.dumps(benchmark.config.backend)
+            headers,
+            values,
+            "Run Info",
+            "Backend",
+            json.dumps(
+                benchmark.config.backend,
+                cls=_SecretStrEncoder,
+            ),
         )
         self._add_field(
             headers,


### PR DESCRIPTION

Pydantic SecretStr (used for api_key) is not JSON-serializable by default.
Add custom encoder to extract secret value during serialization.

<!-- begin:squash-data -->

---

# git log

commit 454e9ce31d69aa19dd595e9dbeccf726df603d9b
Author: Daniele Trifirò <dtrifiro@redhat.com>
Date:   Wed Jul 22 15:59:55 2026 +0200

    Fix SecretStr JSON serialization in CSV output
    
    Pydantic SecretStr (used for api_key) is not JSON-serializable by default.
    Add custom encoder to extract secret value during serialization.
