### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Reporting security issues
+
+Please report security issues privately using [the vulnerability submission form](https://github.com/vllm-project/guidellm/security/advisories/new).
+
+## Issue triage
+
+Reports will be triaged by the GuideLLM maintainers and coordinated with the broader [vLLM vulnerability management team](https://docs.vllm.ai/en/latest/contributing/vulnerability_management.html) when applicable.
+
+## Threat model
+
+GuideLLM is a benchmarking and performance testing tool for large language models. Security considerations include:
+
+- **Remote execution contexts**: GuideLLM may connect to remote LLM endpoints. Ensure proper authentication and network security when benchmarking production systems.
+- **Data handling**: Benchmark data and prompts may contain sensitive information. Use appropriate data classification and access controls.
+- **Model security**: Please see [PyTorch's Security Policy](https://github.com/pytorch/pytorch/blob/main/SECURITY.md) for more information and recommendations on how to securely interact with models.
+
+For broader security guidance related to vLLM deployments, see the [Security Guide in the vLLM documentation](https://docs.vllm.ai/en/latest/usage/security.html).
+
+## Issue severity
+
+We will determine the risk of each issue, taking into account our experience dealing with past issues, versions affected, common defaults, and use cases. We use the following severity categories:
+
+### CRITICAL Severity
+
+Vulnerabilities that allow remote attackers to execute arbitrary code, take full control of the system, or significantly compromise confidentiality, integrity, or availability without any interaction or privileges needed, examples include remote code execution via network, deserialization issues that allow exploit chains. Generally those issues which are rated as CVSS  ≥ 9.0.
+
+### HIGH Severity
+
+Serious security flaws that allow elevated impact—like RCE in specific, limited contexts or significant data loss—but require advanced conditions or some trust, examples include RCE in advanced deployment modes or high impact issues where some sort of privileged network access is required. These issues typically have CVSS scores between 7.0 and 8.9
+
+### MODERATE Severity
+
+Vulnerabilities that cause denial of service or partial disruption, but do not allow arbitrary code execution or data breach and have limited impact. These issues have a CVSS rating between 4.0 and 6.9
+
+### LOW Severity
+
+Minor issues such as informational disclosures, logging errors, non-exploitable flaws, or weaknesses that require local or high-privilege access and offer negligible impact. Examples include side channel attacks or hash collisions. These issues often have CVSS scores less than 4.0
+
+## Fix disclosure policy
+
+When a security report is accepted, the fix process depends on the severity:
+
+* **CRITICAL and HIGH severity**: Fixes are developed in a private security fork and coordinated with the prenotification group before public disclosure.
+* **MODERATE and LOW severity**: Fixes are developed and submitted as public pull requests. These issues do not require embargo since they do not enable arbitrary code execution or significant data breach, and public visibility accelerates community review and adoption of the fix.
+
+The maintainers reserve the right to adjust the disclosure approach on a case-by-case basis, taking into account factors such as active exploitation, unusual attack surface, or coordination requirements with downstream vendors.
+
+## Prenotification policy
+
+For certain security issues of CRITICAL, HIGH, or MODERATE severity level, we may prenotify certain organizations or vendors that ship GuideLLM. The purpose of this prenotification is to allow for a coordinated release of fixes for severe issues.
+
+* This prenotification will be in the form of a private email notification. It may also include adding security contacts to the GitHub security advisory, typically a few days before release.
+
+* If you wish to be added to the prenotification group, please contact the GuideLLM maintainers through the project's communication channels.
+
+* Organizations and vendors who either ship or use GuideLLM are eligible to join the prenotification group if they meet at least one of the following qualifications:
+    * Substantial internal deployment leveraging the upstream GuideLLM project.
+    * Established internal security teams and comprehensive compliance measures.
+    * Active and consistent contributions to the upstream GuideLLM project.
+
+* We may withdraw organizations from receiving future prenotifications if they release fixes or any other information about issues before they are public. Group membership may also change based on policy refinements for who may be included.


### PR DESCRIPTION
## Summary

Adds SECURITY.md for guidellm — a 1.4k-star LLM benchmarking tool currently lacking a vulnerability reporting path.

## Changes

- Added SECURITY.md based on vllm-project/vllm template
- Defines private vulnerability reporting process via GitHub security advisories
- Establishes severity classification (CRITICAL/HIGH/MODERATE/LOW) based on CVSS scoring
- Specifies fix disclosure policy coordinated with vLLM vulnerability management team
- Includes GuideLLM-specific threat model covering remote execution contexts and data handling

## Testing

N/A — verified by grep / visual inspection.

<!-- begin:squash-data -->

---

# git log

commit d5bbe04b9a8ece84d87eadff556abe611755c9ff
Author: arijitroy003 <arijitroy003@gmail.com>
Date:   Sun Jul 26 23:30:19 2026 +0530

    Add SECURITY.md with vulnerability reporting policy
    
    Signed-off-by: arijitroy003 <arijitroy003@gmail.com>

---------

Signed-off-by: arijitroy003 <arijitroy003@gmail.com>
