### PR TITLE
fix(openai): allow opting out of ignore_eos for end-of-turn-sensitive models (#979)

### DIFF
--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -151,6 +151,9 @@ guidellm run \
 
 Values in `extras.body` are merged into the request body and take precedence over the defaults, so `ignore_eos: false` overrides the built-in `true`. Leave `ignore_eos` unset (the default) for models where suppressing the end-of-sequence token is safe, which lets GuideLLM control the exact output length.
 
+> [!NOTE]
+> Removing `ignore_eos: true` allows the model to stop generating at its discretion which can result in significantly shorter sequence lengths than desired.
+
 ## Structured Chat Content Payloads
 
 Some chat templates require metadata alongside the text in each structured content object. Pass these fields through `extras.content` in the `openai_http` backend configuration. GuideLLM adds them to every generated text content object for Chat Completions and Responses API requests.

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -151,8 +151,7 @@ guidellm run \
 
 Values in `extras.body` are merged into the request body and take precedence over the defaults, so `ignore_eos: false` overrides the built-in `true`. Leave `ignore_eos` unset (the default) for models where suppressing the end-of-sequence token is safe, which lets GuideLLM control the exact output length.
 
-> [!NOTE]
-> Removing `ignore_eos: true` allows the model to stop generating at its discretion which can result in significantly shorter sequence lengths than desired.
+> [!NOTE] Removing `ignore_eos: true` allows the model to stop generating at its discretion which can result in significantly shorter sequence lengths than desired.
 
 ## Structured Chat Content Payloads
 

--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -129,6 +129,28 @@ guidellm run \
 
 This will include `temperature`, `top_p`, and `top_k` in every request body sent to the server.
 
+## Controlling End-of-Sequence Behavior
+
+To measure throughput and latency for an exact output length, GuideLLM asks the server to generate precisely the requested number of tokens. For the `openai_http` backend, when you request a specific output token count each request sets `ignore_eos: true` (alongside `max_tokens`/`max_completion_tokens` and `stop: null`) so the server keeps generating instead of stopping when the model emits an end-of-sequence token.
+
+Some models should not have their end-of-sequence token suppressed. Formats such as Harmony / `gpt-oss` expect the model to stop on its own end-of-turn token; forcing generation past it makes the server reject the trailing tokens and fail the request. For these (or similar) models, disable `ignore_eos` by passing `false` through the backend `extras.body` field:
+
+```bash
+guidellm run \
+  --backend '{"kind":"openai_http","target":"http://localhost:8000/v1","model":"openai/gpt-oss-20b","extras":{"body":{"ignore_eos":false}}}' \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128
+```
+
+Or using GuideLLM's compact `key=value` parser:
+
+```bash
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000/v1,model=openai/gpt-oss-20b,extras.body.ignore_eos=false \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128
+```
+
+Values in `extras.body` are merged into the request body and take precedence over the defaults, so `ignore_eos: false` overrides the built-in `true`. Leave `ignore_eos` unset (the default) for models where suppressing the end-of-sequence token is safe, which lets GuideLLM control the exact output length.
+
 ## Structured Chat Content Payloads
 
 Some chat templates require metadata alongside the text in each structured content object. Pass these fields through `extras.content` in the `openai_http` backend configuration. GuideLLM adds them to every generated text content object for Chat Completions and Responses API requests.


### PR DESCRIPTION
Fixes #979.

## Problem

`ignore_eos` is set unconditionally on all three OpenAI generation paths whenever an output-token count is requested:

| path | site |
|---|---|
| `/v1/completions` | `request_handlers.py` — `arguments.body["ignore_eos"] = True` |
| `/v1/chat/completions` | `request_handlers.py` — `body.update({..., "ignore_eos": True})` |
| `/v1/responses` | `request_handlers.py` — `arguments.body["ignore_eos"] = True` |

For a model whose response format carries its own end-of-turn token, suppressing EOS makes generation continue past the end of the turn and the server rejects what follows. On `openai/gpt-oss-120b` (Harmony, `<|return|>`) the reporter measured **971 of 1542 requests failing (65%)** with:

```
ValueError('Streaming response returned an error: Unexpected token 200002 while expecting start token 200006')
```

The error rate scales with output length — at OSL 128 the model rarely finishes a turn, so nothing errors; at OSL 1024 most requests do. Percentiles are computed over successful requests only, so the run still reports a plausible-looking number derived from the ~35% that survived.

## Change

The same file already carves this out for tool calling, where `ignore_eos` is popped because constrained decoding needs the model to stop on its own:

> Tool calling requires the model to stop naturally after producing valid JSON; `ignore_eos` would force generation past that point and break the server's constrained decoding grammar.

Harmony is the same class of problem, so this adds a backend-level knob rather than a model-name heuristic (issue option 3):

```bash
guidellm run \
  --backend kind=openai_http,target=http://127.0.0.1:8000,model=openai/gpt-oss-120b,ignore_eos=false \
  --profile kind=sweep \
  --data kind=synthetic_text,prompt_tokens=1024,output_tokens=1024
```

- `OpenAIHTTPBackendArgs.ignore_eos: bool = True` — default unchanged, so existing benchmarks behave identically.
- Threaded through the existing `request_handler.format(...)` kwargs alongside `stream` / `max_tokens`, and honored at all three sites.
- When disabled the key is **omitted** rather than sent as `false`, matching how the handlers already drop `None`-valued body keys via `deep_filter`.
- `max_tokens` / `max_completion_tokens` / `max_output_tokens` and `stop` are untouched, so output length is still pinned.

Options 1 (auto-detect structured response formats) and 2 (`min_tokens`, the direction of #533) are larger calls about default behavior and are left to maintainers; this only makes the current behavior opt-out-able.

## Tests

Added `test_format_ignore_eos_disabled` to each of the three handler test classes, asserting `ignore_eos` is absent while the token limit still applies. Existing tests that assert `ignore_eos is True` are unchanged and still pass, covering the default.

`ruff format --check` and `ruff check` clean on all three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit dae0dc39928e11404fe9abd28ecc9772abfc900f
Author: Tai An <antai12232931@outlook.com>
Date:   Tue Aug 4 05:00:00 2026 +0000

    docs(backends): document disabling ignore_eos for gpt-oss models (#979)
    
    Per review on #982, the openai_http backend already supports opting out
    of ignore_eos via extras.body.ignore_eos=false, so the code change is
    unnecessary. Instead, document the end-of-sequence behavior and how to
    disable it for Harmony / gpt-oss and other end-of-turn-sensitive models
    in the backends guide.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

commit 55045d213e2d7a59196456464371ee497d1bf4da
Author: Tai An <antai12232931@outlook.com>
Date:   Wed Aug 5 09:20:00 2026 +0000

    docs(backends): note the tradeoff of disabling ignore_eos
    
    Per review feedback on #982, call out that turning off ignore_eos lets
    the model stop at its own discretion, which can produce sequences much
    shorter than the requested output length.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

commit f75e9ee8f683b3eeae5712115ce122824df4d220
Author: Tai An <antai12232931@outlook.com>
Date:   Wed Aug 5 19:04:19 2026 +0000

    docs(backends): apply mdformat to backends guide
    
    Run pre-commit mdformat over docs/backends.md so precommit-checks passes;
    no content change.
    
    Signed-off-by: Tai An <antai12232931@outlook.com>

---------

Signed-off-by: Tai An <antai12232931@outlook.com>
