### PR TITLE
feat: add OpenTelemetry tracing and context propagation

### DIFF
--- a/docs/guides/opentelemetry-tracing.md
+++ b/docs/guides/opentelemetry-tracing.md
@@ -1,0 +1,28 @@
+# OpenTelemetry Tracing
+
+GuideLLM can emit OpenTelemetry spans for benchmark runs, scheduling strategies, and individual inference requests. HTTP requests and WebSocket handshakes propagate the active W3C `traceparent` and `tracestate` context, allowing instrumented model servers and gateways to join the same distributed trace.
+
+Tracing is disabled by default and the base installation does not require OpenTelemetry. Install the optional dependencies and configure an OTLP collector:
+
+```bash
+pip install 'guidellm[otel]'
+
+export OTEL_SERVICE_NAME=guidellm
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=development
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1
+
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000 \
+  --profile kind=constant \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
+  --constraint kind=max_requests,count=100
+```
+
+The OTLP endpoint is the activation signal for GuideLLM's automatic exporter setup. Both `grpc` and `http/protobuf` protocols are supported. Set `OTEL_SDK_DISABLED=true` to explicitly disable tracing.
+
+Request spans cover the full streamed response lifecycle and record request IDs, backend and model metadata, outcome, error type, token usage, total request latency, and time to first token when available. GuideLLM never adds prompt or response content to spans.
+
+Each worker process initializes tracing from the same environment, so multiprocess benchmarks export request spans without sharing unpickleable SDK objects through the scheduler. As with any high-volume benchmark, use an appropriate sampler and size the collector for the expected span rate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Meta Extras
-all = ["guidellm[perf,tokenizers,audio,vision,plot]"]
+all = ["guidellm[perf,tokenizers,audio,vision,plot,otel]"]
 recommended = ["guidellm[perf,tokenizers]"]
 # Feature Extras
 plot = ["matplotlib>=3.10.9"]
@@ -104,6 +104,11 @@ vision = [
     "datasets[vision]",
     "pillow",
     "imageio[ffmpeg]",
+]
+otel = [
+    "opentelemetry-api>=1.31.0",
+    "opentelemetry-sdk>=1.31.0",
+    "opentelemetry-exporter-otlp>=1.31.0",
 ]
 
 [dependency-groups]

--- a/src/guidellm/backends/openai/http.py
+++ b/src/guidellm/backends/openai/http.py
@@ -29,6 +29,7 @@ from guidellm.schemas import (
     GenerationResponse,
     RequestInfo,
 )
