### PR TITLE
Make plot path behave like others

### DIFF
--- a/src/guidellm/benchmark/outputs/plot.py
+++ b/src/guidellm/benchmark/outputs/plot.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from pydantic import Field, field_validator
 
+from guidellm import settings
 from guidellm.benchmark.outputs.output import GenerativeBenchmarkerOutput
 from guidellm.benchmark.schemas import (
     BenchmarkOutputArgs,
@@ -56,7 +57,7 @@ class PlotBenchmarkOutputArgs(BenchmarkOutputArgs):
         description="Type identifier for the plot configuration.",
     )
     path: Path = Field(
-        default_factory=lambda: Path("./benchmarks.png"),
+        default_factory=lambda: settings.default_results_dir / "benchmarks.png",
         description="The file to save the output plot to.",
     )
     dpi: int = Field(


### PR DESCRIPTION
## Summary

The PLOT output kind path default doesn't use "default results dir".

## Details

The timing of merges meant that the PLOT output path missed the introduction of `GUIDELLM__DEFAULT_RESULTS_DIR`.

(I'm really tempted to take this further and merge basedir + name + suffix intelligently; but for now I'll settle for bringing this up to par with the others.)

## Test Plan

- `GUIDELLM__DEFAULT_RESULTS_DIR=/tmp guidellm export --output kind=plot` should write `/tmp/benchmarks.png`

## Related Issues

N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 04e693b4ef55bc282e3162ae76e9d69b367da240
Author: David Butenhof <dbutenho@redhat.com>
Date:   Wed Jul 29 16:26:49 2026 -0400

    Make plot path behave like others
    
    The PLOT output PR was handled in parallel with the addition of
    `GUIDELLM__DEFAULT_RESULTS_DIR` and didn't get that change.
    
    I'm really tempted to take this further and merge basedir + name + suffix
    intelligently; but for now I'll settle for bringing this up to par with the
    others.
    
    Signed-off-by: David Butenhof <dbutenho@redhat.com>

---------

Signed-off-by: David Butenhof <dbutenho@redhat.com>
