### PR TITLE
Drop the development container CI build

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,13 +20,3 @@ jobs:
     uses: ./.github/workflows/quality.yml
     with:
       python: ${{ matrix.python }}
-
-  build-and-push-container:
-    # Only build if the PR branch is local
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      packages: write
-    uses: ./.github/workflows/build-multiarch-container.yml
-    with:
-      build-type: dev
-      tag: pr-${{ github.event.number }}


### PR DESCRIPTION
## Summary

Drop the development container build as it can only be triggered by local branch PRs. Leaves the cleanup of development containers to allow it to slowly cleanup the remaining containers.

## Related Issues

- Closes #1006

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 2a1b7b8f0ad67b40faf23e1b75d626c8700c272b
Author: Samuel Monson <smonson@redhat.com>
Date:   Fri Aug 7 10:28:25 2026 -0400

    Drop the development container CI build
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
