### PR TITLE
Fix non-streaming audio response parsing

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -1332,6 +1332,48 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
 
         return arguments
 
+    def compile_non_streaming(
+        self,
+        request: GenerationRequest,
+        arguments: GenerationRequestArguments,
+        response: dict,
+    ) -> GenerationResponse:
+        """
+        Process a complete audio transcription or translation response.
+
+        :param request: Original generation request
+        :param arguments: The request arguments that were sent
+        :param response: Complete API response containing top-level text and usage
+        :return: Standardized GenerationResponse with extracted text and metrics
+        """
+        text = response.get("text")
+        input_metrics, output_metrics = self.extract_metrics(
+            response.get("usage"), text
+        )
+
+        return GenerationResponse(
+            request_id=request.request_id,
+            request_args=arguments.model_dump_json(),
+            response_id=response.get("id"),
+            text=text,
+            input_metrics=input_metrics,
+            output_metrics=output_metrics,
+        )
+
+    def post_validation(self, response: GenerationResponse) -> None:
+        """Reject audio responses that omit the transcription text field.
+
+        An empty string is a valid transcription for silent or VAD-filtered audio.
+
+        :param response: The compiled audio response to validate.
+        :raises ValueError: If the response has no transcription text field.
+        """
+        if response.text is None:
+            raise ValueError(
+                "[UNUSABLE_BACKEND_RESPONSE] backend resolved with empty response "
+                "payload"
+            )
+
     def extract_metrics(
         self, usage: dict[str, int | dict[str, int]] | None, text: str | None
     ) -> tuple[UsageMetrics, UsageMetrics]:

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2411,6 +2411,90 @@ class TestAudioRequestHandler:
         assert result.body.get("temperature") == 0.0
 
     # Response handling tests
+    @pytest.mark.regression
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"text": "Hello world"},
+            {
+                "task": "transcribe",
+                "language": "english",
+                "duration": 1.0,
+                "text": "Hello world",
+                "segments": [],
+            },
+        ],
+    )
+    def test_compile_non_streaming_top_level_text(self, valid_instances, response):
+        """Test basic and verbose audio responses use top-level text.
+
+        ## WRITTEN BY AI ##
+        """
+        request = GenerationRequest(columns={})
+        arguments = GenerationRequestArguments(body={"model": "whisper"})
+
+        result = valid_instances.compile_non_streaming(request, arguments, response)
+
+        assert result.text == "Hello world"
+        assert result.output_metrics.text_words == 2
+        assert result.output_metrics.text_characters == 11
+        valid_instances.post_validation(result)
+
+    @pytest.mark.regression
+    def test_compile_non_streaming_preserves_usage(self, valid_instances):
+        """Test audio token usage is compiled with top-level text.
+
+        ## WRITTEN BY AI ##
+        """
+        request = GenerationRequest(columns={})
+        arguments = GenerationRequestArguments()
+        response = {
+            "id": "transcription-1",
+            "text": "Hello world",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+        }
+
+        result = valid_instances.compile_non_streaming(request, arguments, response)
+
+        assert result.response_id == "transcription-1"
+        assert result.input_metrics.audio_tokens == 10
+        assert result.output_metrics.text_tokens == 2
+
+    @pytest.mark.regression
+    def test_post_validation_accepts_empty_transcription(self, valid_instances):
+        """Test an explicitly empty transcription remains valid.
+
+        ## WRITTEN BY AI ##
+        """
+        request = GenerationRequest(columns={})
+        result = valid_instances.compile_non_streaming(
+            request,
+            GenerationRequestArguments(),
+            {"text": ""},
+        )
+
+        assert result.text == ""
+        assert result.output_metrics.text_words == 0
+        assert result.output_metrics.text_characters == 0
+        valid_instances.post_validation(result)
+
+    @pytest.mark.regression
+    def test_post_validation_rejects_missing_transcription(self, valid_instances):
+        """Test a response without top-level text remains unusable.
+
+        ## WRITTEN BY AI ##
+        """
+        request = GenerationRequest(columns={})
+        result = valid_instances.compile_non_streaming(
+            request,
+            GenerationRequestArguments(),
+            {},
+        )
+
+        assert result.text is None
+        with pytest.raises(ValueError, match="UNUSABLE_BACKEND_RESPONSE"):
+            valid_instances.post_validation(result)
+
     @pytest.mark.smoke
     @pytest.mark.parametrize(
         (


### PR DESCRIPTION
## Summary

- parse top-level text from non-streaming transcription and translation responses
- preserve audio usage metrics and response IDs
- accept explicit empty transcriptions while rejecting responses that omit text
- add regression coverage for basic, verbose, empty, missing, and usage-bearing responses

## Testing

- tox -e tests -- tests/unit/backends/openai/test_request_handlers.py -k TestAudioRequestHandler
- tox -e lint-check
- tox -e type-check -- src/guidellm/backends/openai/request_handlers.py

Closes #980

<!-- begin:squash-data -->

---

# git log

commit 5dc5dac905a7948420bf4a223bf4722fdc6da660
Author: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
Date:   Sun Aug 2 18:08:11 2026 -0700

    fix: parse non-streaming audio responses
    
    Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>

---------

Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
