### PR TITLE
Fix typo in pyproject.toml comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,7 +293,7 @@ select = [
     "N806",    # allow uppercase variable names in tests
     "PGH003",  # allow general ignores in tests
     "S106",    # allow hardcoded passwords in tests
-    "PLR0915", # allow complext statements in tests
+    "PLR0915", # allow complex statements in tests
 ]
 "scripts/**/*.py" = [
     "T201",    # print statements are the primary output mechanism for scripts


### PR DESCRIPTION
## Summary

Fix a typo in a ruff lint rule comment in `pyproject.toml`.

## Changes

- Fixed "complext" → "complex" in the PLR0915 rule comment (line 296)

## Testing

N/A — comment-only change verified by grep.

<!-- begin:squash-data -->

---

# git log

commit 1f5be5249bda141937912a042fae8f19ad91b7ef
Author: arijitroy003 <arijitroy003@gmail.com>
Date:   Thu Jul 23 15:31:06 2026 +0530

    Fix typo in pyproject.toml: complext → complex
    
    Signed-off-by: arijitroy003 <arijitroy003@gmail.com>

---------

Signed-off-by: arijitroy003 <arijitroy003@gmail.com>