+from guidellm.tracing import inject_trace_headers
 from guidellm.utils.dict import deep_filter
 
 __all__ = [
@@ -448,7 +449,7 @@ class OpenAIHTTPBackend(Backend):
             "url": request_url,
             "method": arguments.method or "POST",
             "params": arguments.params,
-            "headers": self._build_headers(arguments.headers),
+            "headers": inject_trace_headers(self._build_headers(arguments.headers)),
             "json": request_json,
             "data": request_data,
             "files": request_files,

--- a/src/guidellm/backends/openai/websocket.py
+++ b/src/guidellm/backends/openai/websocket.py
@@ -41,6 +41,7 @@ from guidellm.schemas import (
     GenerationResponse,
     RequestInfo,
 )
+from guidellm.tracing import inject_trace_headers
 from guidellm.utils.imports import json
 
 __all__ = [
@@ -434,7 +435,7 @@ class OpenAIWebSocketBackend(Backend):
         session_update["model"] = model_name
 
         ssl_ctx = self._ssl_context()
-        ws_headers = build_headers(self._args.api_key)
+        ws_headers = inject_trace_headers(build_headers(self._args.api_key))
 
         try:
             request_info.timings.request_start = time.time()

--- a/src/guidellm/benchmark/benchmarker.py
+++ b/src/guidellm/benchmark/benchmarker.py
@@ -34,6 +34,7 @@ from guidellm.scheduler import (
     Scheduler,
     SchedulingStrategy,
 )
+from guidellm.tracing import start_span
 from guidellm.utils.mixins import InfoMixin
 from guidellm.utils.singleton import ThreadSafeSingletonMixin
 
@@ -54,7 +55,7 @@ class Benchmarker(
     scheduling strategies and execution environments.
     """
 
-    async def run(
+    async def run(  # noqa: C901
         self,
         accumulator_class: type[BenchmarkAccumulatorT],
         benchmark_class: type[BenchmarkT],
@@ -95,6 +96,13 @@ class Benchmarker(
                 await progress.on_initialize(profile)
 
             run_id = str(uuid.uuid4())
+            run_span = start_span(
+                "guidellm.run",
+                {
+                    "guidellm.run.id": run_id,
+                    "guidellm.profile.type": profile.kind,
+                },
+            )
             strategies_generator = profile.strategies_generator()
             strategy: SchedulingStrategy | None
             constraints: dict[str, Constraint] | None
@@ -128,46 +136,67 @@ class Benchmarker(
                     environment=InfoMixin.extract_from_obj(environment),
                 )
                 accumulator = accumulator_class(config=config)
+                benchmark_span = start_span(
+                    "guidellm.benchmark",
+                    {
+                        "guidellm.run.id": run_id,
+                        "guidellm.benchmark.id": config.id_,
+                        "guidellm.run.index": config.run_index,
+                        "guidellm.strategy.type": strategy.type_,
+                        "guidellm.backend.kind": config.backend.get("kind"),
+                        "server.address": config.backend.get("target"),
+                    },
+                )
                 scheduler_state = None
                 scheduler: Scheduler[RequestT, ResponseT] = Scheduler()
-
-                async for (
-                    response,
-                    request,
-                    request_info,
-                    scheduler_state,
-                ) in scheduler.run(
-                    requests=requests,
-                    backend=backend,
-                    strategy=strategy,
-                    env=environment,
-                    **constraints or {},
-                ):
-                    try:
-                        accumulator.update_estimate(
-                            response,
-                            request,
-                            request_info,
-                            scheduler_state,
-                        )
-                        if progress:
-                            await progress.on_benchmark_update(
-                                accumulator, scheduler_state
+                try:
+                    async for (
+                        response,
+                        request,
+                        request_info,
+                        scheduler_state,
+                    ) in scheduler.run(
+                        requests=requests,
+                        backend=backend,
+                        strategy=strategy,
+                        env=environment,
+                        **constraints or {},
+                    ):
+                        try:
+                            accumulator.update_estimate(
+                                response,
+                                request,
+                                request_info,
+                                scheduler_state,
                             )
-                    except Exception as err:  # noqa: BLE001
-                        logger.error(
-                            "Error updating benchmark estimate/progress: {}", err
-                        )
+                            if progress:
+                                await progress.on_benchmark_update(
+                                    accumulator, scheduler_state
+                                )
+                        except Exception as err:  # noqa: BLE001
+                            logger.error(
+                                "Error updating benchmark estimate/progress: {}", err
+                            )
 
-                benchmark = benchmark_class.compile(
-                    accumulator=accumulator,
-                    scheduler_state=scheduler_state,  # type: ignore[arg-type]
-                )
+                    benchmark = benchmark_class.compile(
+                        accumulator=accumulator,
+                        scheduler_state=scheduler_state,  # type: ignore[arg-type]
+                    )
+                except BaseException as error:
+                    benchmark_span.end(error)
+                    run_span.end(error)
+                    raise
+                else:
+                    benchmark_span.end()
 
-                if progress:
-                    await progress.on_benchmark_complete(benchmark)
+                try:
+                    if progress:
+                        await progress.on_benchmark_complete(benchmark)
 
-                yield benchmark
+                    yield benchmark
+                except BaseException as error:
+                    run_span.end(error)
+                    raise
 
                 try:
                     strategy, constraints = strategies_generator.send(benchmark)
@@ -177,3 +206,4 @@ class Benchmarker(
 
             if progress:
                 await progress.on_finalize()
+            run_span.end()

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -40,7 +40,18 @@ from guidellm.scheduler.schemas import (
     ResponseT,
 )
 from guidellm.scheduler.strategies import SchedulingStrategy
-from guidellm.schemas import RequestInfo, RequestSettings
+from guidellm.schemas import (
+    GenerationRequest,
+    GenerationResponse,
+    RequestInfo,
+    RequestSettings,
+)
+from guidellm.tracing import (
+    activate_trace_context,
+    deactivate_trace_context,
+    shutdown_tracing,
+    start_span,
+)
 from guidellm.utils.messaging import InterProcessMessaging
 from guidellm.utils.synchronous import (
     wait_for_sync_barrier,
@@ -105,6 +116,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         constraint_reached_event: ProcessingEvent,
         shutdown_event: ProcessingEvent,
         error_event: ProcessingEvent,
+        trace_context: dict[str, str] | None = None,
     ):
         """
         Initialize worker process instance.
@@ -121,6 +133,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         :param constraint_reached_event: Event signaling processing constraint reached
         :param shutdown_event: Event signaling graceful shutdown request
         :param error_event: Event signaling error conditions across processes
+        :param trace_context: Serialized parent OpenTelemetry context
         """
         self.worker_index = worker_index
         self.messaging = messaging
@@ -133,6 +146,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         self.constraint_reached_event = constraint_reached_event
         self.shutdown_event = shutdown_event
         self.error_event = error_event
+        self.trace_context = trace_context
 
         # Internal states
         self.startup_completed = False
@@ -151,6 +165,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
 
         :raises RuntimeError: If worker encounters unrecoverable error during execution
         """
+        context_token = activate_trace_context(self.trace_context)
         try:
             if HAS_UVLOOP:
                 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -161,6 +176,9 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 f"Worker process {self.messaging.worker_index} encountered an "
                 f"error: {err}"
             ) from err
+        finally:
+            deactivate_trace_context(context_token)
+            shutdown_tracing()
 
     async def run_async(self):
         """
@@ -369,7 +387,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 request_info.timings.resolve_end = time.time()
                 self._send_update("cancelled", None, request, request_info)
 
-    async def _process_next_request(  # noqa: C901
+    async def _process_next_request(  # noqa: C901, PLR0912, PLR0915
         self, target_start: float
     ) -> ProcessRequestT[RequestT, ResponseT]:
         """
@@ -386,11 +404,26 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         request_info: RequestInfo | None = None
         response: ResponseT | None = None
         premature_exit: bool = False
+        request_span = None
+        request_error: BaseException | None = None
 
         try:
             # Pull request from the queue, update state, and send "pending" update
             history, conversation = await self._dequeue_next_conversation(target_start)
             request, request_info = conversation.pop(0)
+            request_span = start_span(
+                "gen_ai.request",
+                {
+                    "guidellm.request.id": request_info.request_id,
+                    "guidellm.worker.index": self.worker_index,
+                    "guidellm.backend.kind": self.backend.info.get("kind"),
+                    "server.address": self.backend.info.get("target"),
+                    "gen_ai.request.model": self.backend.info.get("model"),
+                    "gen_ai.operation.name": "generate_content",
+                    "guidellm.strategy.type": self.strategy.type_,
+                },
+                client=True,
+            )
 
             effective_target_start = await self.strategy.resolve_dequeued_target_start(
                 self.worker_index,
@@ -426,8 +459,8 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             # Record Turn
             history.append((request, response))
 
-            response = request = None
         except asyncio.CancelledError:
+            request_error = asyncio.CancelledError("Request was cancelled")
             premature_exit = True
             # Handle cancellation
             if request is not None and request_info is not None:
@@ -436,6 +469,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 self._send_update("cancelled", response, request, request_info)
             raise
         except Exception as exc:  # noqa: BLE001
+            request_error = exc
             premature_exit = True
             if request is not None and request_info is not None:
                 request_info.error = repr(exc)
@@ -446,6 +480,43 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                     f"Backend exception for request {request_info.request_id}"
                 )
         finally:
+            if request_span is not None and request_info is not None:
+                request_span.set_attributes(
+                    {
+                        "guidellm.request.outcome": request_info.status,
+                        "guidellm.request.latency_ms": (
+                            1000
+                            * (
+                                request_info.timings.request_end
+                                - request_info.timings.request_start
+                            )
+                            if request_info.timings.request_start is not None
+                            and request_info.timings.request_end is not None
+                            else None
+                        ),
+                        "guidellm.request.time_to_first_token_ms": (
+                            1000
+                            * (
+                                request_info.timings.first_token_iteration
+                                - request_info.timings.request_start
+                            )
+                            if request_info.timings.request_start is not None
+                            and request_info.timings.first_token_iteration is not None
+                            else None
+                        ),
+                        "gen_ai.usage.input_tokens": (
+                            request.input_metrics.total_tokens
+                            if isinstance(request, GenerationRequest)
+                            else None
+                        ),
+                        "gen_ai.usage.output_tokens": (
+                            response.output_metrics.total_tokens
+                            if isinstance(response, GenerationResponse)
+                            else None
+                        ),
+                    }
+                )
+                request_span.end(request_error)
             if request_info is not None:
                 self.strategy.request_completed(request_info)
             if premature_exit and conversation:

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -41,6 +41,7 @@ from guidellm.scheduler.strategies import SchedulingStrategy
 from guidellm.scheduler.worker import WorkerProcess
 from guidellm.schemas import RequestInfo, RequestSettings
 from guidellm.settings import settings
+from guidellm.tracing import capture_trace_context
 from guidellm.utils.messaging import (
     InterProcessMessaging,
     InterProcessMessagingManagerQueue,
@@ -230,6 +231,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             max_concurrency=max_conc,
             mp_context=self.mp_context,
         )
+        trace_context = capture_trace_context()
         for rank in range(num_processes):
             # Distribute any remainder across the first N ranks
             async_limit = per_proc_max_conc + (
@@ -252,6 +254,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
                 constraint_reached_event=self.constraint_reached_event,
                 shutdown_event=self.shutdown_event,
                 error_event=self.error_event,
+                trace_context=trace_context,
             )
             proc = self.mp_context.Process(target=worker.run, daemon=False)
             proc.start()

--- a/src/guidellm/tracing.py
+++ b/src/guidellm/tracing.py
@@ -1,0 +1,232 @@
+"""Optional OpenTelemetry tracing support for GuideLLM benchmark execution."""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import Any
+
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry import propagate, trace
+    from opentelemetry.trace import SpanKind, Status, StatusCode
+
+    OTEL_API_AVAILABLE = True
+except ImportError:
+    OTEL_API_AVAILABLE = False
+
+try:
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as GrpcOTLPSpanExporter,
+    )
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as HttpOTLPSpanExporter,
+    )
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
+
+    OTEL_SDK_AVAILABLE = True
+except ImportError:
+    OTEL_SDK_AVAILABLE = False
+
+__all__ = [
+    "TraceSpan",
+    "activate_trace_context",
+    "capture_trace_context",
+    "deactivate_trace_context",
+    "inject_trace_headers",
+    "shutdown_tracing",
+    "start_span",
+]
+
+_configure_lock = threading.Lock()
+
+
+class _TracingState:
+    """Mutable process-local configuration state."""
+
+    configured_pid: int | None = None
+    tracer_provider: Any = None
+
+
+_state = _TracingState()
+
+
+def _configure_from_environment() -> None:
+    """Configure an OTLP exporter when standard OTEL environment variables enable it."""
+    if (
+        not OTEL_API_AVAILABLE
+        or not OTEL_SDK_AVAILABLE
+        or not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    ):
+        return
+    if os.environ.get("OTEL_SDK_DISABLED", "false").lower() == "true":
+        return
+
+    process_id = os.getpid()
+    if _state.configured_pid == process_id:
+        return
+
+    with _configure_lock:
+        if _state.configured_pid == process_id:
+            return
+
+        protocol = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        exporter: SpanExporter
+        if protocol == "http/protobuf":
+            exporter = HttpOTLPSpanExporter()
+        elif protocol == "grpc":
+            exporter = GrpcOTLPSpanExporter()
+        else:
+            raise ValueError(
+                "OTEL_EXPORTER_OTLP_PROTOCOL must be 'grpc' or 'http/protobuf', "
+                f"got {protocol!r}"
+            )
+
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+
+        _state.tracer_provider = provider
+        _state.configured_pid = process_id
+
+
+class TraceSpan:
+    """Small lifecycle wrapper that keeps OpenTelemetry optional at runtime."""
+
+    def __init__(self, span: Any = None, token: Any = None):
+        """
+        Initialize a trace span wrapper.
+
+        :param span: OpenTelemetry span, or None when tracing is unavailable
+        :param token: Context attachment token paired with the span
+        """
+        self._span = span
+        self._token = token
+        self._ended = False
+
+    def set_attributes(self, attributes: dict[str, Any]) -> None:
+        """
+        Add non-null attributes to the span.
+
+        :param attributes: Attribute names and values to record
+        """
+        if self._span is None:
+            return
+        for key, value in attributes.items():
+            if value is not None:
+                self._span.set_attribute(key, value)
+
+    def end(self, error: BaseException | None = None) -> None:
+        """
+        Record an optional failure, detach the context, and finish the span.
+
+        :param error: Exception associated with the operation, if any
+        """
+        if self._span is None or self._ended:
+            return
+        if error is not None:
+            self._span.record_exception(error)
+            self._span.set_status(Status(StatusCode.ERROR, str(error)))
+            self._span.set_attribute("error.type", type(error).__name__)
+        otel_context.detach(self._token)
+        self._span.end()
+        self._ended = True
+
+
+def start_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+    *,
+    client: bool = False,
+) -> TraceSpan:
+    """
+    Start and activate a span when the OpenTelemetry API is installed.
+
+    :param name: Span name
+    :param attributes: Initial span attributes
+    :param client: Whether the span represents a client operation
+    :return: Lifecycle wrapper; always safe to use when tracing is unavailable
+    """
+    if not OTEL_API_AVAILABLE:
+        return TraceSpan()
+
+    _configure_from_environment()
+    tracer = (
+        _state.tracer_provider.get_tracer("guidellm")
+        if _state.tracer_provider is not None
+        else trace.get_tracer("guidellm")
+    )
+    span = tracer.start_span(
+        name,
+        kind=SpanKind.CLIENT if client else SpanKind.INTERNAL,
+        attributes={
+            key: value for key, value in (attributes or {}).items() if value is not None
+        },
+    )
+    token = otel_context.attach(trace.set_span_in_context(span))
+    return TraceSpan(span, token)
+
+
+def inject_trace_headers(
+    headers: dict[str, str] | None = None,
+) -> dict[str, str] | None:
+    """
+    Inject the active W3C trace context into a copy of outbound headers.
+
+    :param headers: Existing outbound headers
+    :return: Headers with trace context, or the original empty value when unavailable
+    """
+    if not OTEL_API_AVAILABLE:
+        return headers
+
+    _configure_from_environment()
+    carrier = dict(headers or {})
+    propagate.inject(carrier)
+    return carrier or None
+
+
+def capture_trace_context() -> dict[str, str]:
+    """
+    Serialize the active trace context for transfer to a worker process.
+
+    :return: Pickleable W3C trace-context carrier
+    """
+    if not OTEL_API_AVAILABLE:
+        return {}
+
+    carrier: dict[str, str] = {}
+    propagate.inject(carrier)
+    return carrier
+
+
+def activate_trace_context(carrier: dict[str, str] | None) -> Any:
+    """
+    Activate trace context received from another process.
+
+    :param carrier: W3C trace-context carrier from the parent process
+    :return: Context token to pass to :func:`deactivate_trace_context`
+    """
+    if not OTEL_API_AVAILABLE or not carrier:
+        return None
+
+    return otel_context.attach(propagate.extract(carrier))
+
+
+def deactivate_trace_context(token: Any) -> None:
+    """
+    Detach a previously activated cross-process trace context.
+
+    :param token: Token returned by :func:`activate_trace_context`
+    """
+    if OTEL_API_AVAILABLE and token is not None:
+        otel_context.detach(token)
+
+
+def shutdown_tracing() -> None:
+    """Flush and shut down the OTLP provider owned by the current process."""
+    if _state.tracer_provider is None or _state.configured_pid != os.getpid():
+        return
+
+    _state.tracer_provider.shutdown()
+    _state.tracer_provider = None
+    _state.configured_pid = None

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,185 @@
+"""Tests for optional OpenTelemetry tracing helpers."""
+
+from __future__ import annotations
+
+import pickle
+from multiprocessing import get_context
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from guidellm import tracing
+from guidellm.tracing import (
+    activate_trace_context,
+    capture_trace_context,
+    deactivate_trace_context,
+    inject_trace_headers,
+    shutdown_tracing,
+    start_span,
+)
+
+
+def _read_trace_context_in_worker(carrier: dict[str, str], output_queue: Any) -> None:
+    """Activate a carrier in a spawned process and return its span context."""
+    context_token = activate_trace_context(carrier)
+    try:
+        span_context = trace.get_current_span().get_span_context()
+        output_queue.put(
+            (span_context.trace_id, span_context.span_id, span_context.is_remote)
+        )
+    finally:
+        deactivate_trace_context(context_token)
+
+
+@pytest.fixture(scope="module")
+def span_exporter() -> InMemorySpanExporter:
+    """Install an in-memory trace provider for this module."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+@pytest.mark.sanity
+def test_span_hierarchy_survives_process_context_transfer(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Preserve run hierarchy through a pickleable carrier. ## WRITTEN BY AI ##"""
+    run_span = start_span("guidellm.run", {"guidellm.run.id": "run-1"})
+    benchmark_span = start_span(
+        "guidellm.benchmark",
+        {"guidellm.benchmark.id": "benchmark-1"},
+    )
+    carrier = pickle.loads(  # noqa: S301 - trusted local round-trip
+        pickle.dumps(capture_trace_context())
+    )
+    benchmark_span.end()
+    run_span.end()
+
+    context_token = activate_trace_context(carrier)
+    request_span = start_span(
+        "gen_ai.request",
+        {"guidellm.request.id": "request-1"},
+        client=True,
+    )
+    headers = inject_trace_headers({"authorization": "secret"})
+    request_span.end()
+    deactivate_trace_context(context_token)
+
+    assert headers is not None
+    assert headers["authorization"] == "secret"
+    assert headers["traceparent"].startswith("00-")
+    spans = {span.name: span for span in span_exporter.get_finished_spans()[-3:]}
+    run = spans["guidellm.run"]
+    benchmark = spans["guidellm.benchmark"]
+    request = spans["gen_ai.request"]
+    assert benchmark.parent is not None
+    assert benchmark.parent.span_id == run.context.span_id
+    assert request.parent is not None
+    assert request.parent.trace_id == run.context.trace_id
+    assert request.parent.span_id == benchmark.context.span_id
+    assert request.attributes["guidellm.request.id"] == "request-1"
+
+
+@pytest.mark.regression
+def test_span_records_failures(span_exporter: InMemorySpanExporter) -> None:
+    """Mark failed operations with error details. ## WRITTEN BY AI ##"""
+    request_span = start_span("gen_ai.request")
+    request_span.end(ValueError("bad response"))
+
+    span = span_exporter.get_finished_spans()[-1]
+    assert span.status.is_ok is False
+    assert span.attributes["error.type"] == "ValueError"
+    assert span.events[-1].name == "exception"
+
+
+@pytest.mark.regression
+def test_context_reaches_spawned_worker_process(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Activate benchmark context under the spawn start method. ## WRITTEN BY AI ##"""
+    _ = span_exporter
+    benchmark_span = start_span("guidellm.benchmark")
+    expected = trace.get_current_span().get_span_context()
+    carrier = capture_trace_context()
+    mp_context = get_context("spawn")
+    output_queue = mp_context.Queue()
+    process = mp_context.Process(
+        target=_read_trace_context_in_worker,
+        args=(carrier, output_queue),
+    )
+
+    try:
+        process.start()
+        trace_id, parent_span_id, is_remote = output_queue.get(timeout=10)
+    finally:
+        process.join(timeout=10)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=10)
+        output_queue.close()
+        output_queue.join_thread()
+        benchmark_span.end()
+
+    assert process.exitcode == 0
+    assert trace_id == expected.trace_id
+    assert parent_span_id == expected.span_id
+    assert is_remote is True
+
+
+@pytest.mark.regression
+def test_automatic_provider_is_recreated_for_each_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Never reuse an automatically configured forked provider. ## WRITTEN BY AI ##"""
+    providers = [MagicMock(), MagicMock()]
+    provider_factory = MagicMock(side_effect=providers)
+    process_ids = iter([100, 100, 200])
+    monkeypatch.setattr(tracing._state, "configured_pid", None)
+    monkeypatch.setattr(tracing._state, "tracer_provider", None)
+    monkeypatch.setattr(tracing, "TracerProvider", provider_factory)
+    monkeypatch.setattr(tracing, "GrpcOTLPSpanExporter", MagicMock())
+    monkeypatch.setattr(tracing, "BatchSpanProcessor", MagicMock())
+    monkeypatch.setattr(tracing.os, "getpid", lambda: next(process_ids))
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+
+    tracing._configure_from_environment()
+    first_provider = tracing._state.tracer_provider
+    tracing._configure_from_environment()
+    tracing._configure_from_environment()
+
+    assert provider_factory.call_count == 2
+    assert first_provider is providers[0]
+    assert tracing._state.tracer_provider is providers[1]
+
+
+@pytest.mark.regression
+def test_shutdown_flushes_only_current_process_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flush the worker provider without touching inherited state.
+
+    ## WRITTEN BY AI ##
+    """
+    current_provider = MagicMock()
+    inherited_provider = MagicMock()
+    monkeypatch.setattr(tracing.os, "getpid", lambda: 200)
+    monkeypatch.setattr(tracing._state, "configured_pid", 200)
+    monkeypatch.setattr(tracing._state, "tracer_provider", current_provider)
+
+    shutdown_tracing()
+
+    current_provider.shutdown.assert_called_once_with()
+    assert tracing._state.tracer_provider is None
+
+    monkeypatch.setattr(tracing._state, "configured_pid", 100)
+    monkeypatch.setattr(tracing._state, "tracer_provider", inherited_provider)
+    shutdown_tracing()
+    inherited_provider.shutdown.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -5,10 +5,14 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -588,10 +592,14 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
@@ -1101,6 +1109,79 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/fd/655c8a773d728bc3c93fb4713ae4bf79ffc75996f86fb78b2974c8e1dfbd/grpcio-1.83.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fba099b716e73512d61b97f71ea3c31a72abb36904036e316bf4dd148ca8dcc8", size = 6334247, upload-time = "2026-07-23T15:18:53.099Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9a/1ce5760d35a04a992006dd2f79afff2db548f93ee7426fa95c9f1fc90c61/grpcio-1.83.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6755ed67cc3e454d51ae9f6e1915b80d3942fa4de956ef48dacd45ab7f40b727", size = 12168650, upload-time = "2026-07-23T15:18:56.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ab/bbcb5be0a1a6cb21f036e2afdd4f7a70147cfb7a7b42648a310d7c43acfc/grpcio-1.83.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5882c1a721b50ce0123ee5e839e1ab059ad72a7ade76cdf2d5bd833b56791acf", size = 6916899, upload-time = "2026-07-23T15:18:58.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/4c27977ecb3b3f9f363b93f570e001cb24ef264a9a907d7fd0f949ed59f0/grpcio-1.83.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4e3eedfc92b6b9f2960115e7e620cf0cbf80bb7849a51ce3820dc54dfd88b6b9", size = 7648761, upload-time = "2026-07-23T15:19:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/23/49/0c823a7627ff2e69a61e4a53c4edf215272892fc2c47c6431f033d46f4cc/grpcio-1.83.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4fcaa7c45c45b4a89e2867d1f1785d9481a788399d915e341ed2eb49aeef9dd4", size = 7074920, upload-time = "2026-07-23T15:19:02.293Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ce/963f01ff7c789a76909c9691b704112e02ca1e11c10405cd99c2bd7c40f1/grpcio-1.83.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6b6c666a1d5613ff360c9e90f44665e3a88b25a815209ddbc0917eec281931cb", size = 7598046, upload-time = "2026-07-23T15:19:03.921Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/de/1ce6bdefc847a7973040d10cebc8996c653a2a687c0a4da8d05dcab4e397/grpcio-1.83.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:6be5c807b717be3dd649446f021301fd7907e376318675d2147823071034112a", size = 8634792, upload-time = "2026-07-23T15:19:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8b/7fe6a73895e3bdd788101d1276e48e0d262ebb165afacec1ec4efebcd785/grpcio-1.83.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c834e86d8fd2f03d7e4db49a027f7c5b89c5b88eed305543a5295bd6fee61e40", size = 8000286, upload-time = "2026-07-23T15:19:07.739Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b0/9a779de2bcda8722501a056fad1bec3d1117977af0c080ab1fc0655fdf35/grpcio-1.83.0-cp310-cp310-win32.whl", hash = "sha256:35a5b1c192496b6c25956eebfa963468935612206fd2543ac3ce981e6a5e0f03", size = 4404616, upload-time = "2026-07-23T15:19:09.988Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8e/ce9a23590cac33a6c24e6386cc0ffc55821cc13212acc822e98f00a67161/grpcio-1.83.0-cp310-cp310-win_amd64.whl", hash = "sha256:8f6c395e493d20c39b29392ca200e9aaeb78d0bc2f04db0c0a7da7ddc939aa57", size = 5162304, upload-time = "2026-07-23T15:19:11.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f6/3b781cd07a715ea5f5125ae264226e7fc4d87603d6d3955022cabfdc5da2/grpcio-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:8ff0b8767ddd62704e0d9571c1890af08d84a3a689ebba1807e62519d0b3277f", size = 6338720, upload-time = "2026-07-23T15:19:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/d14833d15d5984e366f1b027fa78bd038c9b028c66880bffb0f5a4d25ee2/grpcio-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4772402f43517b4824980be4b3b2274a81eec0004a70009473c31b340d43e223", size = 12178773, upload-time = "2026-07-23T15:19:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/8acbb416544e7871132d8e42a07ed70c802d70e6a16c6009e505a34d32a4/grpcio-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f4cee5fc86e84a0cf7ad1574b454c3320e087c07f55b7df5dc0ac6a873fb90c0", size = 6921203, upload-time = "2026-07-23T15:19:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/0fdbfaf4fc54e5c88f6bce4008a065092fe7fbc4460eb5617ae8b20fd505/grpcio-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f5e822a7e7d03282f6ad225e710493c48b9057a353358344a5f7c42b2b37618d", size = 7648508, upload-time = "2026-07-23T15:19:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ea/107b9dbb2ed3ad14dd774fd3dde7d29ff9938a6c198654becb2c3a0e9a6a/grpcio-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5f410d7c2903eabb34789dfd6342eef04af1ad459943936b7e09a9f5bd417b9", size = 7079466, upload-time = "2026-07-23T15:19:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/9fa9941089e6fae83b060b6ce61c1e81053e52decae43197245f45e07d36/grpcio-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee94a4016fdf8699fb1fd8a38652475ff677f1c72074cee44deeeb9a7e95e745", size = 7605583, upload-time = "2026-07-23T15:19:23.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/f10fb56062dc2771c630827a82d9ad0ecd05cad572ea3b08d49f6631680a/grpcio-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6444666317338e903093c7c756e6cc88eee59f798cb8dd41e87725bf54e1617", size = 8637810, upload-time = "2026-07-23T15:19:25.536Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/f84927258f6a1b6ea6dea661fdc6de859b35e560c96f3012d15ccd39f85e/grpcio-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aa074041231f03959cb097dd5517b0677b8ea49215bae01d5710a7b69dd59969", size = 8008021, upload-time = "2026-07-23T15:19:27.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/cdf72161397ccd29d4ca2192f641524536c9cf54ad948c9dd0e0e01138fa/grpcio-1.83.0-cp311-cp311-win32.whl", hash = "sha256:cb056f6e171c42639a50460b2929c82241fda51f71cf3dcdd68090fe45095a45", size = 4404376, upload-time = "2026-07-23T15:19:30.137Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ed/e0ffeb4c848699c194dc9fb6a29ab29bcb2b6aac8c416bf18c51bfe8242c/grpcio-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:7416952ca770477990257206276999056f8316d79196f2f25942393e58a20b49", size = 5164469, upload-time = "2026-07-23T15:19:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
+    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
+]
+
+[[package]]
 name = "guidellm"
 source = { editable = "." }
 dependencies = [
@@ -1141,6 +1222,9 @@ all = [
     { name = "mistral-common" },
     { name = "msgpack" },
     { name = "msgspec" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
     { name = "orjson" },
     { name = "pillow" },
     { name = "tiktoken" },
@@ -1156,6 +1240,11 @@ audio = [
     { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
     { name = "torchcodec", version = "0.13.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
     { name = "torchcodec", version = "0.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
 ]
 perf = [
     { name = "msgpack" },
@@ -1260,7 +1349,7 @@ requires-dist = [
     { name = "eval-type-backport" },
     { name = "faker" },
     { name = "ftfy", specifier = ">=6.0.0" },
-    { name = "guidellm", extras = ["audio", "perf", "plot", "tokenizers", "vision"], marker = "extra == 'all'" },
+    { name = "guidellm", extras = ["audio", "otel", "perf", "plot", "tokenizers", "vision"], marker = "extra == 'all'" },
     { name = "guidellm", extras = ["perf", "tokenizers"], marker = "extra == 'recommended'" },
     { name = "httpx", extras = ["http2"], specifier = "<1.0.0" },
     { name = "imageio", extras = ["ffmpeg"], marker = "extra == 'vision'" },
@@ -1272,6 +1361,9 @@ requires-dist = [
     { name = "msgpack", marker = "extra == 'perf'" },
     { name = "msgspec", marker = "extra == 'perf'" },
     { name = "numpy", specifier = ">=2.0.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.31.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'otel'", specifier = ">=1.31.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.31.0" },
     { name = "orjson", marker = "extra == 'perf'" },
     { name = "pillow", marker = "extra == 'vision'" },
     { name = "protobuf" },
@@ -1291,7 +1383,7 @@ requires-dist = [
     { name = "uvloop", marker = "extra == 'perf'" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["all", "recommended", "plot", "perf", "tokenizers", "audio", "vision"]
+provides-extras = ["all", "recommended", "plot", "perf", "tokenizers", "audio", "vision", "otel"]
 
 [package.metadata.requires-dev]
 build = [
@@ -2160,10 +2252,14 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 dependencies = [
@@ -2731,10 +2827,14 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/fc/7b6fd4d22c8c4dc5704430140d8b3f520531d4fe7328b8f8d03f5a7950e8/networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad", size = 2511464, upload-time = "2025-11-24T03:03:47.158Z" }
@@ -2825,10 +2925,14 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/65/21b3bc86aac7b8f2862db1e808f1ea22b028e30a225a34a5ede9bf8678f2/numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0", size = 20584950, upload-time = "2025-11-16T22:52:42.067Z" }
@@ -2906,6 +3010,118 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/e4/68d2f474df2cb671b2b6c2986a02e520671295647dad82484cde80ca427b/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffac52f28a7849ad7576293c0cb7b9f08304e8f7d738a8cb8a90ec4c55a998eb", size = 14391768, upload-time = "2025-11-16T22:52:33.593Z" },
     { url = "https://files.pythonhosted.org/packages/b8/50/94ccd8a2b141cb50651fddd4f6a48874acb3c91c8f0842b08a6afc4b0b21/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63c0e9e7eea69588479ebf4a8a270d5ac22763cc5854e9a7eae952a3908103f7", size = 16729263, upload-time = "2025-11-16T22:52:36.369Z" },
     { url = "https://files.pythonhosted.org/packages/2d/ee/346fa473e666fe14c52fcdd19ec2424157290a032d4c41f98127bfb31ac7/numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425", size = 12967213, upload-time = "2025-11-16T22:52:39.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/45/7af37fe54e5d3e66e7dcd7ba8b8aeee73f202bfac909cc94b8c4e428f9ac/opentelemetry_exporter_otlp-1.44.0.tar.gz", hash = "sha256:af1cde7c33ea8ed624bf04ac49a885730fe44c1f1ad698656e592c38f70ce106", size = 6090, upload-time = "2026-07-16T15:25:34.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/c3/7b466a9463944e70b37b744072a0c1b88a425dade3fff0631adec66c9bcc/opentelemetry_exporter_otlp-1.44.0-py3-none-any.whl", hash = "sha256:4a498fa8d8fd8be9e8e2d175fe5524a3fe581ccffadd8509db86526a5fb97051", size = 6727, upload-time = "2026-07-16T15:25:14.445Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -4625,7 +4841,9 @@ version = "2.13.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
@@ -4656,7 +4874,9 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
@@ -4710,7 +4930,9 @@ version = "0.13.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
 ]
@@ -4730,7 +4952,9 @@ resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'arm64') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin')",
+    "(python_full_version == '3.14.*' and platform_machine != 'arm64') or (python_full_version == '3.14.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]


### PR DESCRIPTION
## Summary

- add optional run, benchmark, and full-lifecycle inference request spans
- propagate W3C trace context through OpenAI HTTP requests and WebSocket handshakes
- preserve run → benchmark → request hierarchy across fork, spawn, and forkserver workers using explicit W3C carriers
- create and flush process-local OTLP providers so workers never reuse inherited exporter threads
- record request outcome, failures, token usage, latency, and TTFT without prompt or response content
- configure OTLP exporters from standard OpenTelemetry environment variables
- add the guidellm[otel] extra, lock updates, focused tests, and collector documentation

Fixes #986

## Tests

- uv run tox -e tests -- tests/unit/test_tracing.py tests/unit/backends/openai/test_http.py tests/unit/backends/openai/test_realtime_ws.py tests/unit/scheduler/test_worker.py tests/unit/scheduler/test_worker_group.py tests/unit/benchmark/test_entrypoints.py (98 passed, 16 xfailed, 1 xpassed)
- uv run tox -e lint-check
- uv run tox -e type-check
- uv run tox -e lock

The full unit suite baseline reached 2,710 passing tests; 15 multimedia tests failed because the local TorchCodec installation could not load Homebrew FFmpeg dylibs.

<!-- begin:squash-data -->

---

# git log

commit ce34760ec2211572d85ac324b2b098bcc4a78d95
Author: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
Date:   Mon Aug 3 10:40:22 2026 -0700

    feat: add OpenTelemetry tracing
    
    Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>

---------

Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
