### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ where = ["src"]
 include = ["*"]
 
 [tool.setuptools.package-data]
+guidellm = ["py.typed"]
 "guidellm.data" = ["*.gz"]
 "guidellm.benchmark.scenarios" = ["*.json", "**/*.json"]
 


### PR DESCRIPTION
## Summary

Adds a py.typed marker file to enable type checkers to use the inline type hints already present in the package.

## Changes

- Created empty `py.typed` marker file in `src/guidellm/`
- Updated `pyproject.toml` to include `py.typed` in package data

## Testing

Verified by checking:
- File exists in correct location (`src/guidellm/py.typed`)
- Package data configuration includes the marker file

<!-- begin:squash-data -->

---

# git log

commit 99d0de35310f79b8451db9130dbf1be4e8cbb5e1
Author: arijitroy003 <arijitroy003@gmail.com>
Date:   Thu Jul 23 20:30:00 2026 +0530

    Add py.typed marker for PEP 561 compliance
    
    Signed-off-by: arijitroy003 <arijitroy003@gmail.com>

---------

Signed-off-by: arijitroy003 <arijitroy003@gmail.com>
