### PR TITLE
Fix encoded audio sample frame metrics

### DIFF
--- a/src/guidellm/utils/audio.py
+++ b/src/guidellm/utils/audio.py
@@ -81,6 +81,8 @@ def encode_audio(
     If ``audio_format`` is not provided, the format is detected from the
     source codec (via torchcodec metadata). When detection is not possible
     (e.g. raw float tensors), falls back to WAV with a one-time warning.
+    The returned ``audio_samples`` value is the number of frames represented
+    at the encoded output sample rate.
 
     :param audio: Audio input in any supported form.
     :param sample_rate: Sample rate hint for raw decoded audio.
@@ -117,6 +119,7 @@ def encode_audio(
         audio_format=format_val,
         mono=mono,
     )
+    encoded_sample_frames = round(samples.duration_seconds * encode_sample_rate)
 
     return {
         "type": "audio_file",
@@ -126,7 +129,7 @@ def encode_audio(
         else file_name,
         "format": audio_format,
         "mimetype": f"audio/{format_val}",
-        "audio_samples": samples.sample_rate,
+        "audio_samples": encoded_sample_frames,
         "audio_seconds": samples.duration_seconds,
         "audio_bytes": len(encoded_audio),
     }

--- a/tests/unit/utils/test_audio.py
+++ b/tests/unit/utils/test_audio.py
@@ -165,18 +165,64 @@ def test_encode_audio_different_formats(sample_audio_tensor):
         assert result["audio_bytes"] > 0
 
 
-def test_encode_audio_resampling(sample_audio_tensor):
-    original_rate = 16000
-    target_rate = 8000
+@pytest.mark.regression
+@patch("guidellm.utils.audio._encode_audio", return_value=b"encoded_audio")
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_reports_sample_frames_for_non_one_second_audio(
+    mock_decode: MagicMock, mock_encode: MagicMock
+) -> None:
+    """Report encoded frames rather than the coincidentally equal sample rate.
+
+    ## WRITTEN BY AI ##
+    """
+    samples = MagicMock(sample_rate=16000, duration_seconds=2.0)
+    mock_decode.return_value = (samples, None)
 
     result = _audio_mod.encode_audio(
-        audio=sample_audio_tensor,
-        sample_rate=original_rate,
-        encode_sample_rate=target_rate,
+        audio=b"source_audio",
+        encode_sample_rate=16000,
         audio_format="wav",
     )
 
-    assert "audio_samples" in result
+    assert result["audio_seconds"] == 2.0
+    assert result["audio_samples"] == 32000
+    mock_encode.assert_called_once_with(
+        samples=samples,
+        resample_rate=16000,
+        bitrate=64000,
+        audio_format="wav",
+        mono=True,
+    )
+
+
+@pytest.mark.regression
+@patch("guidellm.utils.audio._encode_audio", return_value=b"encoded_audio")
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_reports_resampled_output_frames(
+    mock_decode: MagicMock, mock_encode: MagicMock
+) -> None:
+    """Report frames at the encoded rate after resampling non-one-second audio.
+
+    ## WRITTEN BY AI ##
+    """
+    samples = MagicMock(sample_rate=24000, duration_seconds=1.5)
+    mock_decode.return_value = (samples, None)
+
+    result = _audio_mod.encode_audio(
+        audio=b"source_audio",
+        encode_sample_rate=16000,
+        audio_format="wav",
+    )
+
+    assert result["audio_seconds"] == 1.5
+    assert result["audio_samples"] == 24000
+    mock_encode.assert_called_once_with(
+        samples=samples,
+        resample_rate=16000,
+        bitrate=64000,
+        audio_format="wav",
+        mono=True,
+    )
 
 
 def test_encode_audio_error_handling():
@@ -202,6 +248,10 @@ def test_audio_quality_preservation(sample_audio_tensor):
 
 
 def test_end_to_end_audio_processing(sample_audio_tensor):
+    """Report frame count for the truncated encoded output.
+
+    ## WRITTEN BY AI ##
+    """
     original_samples = sample_audio_tensor.shape[1]
     original_duration = original_samples / 16000
 
@@ -216,7 +266,7 @@ def test_end_to_end_audio_processing(sample_audio_tensor):
     assert result["type"] == "audio_file"
     assert isinstance(result["audio"], bytes)
     assert result["format"] == "mp3"
-    assert result["audio_samples"] == 16000
+    assert result["audio_samples"] == 8000
     assert result["audio_seconds"] == min(original_duration, 0.5)
 
 


### PR DESCRIPTION
## Summary
- report audio_samples as encoded output frames instead of the decoded sample rate
- define encoded frame semantics from output rate and decoded duration
- add regression coverage for non-one-second and resampled audio
- update truncated-audio expectations to reflect encoded frames

## Tests
- uv run tox -e tests -- tests/unit/utils/test_audio.py -k reports (2 passed)
- uv run tox -e lint-check (passed)
- uv run tox -e type-check (passed)
- uv run ruff check src/guidellm/utils/audio.py tests/unit/utils/test_audio.py (passed)

The complete audio unit module was also attempted. Its real codec tests cannot run on this host because FFmpeg is absent, so TorchCodec cannot load its shared libraries; 9 mock-only tests passed and 16 codec-dependent tests failed during library loading.

Fixes #985

<!-- begin:squash-data -->

---

# git log

commit a0e22679e1f0f36e5feb13350194fae9e86f97fc
Author: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
Date:   Mon Aug 3 10:37:32 2026 -0700

    fix: report encoded audio sample frames
    
    Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>

---------

Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
