### PR TITLE
Added more useful error messages for kind inputs

### DIFF
--- a/src/guidellm/cli/benchmark/from_file.py
+++ b/src/guidellm/cli/benchmark/from_file.py
@@ -9,13 +9,14 @@ import click
 
 from guidellm.benchmark import reimport_benchmarks_report
 from guidellm.benchmark.schemas import BenchmarkOutputArgs
-from guidellm.utils.click_pydantic import registry_option
+from guidellm.utils.click_pydantic import RegistryAwareCommand, registry_option
 
 __all__ = ["from_file"]
 
 
 @click.command(
     "from-file",
+    cls=RegistryAwareCommand,
     help=(
         "Load a saved benchmark report and optionally re-export to other formats. "
         "PATH: Path to the saved benchmark report file (default: ./benchmarks.json)."

--- a/src/guidellm/cli/preprocess/dataset.py
+++ b/src/guidellm/cli/preprocess/dataset.py
@@ -10,6 +10,7 @@ from guidellm.cli.preprocess.args import PreprocessDatasetArgs
 from guidellm.data import process_dataset
 from guidellm.data.schemas import DataArgs
 from guidellm.utils.click_pydantic import (
+    RegistryAwareCommand,
     format_validation_errors,
     registry_options_from_model,
 )
@@ -19,6 +20,7 @@ __all__ = ["dataset"]
 
 @click.command(
     "dataset",
+    cls=RegistryAwareCommand,
     help=(
         "Process a dataset to have specific prompt and output token sizes. "
         "Supports multiple strategies for handling prompts and optional "

--- a/src/guidellm/cli/run.py
+++ b/src/guidellm/cli/run.py
@@ -16,6 +16,7 @@ from guidellm.benchmark import (
 )
 from guidellm.settings import Settings
 from guidellm.utils.click_pydantic import (
+    RegistryAwareCommand,
     format_validation_errors,
     registry_options_from_model,
 )
@@ -30,6 +31,7 @@ __all__ = [
 
 @click.command(
     "run",
+    cls=RegistryAwareCommand,
     help=(
         "Run a benchmark against a generative model. "
         "Supports multiple backends, data sources, strategies, and output formats. "

--- a/src/guidellm/utils/click_pydantic.py
+++ b/src/guidellm/utils/click_pydantic.py
@@ -11,10 +11,40 @@ from guidellm.schemas import PydanticClassRegistryMixin
 from guidellm.utils.cli import parse_arguments
 
 __all__ = [
+    "RegistryAwareCommand",
+    "format_kind_config_usage",
     "format_validation_errors",
     "registry_option",
     "registry_options_from_model",
 ]
+
+# Pydantic error types where the stock message does not list valid kinds, so we
+# append format_kind_config_usage. ``union_tag_invalid`` already lists tags and
+# would be redundant if we appended again.
+_REGISTRY_SHAPE_ERROR_TYPES = frozenset({"model_attributes_type"})
+
+
+def format_kind_config_usage(
+    registry_type: type[PydanticClassRegistryMixin],  # type: ignore[type-arg]
+    discriminator: str | None = None,
+) -> str:
+    """
+    Build a self-documenting usage hint for a registry-backed config option.
+
+    :param registry_type: The ``PydanticClassRegistryMixin`` subclass whose
+        registered names are listed
+    :param discriminator: Discriminator field name; defaults to the registry's
+        ``schema_discriminator`` (typically ``"kind"``)
+    :return: Multi-line string describing expected format and valid kinds
+    """
+    disc = discriminator or registry_type.schema_discriminator
+    names = registry_type.registered_names()
+    choices = ", ".join(names) if names else "(none registered)"
+    return (
+        f"Expected format: {disc}=<type>,key=value,... "
+        f"or JSON/YAML object with a '{disc}' field\n"
+        f"  Valid {disc}s: {choices}"
+    )
 
 
 class _RegistryParamType(click.ParamType):
@@ -71,6 +101,117 @@ class _RegistryParamType(click.ParamType):
         return value
 
 
+class RegistryConfigOption(click.Option):
+    """
+    Click option subclass that carries a reference to its registry type.
+
+    Used by :class:`RegistryAwareCommand` to enrich missing-argument errors
+    with the expected format and valid kinds.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        registry_type: type[PydanticClassRegistryMixin] | None = None,  # type: ignore[type-arg]
+        **kwargs: Any,
+    ) -> None:
+        self.registry_type = registry_type
+        super().__init__(*args, **kwargs)
+
+
+class RegistryAwareCommand(click.Command):
+    """
+    Command subclass that enriches missing-argument errors for registry options.
+
+    When Click's parser raises ``BadOptionUsage`` for a registry-backed option
+    (e.g. bare ``--constraint`` with no value), this override catches it and
+    re-raises a ``BadParameter`` with the expected format and valid kinds.
+    """
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """
+        Override to intercept missing-value errors for registry options.
+
+        :param ctx: Click context
+        :param args: Command-line arguments to parse
+        :return: Remaining arguments after parsing
+        """
+        try:
+            return super().parse_args(ctx, args)
+        except click.BadOptionUsage as e:
+            for param in self.params:
+                if (
+                    isinstance(param, RegistryConfigOption)
+                    and param.registry_type is not None
+                    and hasattr(e, "option_name")
+                    and e.option_name in param.opts
+                ):
+                    usage = format_kind_config_usage(param.registry_type)
+                    raise click.BadParameter(
+                        f"option requires a value.\n{usage}",
+                        ctx=ctx,
+                        param=param,
+                    ) from e
+            raise
+
+
+def _parse_and_check_kind_config(
+    ctx: click.Context,
+    param: click.Parameter,
+    raw: str,
+    discriminator: str,
+    registry_type: type[PydanticClassRegistryMixin],  # type: ignore[type-arg]
+    usage: str,
+) -> dict[str, Any]:
+    """
+    Parse a registry config string and require a valid discriminator value.
+
+    :param ctx: Click context
+    :param param: Click parameter
+    :param raw: Raw CLI string value
+    :param discriminator: Discriminator field name (e.g. ``"kind"``)
+    :param registry_type: Registry used to validate the discriminator value
+    :param usage: Preformatted usage hint to append on errors
+    :return: Parsed config dictionary
+    :raises click.BadParameter: When parsing fails, the value is not a dict
+        with the required discriminator key, or the kind is unregistered
+    """
+    try:
+        parsed = parse_arguments(ctx, param, raw)
+    except click.BadParameter as e:
+        raise click.BadParameter(
+            f"{e.message}\n{usage}",
+            ctx=ctx,
+            param=param,
+        ) from e
+
+    if not isinstance(parsed, dict):
+        raise click.BadParameter(
+            f"invalid config value (expected key=value pairs or "
+            f"JSON/YAML object).\n{usage}",
+            ctx=ctx,
+            param=param,
+        )
+
+    if discriminator not in parsed:
+        raise click.BadParameter(
+            f"missing required key '{discriminator}'.\n{usage}",
+            ctx=ctx,
+            param=param,
+        )
+
+    # Reject unknown kinds early so the error is a single clean usage block.
+    kind_value = parsed[discriminator]
+    valid_kinds = registry_type.registered_names()
+    if kind_value not in valid_kinds:
+        raise click.BadParameter(
+            f"invalid {discriminator} {kind_value!r}.\n{usage}",
+            ctx=ctx,
+            param=param,
+        )
+    return parsed
+
+
 def _make_common_field_callback(
     is_list: bool,
     discriminator: str,
@@ -87,20 +228,7 @@ def _make_common_field_callback(
     :param registry_type: The registry subclass for error messages
     :return: A Click callback function
     """
-
-    def _parse_and_check(
-        ctx: click.Context, param: click.Parameter, raw: str
-    ) -> dict[str, Any]:
-        parsed = parse_arguments(ctx, param, raw)
-        if isinstance(parsed, dict) and discriminator not in parsed:
-            names = registry_type.registered_names()
-            choices = ", ".join(names) if names else "(none registered)"
-            raise click.BadParameter(
-                f"missing required key '{discriminator}'. Valid options: {choices}",
-                ctx=ctx,
-                param=param,
-            )
-        return parsed
+    usage = format_kind_config_usage(registry_type, discriminator)
 
     def callback(
         ctx: click.Context,
@@ -110,11 +238,18 @@ def _make_common_field_callback(
         if is_list:
             if not value:
                 return None
-            return [_parse_and_check(ctx, param, v) for v in value]
+            return [
+                _parse_and_check_kind_config(
+                    ctx, param, v, discriminator, registry_type, usage
+                )
+                for v in value
+            ]
 
         if value is None:
             return None
-        return _parse_and_check(ctx, param, value)
+        return _parse_and_check_kind_config(
+            ctx, param, value, discriminator, registry_type, usage
+        )
 
     return callback
 
@@ -187,6 +322,8 @@ def registry_option(
     if multiple and "help" in extra:
         extra["help"] = f"{extra['help']}  [repeatable]"
     kwargs: dict[str, Any] = {
+        "cls": RegistryConfigOption,
+        "registry_type": registry,
         "type": param_type,
         "multiple": multiple,
         "callback": _make_common_field_callback(
@@ -326,6 +463,49 @@ def _resolve_param_name(
     raise KeyError("Key does not exist")
 
 
+def _resolve_registry_type(
+    loc: tuple[str | int, ...],
+    base_class: type[BaseModel],
+) -> type[PydanticClassRegistryMixin] | None:  # type: ignore[type-arg]
+    """
+    Walk a pydantic error location to the nearest registry-backed field type.
+
+    :param loc: Validation error location tuple
+    :param base_class: Root model to start walking from
+    :return: The registry mixin class if found, otherwise ``None``
+    """
+    current_model: type[BaseModel] = base_class
+
+    for component in loc:
+        if isinstance(component, int):
+            continue
+
+        fields = current_model.model_fields
+        if component not in fields:
+            return None
+
+        annotation = fields[component].annotation
+        if get_origin(annotation) is list:
+            args = get_args(annotation)
+            annotation = args[0] if args else None
+
+        if annotation is None:
+            return None
+
+        try:
+            if issubclass(annotation, PydanticClassRegistryMixin):
+                return annotation
+            if issubclass(annotation, BaseModel):
+                current_model = annotation
+                continue
+        except TypeError:
+            return None
+
+        return None
+
+    return None
+
+
 def format_validation_errors(
     ctx: click.Context,
     err: ValidationError,
@@ -338,6 +518,10 @@ def format_validation_errors(
     ``data[0].synthetic_text.output_tokens``, so callers can identify which
     nested subfield failed rather than only the top-level CLI option.
 
+    For registry shape failures where the stock message does not list kinds
+    (non-object input), appends a usage hint with expected format and valid kinds.
+    Invalid ``kind`` tags are left as-is because pydantic already lists them.
+
     :param ctx: The active Click context
     :param err: The pydantic validation error to translate
     :param base_class: Optional root model class for resolving argument aliases
@@ -348,8 +532,10 @@ def format_validation_errors(
     param_names = set()
     msgs = []
     for e in errs:
-        loc = e.get("loc", ())
+        original_loc = e.get("loc", ())
+        loc = original_loc
         msg = e.get("msg", "validation error")
+        err_type = e.get("type")
 
         top_field: str | None = None
         if len(loc) > 0:
@@ -361,7 +547,17 @@ def format_validation_errors(
             if top_field:
                 param_names.add("--" + top_field.replace("_", "-"))
 
-        msgs.append(_error_to_message(loc, msg))
+        formatted = _error_to_message(loc, msg)
+
+        if (
+            base_class is not None
+            and err_type in _REGISTRY_SHAPE_ERROR_TYPES
+            and (registry := _resolve_registry_type(original_loc, base_class))
+            is not None
+        ):
+            formatted = f"{formatted}\n{format_kind_config_usage(registry)}"
+
+        msgs.append(formatted)
 
     error_msg = "".join(f"\n  - {msg}" for msg in msgs)
     return click.BadParameter(error_msg, ctx=ctx, param_hint=list(param_names))

--- a/src/guidellm/utils/click_pydantic.py
+++ b/src/guidellm/utils/click_pydantic.py
@@ -26,18 +26,15 @@ _REGISTRY_SHAPE_ERROR_TYPES = frozenset({"model_attributes_type"})
 
 def format_kind_config_usage(
     registry_type: type[PydanticClassRegistryMixin],  # type: ignore[type-arg]
-    discriminator: str | None = None,
 ) -> str:
     """
     Build a self-documenting usage hint for a registry-backed config option.
 
     :param registry_type: The ``PydanticClassRegistryMixin`` subclass whose
         registered names are listed
-    :param discriminator: Discriminator field name; defaults to the registry's
-        ``schema_discriminator`` (typically ``"kind"``)
     :return: Multi-line string describing expected format and valid kinds
     """
-    disc = discriminator or registry_type.schema_discriminator
+    disc = registry_type.schema_discriminator
     names = registry_type.registered_names()
     choices = ", ".join(names) if names else "(none registered)"
     return (
@@ -228,7 +225,7 @@ def _make_common_field_callback(
     :param registry_type: The registry subclass for error messages
     :return: A Click callback function
     """
-    usage = format_kind_config_usage(registry_type, discriminator)
+    usage = format_kind_config_usage(registry_type)
 
     def callback(
         ctx: click.Context,

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -57,3 +57,98 @@ def test_run_allows_synthetic_text_without_output_tokens():
 
     assert "Invalid value for --data" not in result.output
     assert "output_tokens" not in result.output
+
+
+@pytest.mark.regression
+def test_run_constraint_bare_word_shows_kind_usage():
+    """
+    A bare non-dict ``--constraint`` value documents expected format and kinds
+    instead of the opaque pydantic dictionary message.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--constraint", "wrong"])
+
+    assert result.exit_code != 0
+    assert "--constraint" in result.output
+    assert "Expected format" in result.output
+    assert "max_requests" in result.output
+    assert "valid dictionary" not in result.output.lower()
+
+
+@pytest.mark.regression
+def test_run_constraint_missing_argument_shows_kind_usage():
+    """
+    ``--constraint`` with no value documents expected format and kinds instead
+    of Click's stock requires-an-argument message.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--constraint"])
+
+    assert result.exit_code != 0
+    assert "requires a value" in result.output
+    assert "Expected format" in result.output
+    assert "max_requests" in result.output
+    assert "Option '--constraint' requires an argument." not in result.output
+
+
+@pytest.mark.regression
+def test_run_constraint_missing_kind_shows_kind_usage():
+    """
+    Dict-like ``--constraint`` input without ``kind`` lists valid kinds.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--constraint", "count=1"])
+
+    assert result.exit_code != 0
+    assert "missing required key 'kind'" in result.output
+    assert "Expected format" in result.output
+    assert "max_requests" in result.output
+
+
+@pytest.mark.regression
+def test_run_constraint_invalid_kind_lists_valid_kinds():
+    """
+    An unknown ``kind`` fails with a single usage block listing valid kinds,
+    without duplicating pydantic's expected-tags list.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--constraint", "kind=bogus"])
+
+    assert result.exit_code != 0
+    assert "invalid kind 'bogus'" in result.output
+    assert "Expected format" in result.output
+    assert "max_requests" in result.output
+    assert "expected tags" not in result.output
+
+
+@pytest.mark.regression
+def test_run_constraint_missing_field_stays_specific():
+    """
+    A valid kind with a missing required field reports the field error without
+    drowning it in generic format help.
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "run",
+            "--data",
+            "kind=synthetic_text,prompt_tokens=128",
+            "--constraint",
+            "kind=max_requests",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "count" in result.output or "Field required" in result.output
+    assert "Expected format" not in result.output

--- a/tests/unit/utils/test_click_pydantic.py
+++ b/tests/unit/utils/test_click_pydantic.py
@@ -6,12 +6,18 @@ from typing import Any
 
 import click
 import pytest
+from click.testing import CliRunner
 from pydantic import BaseModel, Field, ValidationError
 
+from guidellm.scheduler.constraints import ConstraintArgs
 from guidellm.utils.click_pydantic import (
+    RegistryAwareCommand,
     _error_to_message,
     _resolve_param_name,
+    _resolve_registry_type,
+    format_kind_config_usage,
     format_validation_errors,
+    registry_option,
 )
 
 
@@ -262,3 +268,208 @@ class TestErrorToMessage:
             "Input should be a valid number",
         )
         assert formatted == "Input should be a valid number (at 'rate')"
+
+
+@pytest.mark.smoke
+class TestFormatKindConfigUsage:
+    """Tests for format_kind_config_usage helper.
+
+    ## WRITTEN BY AI ##
+    """
+
+    def test_lists_registered_kinds_and_format(self):
+        """Usage text includes expected format and all registered kinds.
+
+        ## WRITTEN BY AI ##
+        """
+        usage = format_kind_config_usage(ConstraintArgs)
+        assert "kind=<type>,key=value" in usage
+        assert "JSON/YAML" in usage
+        assert "max_requests" in usage
+        assert "max_duration" in usage
+
+
+@pytest.mark.sanity
+class TestRegistryOptionErrors:
+    """Tests for registry_option early rejection and missing-arg UX.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @staticmethod
+    def _make_command(*, multiple: bool = False):
+        @click.command(cls=RegistryAwareCommand)
+        @registry_option("--cfg", "cfg", registry=ConstraintArgs, multiple=multiple)
+        def cmd(cfg):
+            click.echo(repr(cfg))
+
+        return cmd
+
+    def test_bare_word_shows_usage_and_kinds(self):
+        """Non-dict values are rejected with format help and kind list.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(self._make_command(), ["--cfg", "wrong"])
+        assert result.exit_code != 0
+        assert "Expected format" in result.output
+        assert "max_requests" in result.output
+        assert "valid dictionary" not in result.output.lower()
+
+    def test_missing_argument_shows_usage_and_kinds(self):
+        """Bare ``--cfg`` without a value documents expected format and kinds.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(self._make_command(), ["--cfg"])
+        assert result.exit_code != 0
+        assert "requires a value" in result.output
+        assert "Expected format" in result.output
+        assert "max_requests" in result.output
+        assert "Option '--cfg' requires an argument." not in result.output
+
+    def test_missing_kind_key_shows_usage(self):
+        """Dict-like input missing ``kind`` uses the shared usage wording.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(self._make_command(), ["--cfg", "count=1"])
+        assert result.exit_code != 0
+        assert "missing required key 'kind'" in result.output
+        assert "Expected format" in result.output
+        assert "max_requests" in result.output
+
+    def test_invalid_kind_shows_usage_once(self):
+        """Unknown kind values get one usage block without pydantic tag duplication.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(self._make_command(), ["--cfg", "kind=bogus"])
+        assert result.exit_code != 0
+        assert "invalid kind 'bogus'" in result.output
+        assert "Expected format" in result.output
+        assert "max_requests" in result.output
+        assert "expected tags" not in result.output
+
+    def test_multiple_missing_argument_shows_usage(self):
+        """Repeatable registry options also document missing values.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(self._make_command(multiple=True), ["--cfg"])
+        assert result.exit_code != 0
+        assert "requires a value" in result.output
+        assert "Expected format" in result.output
+
+
+@pytest.mark.sanity
+class TestFormatValidationErrorsRegistryHints:
+    """Tests for appending kind usage on registry-shape pydantic errors.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @staticmethod
+    def _make_ctx() -> click.Context:
+        return click.Context(click.Command("test"))
+
+    def test_appends_usage_for_non_object_input(self):
+        """Non-dict registry values get a usage hint in the BadParameter.
+
+        ## WRITTEN BY AI ##
+        """
+
+        class _Model(BaseModel):
+            constraints: list[ConstraintArgs] = Field(  # type: ignore[assignment]
+                default_factory=list,
+                json_schema_extra={"argument_alias": "constraint"},
+            )
+
+        try:
+            _Model.model_validate({"constraints": ["wrong"]})
+        except ValidationError as err:
+            result = format_validation_errors(self._make_ctx(), err, base_class=_Model)
+
+        msg = result.format_message()
+        assert "Expected format" in msg
+        assert "max_requests" in msg
+        assert "--constraint" in msg
+
+    def test_does_not_append_usage_for_invalid_kind(self):
+        """Invalid kind tags already list valid kinds; do not append usage again.
+
+        ## WRITTEN BY AI ##
+        """
+
+        class _Model(BaseModel):
+            constraints: list[ConstraintArgs] = Field(  # type: ignore[assignment]
+                default_factory=list,
+                json_schema_extra={"argument_alias": "constraint"},
+            )
+
+        try:
+            _Model.model_validate({"constraints": [{"kind": "bogus"}]})
+        except ValidationError as err:
+            result = format_validation_errors(self._make_ctx(), err, base_class=_Model)
+
+        msg = result.format_message()
+        assert "bogus" in msg
+        assert "max_requests" in msg
+        assert "Expected format" not in msg
+
+    def test_does_not_append_usage_for_missing_field(self):
+        """Normal field errors stay specific without generic format spam.
+
+        ## WRITTEN BY AI ##
+        """
+
+        class _Model(BaseModel):
+            constraints: list[ConstraintArgs] = Field(  # type: ignore[assignment]
+                default_factory=list,
+                json_schema_extra={"argument_alias": "constraint"},
+            )
+
+        try:
+            _Model.model_validate({"constraints": [{"kind": "max_requests"}]})
+        except ValidationError as err:
+            result = format_validation_errors(self._make_ctx(), err, base_class=_Model)
+
+        msg = result.format_message()
+        assert "Field required" in msg or "count" in msg
+        assert "Expected format" not in msg
+
+
+@pytest.mark.smoke
+class TestResolveRegistryType:
+    """Tests for _resolve_registry_type loc walking.
+
+    ## WRITTEN BY AI ##
+    """
+
+    def test_resolves_list_registry_field(self):
+        """Finds the registry class for a list[ConstraintArgs] field.
+
+        ## WRITTEN BY AI ##
+        """
+
+        class _Model(BaseModel):
+            constraints: list[ConstraintArgs] = Field(default_factory=list)
+
+        resolved = _resolve_registry_type(("constraints", 0), _Model)
+        assert resolved is ConstraintArgs
+
+    def test_unknown_field_returns_none(self):
+        """Returns None when the loc does not match a registry field.
+
+        ## WRITTEN BY AI ##
+        """
+
+        class _Model(BaseModel):
+            count: int = 0
+
+        assert _resolve_registry_type(("count",), _Model) is None


### PR DESCRIPTION
## Summary

This adds a more useful error message to all `kind`-based discriminator inputs.

I found the refactor to the `kind` system reduced the user friendliness of the CLI. I find this to be a huge improvement. 

## Details

- Adds a centrally located class that's added once with `cls=RegistryAwareCommand` that intersects all errors to determine if it's a kind based error, and if so it shows the expected format and the valid `kind` values.

Inputs to `guidellm run` and the error message created:

Just `--constraint`
```
Usage: guidellm run [OPTIONS]
Try 'guidellm run --help' for help.

Error: Invalid value for '--constraint': option requires a value.
Expected format: kind=<type>,key=value,... or JSON/YAML object with a 'kind' field
  Valid kinds: max_errors, max_error_rate, max_global_error_rate, max_duration, max_requests, over_saturation
```

Without the key-value pair format (`--constraint nodict`)
```
Usage: guidellm run [OPTIONS]
Try 'guidellm run --help' for help.

Error: Invalid value for '--constraint': invalid config value (expected key=value pairs or JSON/YAML object).
Expected format: kind=<type>,key=value,... or JSON/YAML object with a 'kind' field
  Valid kinds: max_errors, max_error_rate, max_global_error_rate, max_duration, max_requests, over_saturation
```

Without the kind field ( --constraint nokind=test)
```
Usage: guidellm run [OPTIONS]
Try 'guidellm run --help' for help.

Error: Invalid value for '--constraint': missing required key 'kind'.
Expected format: kind=<type>,key=value,... or JSON/YAML object with a 'kind' field
  Valid kinds: max_errors, max_error_rate, max_global_error_rate, max_duration, max_requests, over_saturation
```

With an invalid kind value (--constraint kind=wrong)
```
Usage: guidellm run [OPTIONS]
Try 'guidellm run --help' for help.

Error: Invalid value for '--constraint': invalid kind 'wrong'.
Expected format: kind=<type>,key=value,... or JSON/YAML object with a 'kind' field
  Valid kinds: max_errors, max_error_rate, max_global_error_rate, max_duration, max_requests, over_saturation
```

Does not affect when you correctly input the kind (--constraint kind=max_duration)
```
Usage: guidellm run [OPTIONS]
Try 'guidellm run --help' for help.

Error: Invalid value for '--constraint':
  - Field required (at 'constraints[1].max_duration.seconds')
```

Example with different CLI options (from-file and --output)
```
Usage: guidellm benchmark from-file [OPTIONS] [PATH]
Try 'guidellm benchmark from-file --help' for help.

Error: Invalid value for '--output': option requires a value.
Expected format: kind=<type>,key=value,... or JSON/YAML object with a 'kind' field
  Valid kinds: console, csv, html, plot, json, yaml
```


## Test Plan

- Includes test cases
- I would recommend testing this with missing fields as shown, but with other config options than `constraint` or `output`

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit a762c9c961bcc933d41cd4e655676d1e9a4738ea
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Jul 22 16:19:22 2026 -0400

    Added more useful error messages for kind inputs
    
    Generated-by: Cursor AI
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 47bd6d49978b8e435a56a96c12191ae55e82e357
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Jul 22 17:34:01 2026 -0400

    Handle empty args for preprocess dataset command
    
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 0f84a0731b1460039abf4f16e2d1a94402c3069d
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Jul 23 11:45:37 2026 -0400

    Remove unnecessary parameter
    
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
