### PR TITLE
Fix multipart filenames for audio uploads

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -1324,7 +1324,7 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
 
         arguments.files = {
             "file": (
-                audio_columns[0].get("file_name", "audio_input"),
+                audio_columns[0].get("file_name") or "audio_input",
                 audio_columns[0].get("audio"),
                 audio_columns[0].get("mimetype"),
             )

--- a/src/guidellm/utils/audio.py
+++ b/src/guidellm/utils/audio.py
@@ -118,12 +118,16 @@ def encode_audio(
         mono=mono,
     )
 
+    resolved_file_name = file_name
+    if not resolved_file_name and isinstance(audio, str | Path):
+        resolved_file_name = get_file_name(audio)
+    if not resolved_file_name:
+        resolved_file_name = f"audio.{format_val}"
+
     return {
         "type": "audio_file",
         "audio": encoded_audio,
-        "file_name": get_file_name(audio)
-        if isinstance(audio, str | Path)
-        else file_name,
+        "file_name": resolved_file_name,
         "format": audio_format,
         "mimetype": f"audio/{format_val}",
         "audio_samples": samples.sample_rate,

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2344,6 +2344,29 @@ class TestAudioRequestHandler:
         assert file_tuple[1] == audio_data
         assert file_tuple[2] == "audio/wav"
 
+    @pytest.mark.regression
+    @pytest.mark.parametrize("file_name", [None, ""], ids=["missing", "empty"])
+    def test_format_file_upload_defaults_nonempty_file_name(
+        self,
+        valid_instances: AudioRequestHandler,
+        file_name: str | None,
+    ) -> None:
+        """Use a nonempty multipart filename when metadata has none.
+
+        ## WRITTEN BY AI ##
+        """
+        audio_entry = {
+            "audio": b"fake_audio_bytes",
+            "mimetype": "audio/wav",
+        }
+        if file_name is not None:
+            audio_entry["file_name"] = file_name
+        data = GenerationRequest(columns={"audio_column": [audio_entry]})
+
+        result = valid_instances.format(data)
+
+        assert result.files["file"][0] == "audio_input"
+
     @pytest.mark.sanity
     def test_format_missing_audio(self, valid_instances):
         """Test format method raises error when no audio column provided.

--- a/tests/unit/utils/test_audio.py
+++ b/tests/unit/utils/test_audio.py
@@ -103,6 +103,77 @@ def test_encode_audio_with_real_file_path(real_wav_file):
     assert result["audio_seconds"] <= 1.0
 
 
+@pytest.mark.regression
+@patch("guidellm.utils.audio._encode_audio")
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_explicit_file_name_overrides_path(
+    mock_decoder: MagicMock,
+    mock_encode: MagicMock,
+    real_wav_file: Path,
+) -> None:
+    """Use an explicit filename instead of the source path basename.
+
+    ## WRITTEN BY AI ##
+    """
+    mock_audio_result = MagicMock(sample_rate=16000, duration_seconds=1.0)
+    mock_decoder.return_value = (mock_audio_result, "pcm_s16le")
+    mock_encode.return_value = b"encoded_data"
+
+    result = _audio_mod.encode_audio(
+        audio=real_wav_file,
+        file_name="upload-name.wav",
+    )
+
+    assert result["file_name"] == "upload-name.wav"
+
+
+@pytest.mark.regression
+@patch("guidellm.utils.audio._encode_audio")
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_path_defaults_to_basename(
+    mock_decoder: MagicMock,
+    mock_encode: MagicMock,
+    real_wav_file: Path,
+) -> None:
+    """Use the source basename when a path has no explicit filename.
+
+    ## WRITTEN BY AI ##
+    """
+    mock_audio_result = MagicMock(sample_rate=16000, duration_seconds=1.0)
+    mock_decoder.return_value = (mock_audio_result, "pcm_s16le")
+    mock_encode.return_value = b"encoded_data"
+
+    result = _audio_mod.encode_audio(audio=real_wav_file)
+
+    assert result["file_name"] == real_wav_file.name
+
+
+@pytest.mark.regression
+@patch("guidellm.utils.audio._encode_audio")
+@patch("guidellm.utils.audio._decode_audio")
+def test_encode_audio_in_memory_defaults_to_resolved_format(
+    mock_decoder: MagicMock,
+    mock_encode: MagicMock,
+    sample_audio_tensor: torch.Tensor,
+) -> None:
+    """Derive an in-memory filename from the resolved output format.
+
+    ## WRITTEN BY AI ##
+    """
+    mock_audio_result = MagicMock(sample_rate=16000, duration_seconds=1.0)
+    mock_decoder.return_value = (mock_audio_result, None)
+    mock_encode.return_value = b"encoded_data"
+
+    result = _audio_mod.encode_audio(
+        audio=sample_audio_tensor,
+        sample_rate=16000,
+        audio_format="FLAC",
+    )
+
+    assert result["file_name"] == "audio.flac"
+    assert result["format"] == "FLAC"
+
+
 def test_encode_audio_with_dict_input_complete():
     """
     Dict with raw 'data' key (float tensor) has no codec, falls back to WAV.


### PR DESCRIPTION
## Summary

- honor explicit audio filenames before path-derived names
- derive in-memory filenames from the resolved audio format
- defensively provide a nonempty multipart filename in the audio request handler

## Testing

- uv run tox -e tests -- targeted filename regression tests (5 passed)
- uv run tox -e lint-check
- uv run tox -e type-check

The complete audio utility file was also attempted locally; 250 tests passed and 18 audio codec tests failed because TorchCodec could not load local FFmpeg dylibs. The new metadata-only regressions mock the codec boundary and pass.

Fixes #983

<!-- begin:squash-data -->

---

# git log

commit 7efdd8b65e53fdf5823cf4170696320665f1d507
Author: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
Date:   Mon Aug 3 10:42:54 2026 -0700

    fix: ensure audio uploads include filenames
    
    Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>

---------

Signed-off-by: Fedir Zadniprovskyi <github.g1k56@simplelogin.com>
