### PR TITLE
Prevent .env files from tainting tests

### DIFF
--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -22,7 +22,7 @@ def test_default_settings(mocker):
         {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
         clear=True,
     )
-    settings = Settings()
+    settings = Settings(_env_file=None)
     assert settings.logging == LoggingSettings()
     assert settings.report_generation.source.startswith(BASE_URL)
 
@@ -68,7 +68,7 @@ def test_generate_env_file(mocker):
         {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
         clear=True,
     )
-    settings = Settings()
+    settings = Settings(_env_file=None)
     env_file_content = settings.generate_env_file()
     assert "GUIDELLM__LOGGING__DISABLED" in env_file_content
 
@@ -124,7 +124,7 @@ def test_table_properties_defaults(mocker):
         {k: v for k, v in os.environ.items() if not k.startswith("GUIDELLM__")},
         clear=True,
     )
-    settings = Settings()
+    settings = Settings(_env_file=None)
     assert settings.table_border_char == "="
     assert settings.table_headers_border_char == "-"
     assert settings.table_column_separator_char == "|"


### PR DESCRIPTION
## Summary

This is a follow up to #751. I discovered that .env files were not addressed by my prior fix.

## Details

- Just instructs the tests to ignore the .env file.

## Test Plan

Just run the tests normally and with a .env file that includes values that cause problems with the tests, like `GUIDELLM__LOGGING__CONSOLE_LOG_LEVEL=DEBUG`

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Relates to #751 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 0acbbb4f67dbf9bb27982a44f77981f1f81b1202
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Mon Jul 27 17:46:08 2026 -0400

    Prevent .env files from tainting tests
    
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Signed-off-by: Jared O'Connell <joconnel@redhat.com>
