### PR TITLE
feat: capture cached_tokens from prompt_tokens_details in usage metrics

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -687,6 +687,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
                 or usage_metrics.get("prompt_tokens")
                 or 0
             ),
+            cached_tokens=input_details.get("cached_tokens"),
             image_tokens=input_details.get("image_tokens"),
             video_tokens=input_details.get("video_tokens"),
             audio_tokens=input_details.get("audio_tokens"),

--- a/src/guidellm/backends/vllm_python/vllm_response.py
+++ b/src/guidellm/backends/vllm_python/vllm_response.py
@@ -83,6 +83,7 @@ class VLLMResponseHandler:
 
         input_metrics = UsageMetrics(
             text_tokens=usage_metrics.get("prompt_tokens", 0),
+            cached_tokens=input_details.get("cached_tokens"),
             image_tokens=input_details.get("image_tokens"),
             video_tokens=input_details.get("video_tokens"),
             audio_tokens=input_details.get("audio_tokens"),

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -125,8 +125,11 @@ class UsageMetrics(StandardBaseDict):
     )
     cached_tokens: int | None = Field(
         default=None,
-        description="Number of input tokens served from the prefix cache (KV cache hit). "
-        "Populated from the server's prompt_tokens_details.cached_tokens field.",
+        description=(
+            "Number of input tokens served from the prefix cache"
+            " (KV cache hit). Populated from the server's"
+            " prompt_tokens_details.cached_tokens field."
+        ),
     )
     text_words: int | None = Field(
         default=None, description="Number of text words processed/generated."

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -123,6 +123,11 @@ class UsageMetrics(StandardBaseDict):
     text_tokens: int | None = Field(
         default=None, description="Number of text tokens processed/generated."
     )
+    cached_tokens: int | None = Field(
+        default=None,
+        description="Number of input tokens served from the prefix cache (KV cache hit). "
+        "Populated from the server's prompt_tokens_details.cached_tokens field.",
+    )
     text_words: int | None = Field(
         default=None, description="Number of text words processed/generated."
     )

--- a/src/guidellm/schemas/request_stats.py
+++ b/src/guidellm/schemas/request_stats.py
@@ -124,6 +124,14 @@ class GenerativeRequestStats(StandardBaseDict):
 
     @computed_field  # type: ignore[misc]
     @property
+    def cached_tokens(self) -> int | None:
+        """
+        :return: Number of input tokens served from the prefix cache, or None
+        """
+        return self.input_metrics.cached_tokens
+
+    @computed_field  # type: ignore[misc]
+    @property
     def output_tokens(self) -> int | None:
         """
         :return: Number of tokens in the generated output, or None if unavailable

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -847,6 +847,19 @@ class TestTextCompletionsRequestHandler:
         assert output_metrics.text_words == (len(text.split()) if text else 0)
         assert output_metrics.text_characters == len(text)
 
+    @pytest.mark.smoke
+    def test_extract_metrics_cached_tokens(self, valid_instances):
+        """Test extract_metrics captures prompt_tokens_details.cached_tokens."""
+        usage = {
+            "prompt_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 8},
+            "completion_tokens": 5,
+        }
+        input_metrics, _ = valid_instances.extract_metrics(usage, "Test response")
+
+        assert input_metrics.text_tokens == 10
+        assert input_metrics.cached_tokens == 8
+
 
 class TestChatCompletionsRequestHandler:
     """Test cases for ChatCompletionsRequestHandler.

--- a/tests/unit/backends/vllm_python/test_vllm_response.py
+++ b/tests/unit/backends/vllm_python/test_vllm_response.py
@@ -91,6 +91,7 @@ class TestVLLMResponseHandler:
             "total_tokens": 15,
             "prompt_tokens_details": {
                 "image_tokens": 3,
+                "cached_tokens": 8,
             },
             "completion_tokens_details": {
                 "audio_tokens": 1,
@@ -99,6 +100,7 @@ class TestVLLMResponseHandler:
         out = VLLMResponseHandler.build_response(request_fixture, "result", usage)
         assert out.input_metrics.text_tokens == 10
         assert out.input_metrics.image_tokens == 3
+        assert out.input_metrics.cached_tokens == 8
         assert out.output_metrics.text_tokens == 5
         assert out.output_metrics.audio_tokens == 1
 


### PR DESCRIPTION
## Summary

vLLM and OpenAI-compatible servers already return `prompt_tokens_details.cached_tokens`, indicating how many input tokens were served from the prefix/KV cache. GuideLLM parsed `prompt_tokens_details` but only read `prompt_tokens` out of it, so the cache-hit information was discarded. This PR stores that value on `UsageMetrics` and surfaces it on `GenerativeRequestStats`, so tools consuming `benchmark.json` can compute per-request prefix cache hit rates (`cached_tokens / prompt_tokens`) without scraping server-side Prometheus metrics.

There is no behavioral change to the benchmark runner: the field is optional, defaults to `None`, and is excluded from `UsageMetrics.total_tokens` (it is a subset of `text_tokens`, so including it would double-count).

## Details

- [x] Add optional `cached_tokens: int | None` field to `UsageMetrics` (`src/guidellm/schemas/request.py`)
- [x] Populate it from `prompt_tokens_details.cached_tokens` in `TextCompletionsRequestHandler.extract_metrics` (`src/guidellm/backends/openai/request_handlers.py`); `ChatCompletionsRequestHandler` inherits this
- [x] Populate it from `prompt_tokens_details.cached_tokens` in `VLLMResponseHandler` (`src/guidellm/backends/vllm_python/vllm_response.py`)
- [x] Expose `cached_tokens` as a `computed_field` on `GenerativeRequestStats`, delegating to `input_metrics` (`src/guidellm/schemas/request_stats.py`)
- [x] Add unit tests asserting the field is parsed on both the OpenAI and vLLM paths

Not included: `ResponsesRequestHandler.extract_metrics` overrides metric extraction and reads `input_tokens_details` rather than `prompt_tokens_details`; it is left unchanged here and can be covered separately.

## Test Plan

- `pytest tests/unit/backends/openai/test_request_handlers.py -k cached_tokens` — asserts `input_metrics.cached_tokens == 8` when the server returns `prompt_tokens_details: {"cached_tokens": 8}`
- `pytest tests/unit/backends/vllm_python/test_vllm_response.py -k detailed_usage` — extends the existing detailed-usage fixture with `cached_tokens` and asserts it round-trips
- Existing suites confirm no regression in `total_tokens` aggregation, since `cached_tokens` is deliberately not summed into it
- Manual: run a benchmark against a vLLM server with prefix caching enabled and confirm `cached_tokens` appears per request in `benchmark.json`

## Related Issues

- N/A

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Commits carry `Generated-by: Claude Code claude-opus-4-6` trailers as described in `DEVELOPING.md`.

<!-- begin:squash-data -->

---

# git log

commit 0dbeed1f94beb827c08359e9aefb6bf9532dea8e
Author: sfc-gh-zhwang <flex.wang@snowflake.com>
Date:   Tue Aug 4 14:33:18 2026 -0700

    feat: capture cached_tokens from prompt_tokens_details in usage metrics
    
    vLLM and OpenAI-compatible APIs return prompt_tokens_details.cached_tokens
    indicating how many input tokens were served from the prefix/KV cache.
    This was previously ignored. Now it's stored in UsageMetrics.cached_tokens
    and exposed as a computed field on GenerativeRequestStats, enabling
    downstream tools to compute per-request prefix cache hit rates without
    needing server-side Prometheus metrics.
    
    Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
    Signed-off-by: sfc-gh-zhwang <flex.wang@snowflake.com>
    Generated-by: Claude Code claude-opus-4-6

commit 0a4d56f9ac9d72b0a6b6a75a98780c86ffae2748
Author: sfc-gh-zhwang <flex.wang@snowflake.com>
Date:   Tue Aug 4 18:52:38 2026 -0700

    fix: wrap long description line to satisfy ruff E501 (88 char limit)
    
    Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
    Signed-off-by: sfc-gh-zhwang <flex.wang@snowflake.com>
    Generated-by: Claude Code claude-opus-4-6

commit 5d18a1f62ce9a09d7a3dd92eb8d15db692c22621
Author: sfc-gh-zhwang <flex.wang@snowflake.com>
Date:   Wed Aug 5 13:45:59 2026 -0700

    test: assert cached_tokens is captured from prompt_tokens_details
    
    Signed-off-by: sfc-gh-zhwang <flex.wang@snowflake.com>
    Generated-by: Claude Code claude-opus-4-6

---------

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Generated-by: Claude Code claude-opus-4-6
Signed-off-by: sfc-gh-zhwang <flex.wang@snowflake.com>
