### PR TITLE
Fix persisted multimodal request payloads

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -422,7 +422,7 @@ def _compile_streaming_response(
 
     return GenerationResponse(
         request_id=request.request_id,
-        request_args=arguments.model_dump_json(),
+        request_args=arguments.model_dump_json_for_persistence(),
         response_id=streaming_response_id,
         text=text,
         reasoning_text=reasoning_text,
@@ -556,7 +556,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_json_for_persistence(),
             response_id=response.get("id"),  # use vLLM ID if available
             text=text,
             input_metrics=input_metrics,
@@ -606,7 +606,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_json_for_persistence(),
             response_id=self.streaming_response_id,  # use vLLM ID if available
             text=text,
             input_metrics=input_metrics,
@@ -1140,7 +1140,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_json_for_persistence(),
             response_id=response.get("id"),  # use vLLM ID if available
             text=text,
             reasoning_text=reasoning_text,
@@ -1504,7 +1504,7 @@ class RealtimeTranscriptionWSRequestHandler(OpenAIWSRequestHandler):
         request_args = arguments.model_copy(update={"body": body or None})
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=request_args.model_dump_json(),
+            request_args=request_args.model_dump_json_for_persistence(),
             text=full_text,
             input_metrics=inp,
             output_metrics=outp,
@@ -1907,7 +1907,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_json_for_persistence(),
             response_id=response.get("id"),
             text=text,
             reasoning_text=reasoning_text,
@@ -2353,7 +2353,7 @@ class EmbeddingsRequestHandler(OpenAIRequestHandler):
         # Build response (no text output for embeddings)
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_json_for_persistence(),
             text="",  # Embeddings don't generate text
             input_metrics=UsageMetrics(
                 text_tokens=usage.get("prompt_tokens", 0),

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -10,6 +10,7 @@ consistent interaction with various AI generation APIs.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 from pydantic import Field, computed_field
@@ -31,6 +32,69 @@ __all__ = [
     "TurnType",
     "UsageMetrics",
 ]
+
+
+def _base64_byte_count(value: str) -> int:
+    """Calculate decoded byte count without allocating the decoded payload."""
+    value_length = len(value)
+    padding = value_length - len(value.rstrip("="))
+    return max((value_length * 3) // 4 - padding, 0)
+
+
+def _sanitize_data_url(value: str) -> str | dict[str, str | int]:
+    """Replace a Base64 data URL with bounded media metadata."""
+    header, separator, payload = value.partition(",")
+    if not separator or not header.startswith("data:") or ";base64" not in header:
+        return value
+
+    mime_type = header.removeprefix("data:").split(";", maxsplit=1)[0]
+    return {
+        "mime_type": mime_type or "application/octet-stream",
+        "encoding": "base64",
+        "byte_count": _base64_byte_count(payload),
+    }
+
+
+def _sanitize_transport_value(value: Any) -> Any:
+    """Recursively replace transport payloads with bounded metadata."""
+    if isinstance(value, bytes | bytearray | memoryview):
+        return {"byte_count": len(value)}
+    if isinstance(value, str):
+        return _sanitize_data_url(value)
+    if isinstance(value, Mapping):
+        sanitized: dict[Any, Any] = {}
+        for key, item in value.items():
+            is_inline_base64 = key == "file_data" or (
+                key == "data" and "format" in value
+            )
+            if is_inline_base64 and isinstance(item, str):
+                sanitized[key] = {
+                    "encoding": "base64",
+                    "byte_count": _base64_byte_count(item),
+                }
+            else:
+                sanitized[key] = _sanitize_transport_value(item)
+        return sanitized
+    if isinstance(value, Sequence):
+        if value:
+            filename, *file_parts = value
+        else:
+            filename, file_parts = None, []
+        if (
+            file_parts
+            and isinstance(filename, str)
+            and isinstance(file_parts[0], bytes | bytearray | memoryview)
+        ):
+            payload, *metadata_parts = file_parts
+            metadata: dict[str, str | int] = {
+                "filename": filename,
+                "byte_count": len(payload),
+            }
+            if metadata_parts and isinstance(metadata_parts[0], str):
+                metadata["mime_type"] = metadata_parts[0]
+            return metadata
+        return [_sanitize_transport_value(item) for item in value]
+    return value
 
 
 class GenerationRequestArguments(StandardBaseDict):
@@ -109,6 +173,19 @@ class GenerationRequestArguments(StandardBaseDict):
                 setattr(self, combine, current)
 
         return self
+
+    def model_dump_json_for_persistence(self) -> str:
+        """
+        Serialize request arguments without retaining transport media payloads.
+
+        Raw bytes, multipart file content, Base64 data URLs, and known inline
+        Base64 file fields are replaced with bounded metadata. Ordinary request
+        parameters and remote media URLs remain unchanged.
+
+        :return: JSON request metadata safe to persist in benchmark reports.
+        """
+        sanitized = _sanitize_transport_value(self.model_dump())
+        return GenerationRequestArguments.model_validate(sanitized).model_dump_json()
 
 
 class UsageMetrics(StandardBaseDict):

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2344,6 +2344,46 @@ class TestAudioRequestHandler:
         assert file_tuple[1] == audio_data
         assert file_tuple[2] == "audio/wav"
 
+    @pytest.mark.regression
+    def test_compile_redacts_audio_payload_from_request_args(self, valid_instances):
+        """Persist audio metadata without retaining the multipart payload.
+
+        ## WRITTEN BY AI ##
+        """
+        audio_data = b"private audio bytes" * 100
+        request = GenerationRequest(
+            columns={
+                "audio_column": [
+                    {
+                        "audio": audio_data,
+                        "file_name": "recording.wav",
+                        "mimetype": "audio/wav",
+                    }
+                ]
+            }
+        )
+        arguments = valid_instances.format(
+            request,
+            model="whisper-1",
+            extras=GenerationRequestArguments(body={"language": "en"}),
+        )
+
+        response = valid_instances.compile_non_streaming(
+            request,
+            arguments,
+            {"choices": [{"message": {"content": "transcript"}}]},
+        )
+        assert response.request_args is not None
+        request_args = json.loads(response.request_args)
+
+        assert request_args["body"] == {"model": "whisper-1", "language": "en"}
+        assert request_args["files"]["file"] == {
+            "filename": "recording.wav",
+            "mime_type": "audio/wav",
+            "byte_count": len(audio_data),
+        }
+        assert len(response.request_args) < 500
+
     @pytest.mark.sanity
     def test_format_missing_audio(self, valid_instances):
         """Test format method raises error when no audio column provided.

--- a/tests/unit/schemas/test_request.py
+++ b/tests/unit/schemas/test_request.py
@@ -4,6 +4,7 @@ Unit tests for GenerationRequest, GenerationRequestArguments, and UsageMetrics.
 
 from __future__ import annotations
 
+import json
 import uuid
 
 import pytest
@@ -256,6 +257,77 @@ class TestGenerationRequestArguments:
         reconstructed = GenerationRequestArguments.model_validate(data_dict)
         for key, expected_value in constructor_args.items():
             assert getattr(reconstructed, key) == expected_value
+
+    @pytest.mark.regression
+    def test_persistence_serialization_redacts_multipart_bytes(self):
+        """Retain multipart metadata without persisting file bytes.
+
+        ## WRITTEN BY AI ##
+        """
+        payload = b"private audio" * 100
+        arguments = GenerationRequestArguments(
+            body={"model": "whisper-1", "language": "en"},
+            files={"file": ("recording.wav", payload, "audio/wav")},
+        )
+
+        persisted = arguments.model_dump_json_for_persistence()
+        result = json.loads(persisted)
+
+        assert len(persisted) < 500
+        assert result["body"] == {"model": "whisper-1", "language": "en"}
+        assert result["files"]["file"] == {
+            "filename": "recording.wav",
+            "mime_type": "audio/wav",
+            "byte_count": len(payload),
+        }
+        assert "private audio" not in persisted
+
+    @pytest.mark.regression
+    def test_persistence_serialization_redacts_inline_multimodal_payloads(self):
+        """Redact inline audio, file, and data URL payloads recursively.
+
+        ## WRITTEN BY AI ##
+        """
+        arguments = GenerationRequestArguments(
+            body={
+                "model": "multimodal-model",
+                "input": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": "cHJpdmF0ZQ==", "format": "wav"},
+                    },
+                    {"type": "input_file", "file_data": "cGRm"},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,aW1hZ2U=",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image.png",
+                    },
+                ],
+                "temperature": 0.2,
+            }
+        )
+
+        result = json.loads(arguments.model_dump_json_for_persistence())
+        inputs = result["body"]["input"]
+
+        assert inputs[0]["input_audio"] == {
+            "data": {"encoding": "base64", "byte_count": 7},
+            "format": "wav",
+        }
+        assert inputs[1]["file_data"] == {
+            "encoding": "base64",
+            "byte_count": 3,
+        }
+        assert inputs[2]["image_url"] == {
+            "mime_type": "image/png",
+            "encoding": "base64",
+            "byte_count": 5,
+        }
+        assert inputs[3]["image_url"] == "https://example.com/image.png"
+        assert result["body"]["temperature"] == 0.2
 
     @pytest.mark.regression
     def test_model_combine_deep_merge_nested_dicts(self):


### PR DESCRIPTION
## Summary

- serialize persisted OpenAI request arguments through a bounded transport-payload sanitizer
- replace multipart bytes, inline Base64 file/audio fields, and Base64 data URLs with filename/MIME/encoding/byte-count metadata where available
- preserve ordinary request parameters and remote media URLs

Central sanitization keeps HTML request samples bounded for media workloads without separately truncating useful request metadata.

## Tests

- uv run tox -e tests -- tests/unit/schemas/test_request.py tests/unit/backends/openai/test_request_handlers.py (308 passed)
- uv run tox -e lint-check
- uv run tox -e type-check
- uv run tox -e test-unit (baseline: 2710 passed; 15 failures caused by unavailable local TorchCodec/FFmpeg dynamic libraries)

Fixes #984

<!-- begin:squash-data -->

---

# git log

commit 3257aaa0ee302406d2854b79ec060e83ace3a93d
Author: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
Date:   Mon Aug 3 10:38:41 2026 -0700

    fix: redact persisted media request payloads
    
    Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>

---------

Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
