### PR TITLE
Switch current trace formats to use a DAG

### DIFF
--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -48,7 +48,7 @@ The Mooncake format expects an additional column for prefix-based cache hash IDs
 
 **NOTE:** :construction: While the format is accepted, some features such as subagent conversations, tool call events and non-linear histories are still in active development. The results from datasets including these features will be unreliable.
 
-The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must either be top level columns, or must all be wrapped inside the same JSON column (ex. "requests").
+The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must all be wrapped inside one JSON column (ex. "requests"), in the form a list of JSON objects.
 
 Similar to Mooncake, WEKA uses prefix-based cache hash IDs. The original [specification](https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md) for the trace requires hash IDs to be 1 or greater, and for trailing hash IDs to be dropped if there are not enough input tokens to fill the hash ID block size. To accommodate for datasets which may not follow the specification exactly (ex. [semianalysisai/cc-traces-weka-no-subagents-051226](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-no-subagents-051226)), GuideLLM will accept any non-negative integer as a valid hash ID, and will drop partially filled hash IDs if they exist.
 

--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -48,7 +48,7 @@ The Mooncake format expects an additional column for prefix-based cache hash IDs
 
 **NOTE:** :construction: While the format is accepted, some features such as subagent conversations, tool call events and non-linear histories are still in active development. The results from datasets including these features will be unreliable.
 
-The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must all be wrapped inside one JSON column (ex. "requests"), in the form a list of JSON objects.
+The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must all be wrapped inside one JSON column (ex. "requests"), in the form of a list of JSON objects.
 
 Similar to Mooncake, WEKA uses prefix-based cache hash IDs. The original [specification](https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md) for the trace requires hash IDs to be 1 or greater, and for trailing hash IDs to be dropped if there are not enough input tokens to fill the hash ID block size. To accommodate for datasets which may not follow the specification exactly (ex. [semianalysisai/cc-traces-weka-no-subagents-051226](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-no-subagents-051226)), GuideLLM will accept any non-negative integer as a valid hash ID, and will drop partially filled hash IDs if they exist.
 

--- a/src/guidellm/data/deserializers/__init__.py
+++ b/src/guidellm/data/deserializers/__init__.py
@@ -39,6 +39,7 @@ from .synthetic_video import (
     SyntheticVideoDatasetDeserializer,
 )
 from .trace_common import (
+    MissingColumnsLocation,
     TraceDataArgs,
     TraceDatasetDeserializer,
     TraceFormatBase,
@@ -47,6 +48,7 @@ from .trace_common import (
     create_prompt_from_hash_ids,
     decode_prompt,
     generate_token_ids,
+    get_missing_columns,
 )
 from .trace_minimal import MinimalTraceFormatArgs
 from .trace_mooncake import MooncakeTraceFormatArgs
@@ -71,6 +73,7 @@ __all__ = [
     "InMemoryItemListDatasetDeserializer",
     "JSONFileDatasetDeserializer",
     "MinimalTraceFormatArgs",
+    "MissingColumnsLocation",
     "MooncakeTraceFormatArgs",
     "ParquetFileDatasetDeserializer",
     "SyntheticImageDataArgs",
@@ -93,4 +96,5 @@ __all__ = [
     "create_prompt_from_hash_ids",
     "decode_prompt",
     "generate_token_ids",
+    "get_missing_columns",
 ]

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -80,6 +80,12 @@ def generate_token_ids(
             return tuple(token_ids[:token_count])
 
 
+def get_missing_columns(
+    required_columns: list[str], actual_columns: list[str]
+) -> list[str]:
+    return [c for c in required_columns if c not in actual_columns]
+
+
 def create_prompt_from_hash_ids(
     hash_ids: list[int],
     hash_id_table: dict[int, tuple[int, ...]],
@@ -117,36 +123,30 @@ def create_distinct_token_block(
 class TraceFormatBase(Protocol):
     conversation_locations: list[list[int]]
 
-    def __init__(self, dataset: Dataset) -> None: ...
+    def __init__(self, config, dataset: Dataset) -> None: ...
+
+    def __iter__(self) -> Iterable[Dataset]:
+        """TODO"""
 
     def reset(self) -> None:
         pass
 
-    def required_columns(self, config) -> Features: ...
+    def required_columns(self) -> Features: ...
 
-    def find_required_columns(
-        self, config, columns: list[str], dataset: Dataset
-    ) -> list[str]:
+    def find_required_columns(self, columns: list[str]) -> list[str]:
         """TODO"""
 
     def get_conversation_id_trace(
-        self, config, conversation_location: list[int], dataset: Dataset
+        self, conversation_location: list[int]
     ) -> list[str] | None:
         """TODO"""
 
-    def get_conversation_iter(self, config, dataset: Dataset) -> Iterable[Dataset]:
-        """TODO"""
-
-    def validate_row(self, config, row: dict) -> None:
-        """Called within `trace_common.TraceExamplesIterable` on initialization,
-        immediately after doing its own checks on the row."""
+    def validate_row(self, row: dict) -> None:
+        """OUTDATED: Called within `trace_common.TraceExamplesIterable` on
+        initialization, immediately after doing its own checks on the row."""
 
     def create_prompt(
-        self,
-        config,
-        row: dict,
-        processor: PreTrainedTokenizerBase,
-        faker: Faker,
+        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
     ) -> str:
         """Called within `trace_common.TraceExamplesIterable` on each iteration.
         Returns a generated synthetic prompt."""
@@ -160,7 +160,7 @@ class TraceFormatRegistry(RegistryMixin[type[TraceFormatBase]]):
             raise DataNotSupportedError(
                 f"Format type '{config.kind}' is not registered."
             )
-        return format_from_type(dataset)
+        return format_from_type(config, dataset)
 
 
 class TraceDataArgs(DataArgs):
@@ -199,7 +199,6 @@ class TraceExamplesIterable(_BaseExamplesIterable):
     def __init__(
         self,
         config: TraceDataArgs,
-        dataset: Dataset,
         trace_format: TraceFormatBase,
         processor: PreTrainedTokenizerBase,
         random_seed: int,
@@ -210,18 +209,14 @@ class TraceExamplesIterable(_BaseExamplesIterable):
         self.processor = processor
         self.faker = Faker()
         self.faker.seed_instance(random_seed)
-        self.dataset = dataset
         self.iteration_count = 0
 
     def __iter__(self) -> Iterable[tuple[int, dict[str, Any]]]:
         self.iteration_count += 1
-        conversations = self.format.get_conversation_iter(self.config, self.dataset)
-        for conv in conversations:
+        for conv in self.format:
             start_ts = conv[0][self.config.timestamp_column]
             for row_idx, row in enumerate(conv):
-                prompt = self.format.create_prompt(
-                    self.config, row, self.processor, self.faker
-                )
+                prompt = self.format.create_prompt(row, self.processor, self.faker)
                 relative_timestamp = row[self.config.timestamp_column] - start_ts
                 yield (
                     row_idx,
@@ -283,13 +278,12 @@ class TraceDataset(IterableDataset):
     def __init__(
         self,
         config: TraceDataArgs,
-        dataset: Dataset,
         trace_format: TraceFormatBase,
         processor: PreTrainedTokenizerBase,
         random_seed: int,
     ):
         ex_iterable = TraceExamplesIterable(
-            config, dataset, trace_format, processor, random_seed
+            config, trace_format, processor, random_seed
         )
         super().__init__(
             ex_iterable=ex_iterable,
@@ -303,12 +297,6 @@ class TraceDataset(IterableDataset):
         """Set the epoch for the dataset iteration."""
         if hasattr(self._ex_iterable, "iteration_count"):
             self._ex_iterable.iteration_count = epoch
-
-
-def get_missing_columns(
-    required_columns: list[str], actual_columns: list[str]
-) -> list[str]:
-    return [c for c in required_columns if c not in actual_columns]
 
 
 @dataclasses.dataclass
@@ -349,40 +337,35 @@ def _raise_if_incorrect_types(dataset: Dataset, features: Features) -> None:
         raise DataNotSupportedError(str(e)) from e
 
 
-def _validate_dataset(
-    config: TraceDataArgs, dataset: Dataset, trace_format: TraceFormatBase
-) -> None:
-    conversations = trace_format.get_conversation_iter(config, dataset)
+def _validate_dataset(config: TraceDataArgs, trace_format: TraceFormatBase) -> None:
     features = Features(
         {
             config.timestamp_column: Value("float"),
             config.prompt_tokens_column: Value("int32"),
             config.output_tokens_column: Value("int32"),
-            **dict(trace_format.required_columns(config)),
+            **dict(trace_format.required_columns()),
         }
     )
-    for conv in conversations:
+    for conv in trace_format:
         if config.conversation_id_column in features:
             features.pop(config.conversation_id_column)
         _raise_if_nonetype_found(conv)
         _raise_if_incorrect_types(conv, features)
         for row in conv:
             _validate_row(row, config)
-            trace_format.validate_row(config, row)
+            trace_format.validate_row(row)
 
 
-def _handle_column_search(
-    config: TraceDataArgs, dataset: Dataset, trace_format: TraceFormatBase
-) -> None:
+def _handle_column_search(config: TraceDataArgs, trace_format: TraceFormatBase) -> None:
     features = Features(
         {
             config.timestamp_column: Value("float"),
             config.prompt_tokens_column: Value("int32"),
             config.output_tokens_column: Value("int32"),
-            **dict(trace_format.required_columns(config)),
+            **dict(trace_format.required_columns()),
         }
     )
-    missing = trace_format.find_required_columns(config, list(features.keys()), dataset)
+    missing = trace_format.find_required_columns(list(features.keys()))
     if missing:
         raise DataNotSupportedError(f"Trace missing required columns: {missing}")
 
@@ -429,8 +412,6 @@ class TraceDatasetDeserializer(DatasetDeserializer):
             raise DataNotSupportedError(f"Trace file has no valid rows: {config.path}")
         dataset.map(_deserialize_nested_data, batched=True)
         trace_format = TraceFormatRegistry.dispatch(config, dataset)
-        _handle_column_search(config, dataset, trace_format)
-        _validate_dataset(config, dataset, trace_format)
-        return TraceDataset(
-            config, dataset, trace_format, processor_factory(), random_seed
-        )
+        _handle_column_search(config, trace_format)
+        _validate_dataset(config, trace_format)
+        return TraceDataset(config, trace_format, processor_factory(), random_seed)

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -132,7 +132,7 @@ class TraceFormatBase(Protocol):
     def __init__(self, config, dataset: Dataset) -> None: ...
 
     def __iter__(self) -> Iterable[Dataset]:
-        """TODO"""
+        """Returns the next conversation as a `Dataset`."""
 
     def reset(self) -> None:
         pass
@@ -140,16 +140,18 @@ class TraceFormatBase(Protocol):
     def required_columns(self) -> Features: ...
 
     def find_required_columns(self, columns: list[str]) -> list[str]:
-        """TODO"""
+        """Checks if all required columns needed by the format exist
+        and are located in the expected place."""
 
     def get_conversation_id_trace(
         self, conversation_location: list[int]
     ) -> list[str] | None:
-        """TODO"""
+        """Returns a trace to a specified location within conversations. Returns
+        `None` if the location does not exist, or if not applicable."""
 
     def validate_row(self, row: dict) -> None:
-        """OUTDATED: Called within `trace_common.TraceExamplesIterable` on
-        initialization, immediately after doing its own checks on the row."""
+        """Called during initialization, immediately after doing
+        format-agnostic validation."""
 
     def create_prompt(
         self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -445,7 +445,7 @@ class TraceDatasetDeserializer(DatasetDeserializer):
             raise DataNotSupportedError(str(e)) from e
         if not dataset:
             raise DataNotSupportedError(f"Trace file has no valid rows: {config.path}")
-        dataset.map(_deserialize_nested_data, batched=True)
+        dataset = dataset.map(_deserialize_nested_data, batched=True)
         trace_format = TraceFormatRegistry.dispatch(config, dataset)
         _handle_column_search(config, trace_format)
         _validate_dataset(config, trace_format)

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -468,7 +468,6 @@ def _load_trace_rows(
     if applicable.
     :return: HuggingFace Dataset (iterable as dicts, column-accessible).
     :raises DataNotSupportedError: For any of the following reasons:
-    - The dataset is empty or has no valid rows
     - A required column contains a NoneType
     - A required column failed during cast to feature type
     """

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -7,6 +7,7 @@ requested input_length for replay benchmarks."""
 from __future__ import annotations
 
 import dataclasses
+import json
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any, Protocol
@@ -30,6 +31,11 @@ from guidellm.data.deserializers.deserializer import (
     DatasetDeserializerFactory,
 )
 from guidellm.data.schemas import DataArgs
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationParentRef,
+    ConversationTurnData,
+)
 from guidellm.utils.hf_datasets import load_dataset_from_file
 from guidellm.utils.json_unwrap import try_json_load
 from guidellm.utils.registry import RegistryMixin
@@ -213,21 +219,51 @@ class TraceExamplesIterable(_BaseExamplesIterable):
 
     def __iter__(self) -> Iterable[tuple[int, dict[str, Any]]]:
         self.iteration_count += 1
-        for conv in self.format:
+        samples_count = 0
+        for conv in self.format:  # type: ignore[attr-defined]
             start_ts = conv[0][self.config.timestamp_column]
-            for row_idx, row in enumerate(conv):
-                prompt = self.format.create_prompt(row, self.processor, self.faker)
-                relative_timestamp = row[self.config.timestamp_column] - start_ts
-                yield (
-                    row_idx,
-                    {
-                        "prompt": prompt,
-                        "prompt_tokens_count": row[self.config.prompt_tokens_column],
-                        "output_tokens_count": row[self.config.output_tokens_column],
-                        "relative_timestamp": relative_timestamp,
-                    },
-                )
+            row = self._create_conversation_row(conv, start_ts)
+            samples_count += len(conv)
+            yield samples_count, row
             self.format.reset()
+
+    def _create_conversation_row(
+        self, conversation: Dataset, start_ts: float
+    ) -> dict[str, Any]:
+        """Build a ``conversation_turns`` payload for linear or branched graphs."""
+        turns = []
+        for turn_idx, turn in enumerate(conversation):
+            parents = []
+            if turn_idx > 0:
+                parents.append(
+                    ConversationParentRef(parent_node_id=f"main_{turn_idx - 1}")
+                )
+
+            # TODO: Branches & subagents
+
+            prompt = self.format.create_prompt(turn, self.processor, self.faker)
+            relative_timestamp = turn[self.config.timestamp_column] - start_ts
+            columns = {
+                "text_column": [prompt],
+                "prompt_tokens_count_column": [turn[self.config.prompt_tokens_column]],
+                "output_tokens_count_column": [turn[self.config.output_tokens_column]],
+                "relative_timestamp_column": [relative_timestamp],
+            }
+            turns.append(
+                ConversationTurnData(
+                    node_id=f"main_{turn_idx}",
+                    agent_id="default",
+                    parents=parents,
+                    columns=columns,
+                )
+            )
+        graph_data = ConversationGraphData(turns=turns)
+        payload = json.dumps(graph_data.model_dump(mode="json"))
+        return {
+            "conversation_turns": (
+                payload.decode() if isinstance(payload, bytes) else payload
+            )
+        }
 
     @property
     def is_typed(self) -> bool:
@@ -235,14 +271,7 @@ class TraceExamplesIterable(_BaseExamplesIterable):
 
     @property
     def features(self) -> Features:
-        return Features(
-            {
-                "prompt": Value("string"),
-                "prompt_tokens_count": Value("int32"),
-                "output_tokens_count": Value("int32"),
-                "relative_timestamp": Value("float"),
-            }
-        )
+        return Features({"conversation_turns": Value("large_string")})
 
     @property
     def num_shards(self) -> int:
@@ -346,7 +375,7 @@ def _validate_dataset(config: TraceDataArgs, trace_format: TraceFormatBase) -> N
             **dict(trace_format.required_columns()),
         }
     )
-    for conv in trace_format:
+    for conv in trace_format:  # type: ignore[attr-defined]
         if config.conversation_id_column in features:
             features.pop(config.conversation_id_column)
         _raise_if_nonetype_found(conv)

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -43,6 +43,7 @@ from guidellm.utils.json_unwrap import (
 from guidellm.utils.registry import RegistryMixin
 
 __all__ = [
+    "MissingColumnsLocation",
     "TraceDataArgs",
     "TraceDatasetDeserializer",
     "TraceFormatBase",
@@ -51,6 +52,7 @@ __all__ = [
     "create_prompt_from_hash_ids",
     "decode_prompt",
     "generate_token_ids",
+    "get_missing_columns",
 ]
 
 
@@ -121,12 +123,27 @@ def create_distinct_token_block(
 
 
 class TraceFormatBase(Protocol):
-    def __init__(self) -> None: ...
+    conversation_locations: list[list[int]]
+
+    def __init__(sel, dataset: Dataset) -> None: ...
 
     def reset(self) -> None:
         pass
 
     def required_columns(self, config) -> Features: ...
+
+    def find_required_columns(
+        self, config, columns: list[str], dataset: Dataset
+    ) -> list[str]:
+        """TODO"""
+
+    def get_conversation_id_trace(
+        self, config, conversation_location: list[int], dataset: Dataset
+    ) -> list[str] | None:
+        """TODO"""
+
+    def get_conversation_iter(self, config, dataset: Dataset) -> Iterable[Dataset]:
+        """TODO"""
 
     def validate_row(self, config, row: dict) -> None:
         """Called within `trace_common.TraceExamplesIterable` on initialization,
@@ -145,13 +162,13 @@ class TraceFormatBase(Protocol):
 
 class TraceFormatRegistry(RegistryMixin[type[TraceFormatBase]]):
     @classmethod
-    def dispatch(cls, config: TraceDataArgs) -> TraceFormatBase:
+    def dispatch(cls, config: TraceDataArgs, dataset: Dataset) -> TraceFormatBase:
         format_from_type = cls.get_registered_object(config.kind)
         if format_from_type is None:
             raise DataNotSupportedError(
                 f"Format type '{config.kind}' is not registered."
             )
-        return format_from_type()
+        return format_from_type(dataset)
 
 
 class TraceDataArgs(DataArgs):
@@ -190,46 +207,40 @@ class TraceExamplesIterable(_BaseExamplesIterable):
     def __init__(
         self,
         config: TraceDataArgs,
-        trace_rows: Dataset,
+        dataset: Dataset,
+        trace_format: TraceFormatBase,
         processor: PreTrainedTokenizerBase,
         random_seed: int,
     ):
         super().__init__()
         self.config = config
-        self.format = TraceFormatRegistry.dispatch(self.config)
+        self.format = trace_format
         self.processor = processor
         self.faker = Faker()
         self.faker.seed_instance(random_seed)
-        self.trace_rows = trace_rows
+        self.dataset = dataset
         self.iteration_count = 0
 
     def __iter__(self) -> Iterable[tuple[int, dict[str, Any]]]:
         self.iteration_count += 1
-        timestamps = self.trace_rows[self.config.timestamp_column]
-        conv_col = self.config.conversation_id_column
-        current_conv = None
-        conv_start_ts = timestamps[0]
-        for row_idx, row in enumerate(self.trace_rows):
-            if conv_col:
-                conv_id = row[conv_col]
-                if conv_id != current_conv:
-                    current_conv = conv_id
-                    conv_start_ts = row[self.config.timestamp_column]
-                    self.format.reset()
-
-            prompt = self.format.create_prompt(
-                self.config, row, self.processor, self.faker
-            )
-            relative_timestamp = timestamps[row_idx] - conv_start_ts
-            yield (
-                row_idx,
-                {
-                    "prompt": prompt,
-                    "prompt_tokens_count": row[self.config.prompt_tokens_column],
-                    "output_tokens_count": row[self.config.output_tokens_column],
-                    "relative_timestamp": relative_timestamp,
-                },
-            )
+        conversations = self.format.get_conversation_iter(self.config, self.dataset)
+        for conv in conversations:
+            start_ts = conv[0][self.config.timestamp_column]
+            for row_idx, row in enumerate(conv):
+                prompt = self.format.create_prompt(
+                    self.config, row, self.processor, self.faker
+                )
+                relative_timestamp = row[self.config.timestamp_column] - start_ts
+                yield (
+                    row_idx,
+                    {
+                        "prompt": prompt,
+                        "prompt_tokens_count": row[self.config.prompt_tokens_column],
+                        "output_tokens_count": row[self.config.output_tokens_column],
+                        "relative_timestamp": relative_timestamp,
+                    },
+                )
+            self.format.reset()
 
     @property
     def is_typed(self) -> bool:
@@ -280,11 +291,14 @@ class TraceDataset(IterableDataset):
     def __init__(
         self,
         config: TraceDataArgs,
-        trace_rows: Dataset,
+        dataset: Dataset,
+        trace_format: TraceFormatBase,
         processor: PreTrainedTokenizerBase,
         random_seed: int,
     ):
-        ex_iterable = TraceExamplesIterable(config, trace_rows, processor, random_seed)
+        ex_iterable = TraceExamplesIterable(
+            config, dataset, trace_format, processor, random_seed
+        )
         super().__init__(
             ex_iterable=ex_iterable,
             info=DatasetInfo(
@@ -299,223 +313,25 @@ class TraceDataset(IterableDataset):
             self._ex_iterable.iteration_count = epoch
 
 
-def _get_missing_columns(
+def get_missing_columns(
     required_columns: list[str], actual_columns: list[str]
 ) -> list[str]:
     return [c for c in required_columns if c not in actual_columns]
 
 
-class Status(enum.Enum):
-    FAILURE = enum.auto()
-    SUCCESS = enum.auto()
-
-
 @dataclasses.dataclass
-class ColumnSearchResult:
-    status: Status
-    checked_json_columns: bool
-    relevant_column_names: Sequence[str | VirtualColumnLocation]
+class MissingColumnsLocation:
+    conversation_location: list[int]
+    columns: list[str]
 
 
-def _is_supported_json_data_type(data: Any) -> bool:
-    """Currently, only JSON data in the form of a list of JSON objects is supported."""
-    return isinstance(data, list) and (len(data) == 0 or isinstance(data[0], dict))
-
-
-def _find_virtual_columns(
-    sample_row: dict[str, Any],
-    json_column_names: list[str],
-    target_columns: list[str],
-) -> ColumnSearchResult:
-    """Required columns must all be stored within the same column."""
-    completely_missing = set(target_columns)
-    for col in json_column_names:
-        sample = sample_row[col]
-        parsed = try_json_load(sample) if isinstance(sample, str) else sample
-        if _is_supported_json_data_type(parsed) and len(parsed) > 0:
-            virtual_columns = [] if parsed is None else list(parsed[0].keys())
-            missing = _get_missing_columns(target_columns, virtual_columns)
-            if not missing:
-                locations = construct_virtual_column_locations(col, target_columns)
-                return ColumnSearchResult(Status.SUCCESS, True, locations)
-            completely_missing = completely_missing.difference(missing)
-    if json_column_names:
-        return ColumnSearchResult(Status.FAILURE, True, list(completely_missing))
-    return ColumnSearchResult(Status.FAILURE, False, [])
-
-
-def _find_required_columns(
-    columns: list[str], dataset: Dataset, conversation_id_col: str | None = None
-) -> ColumnSearchResult:
-    """Returns a list of all missing columns on failure. Otherwise returns a list of
-    the locations of any required columns embedded inside a JSON dict."""
-    missing = _get_missing_columns(columns, dataset.column_names)
-    if missing:
-        # The conversation IDs should always be top-level.
-        if conversation_id_col:
-            if conversation_id_col in missing:
-                return ColumnSearchResult(Status.FAILURE, False, [conversation_id_col])
-            columns.remove(conversation_id_col)
-        json_column_names = get_json_column_names(dataset)
-        sample = dataset[0]
-        result = _find_virtual_columns(sample, json_column_names, columns)
-        if result.status is Status.FAILURE and not result.checked_json_columns:
-            result.relevant_column_names = missing
-        return result
-    return ColumnSearchResult(Status.SUCCESS, False, [])
-
-
-def _get_json_dicts(data: Any) -> Any:
-    if isinstance(data, str):
-        return try_json_load(data)
-    if isinstance(data, list) and len(data) > 0 and isinstance(data[0], str):
-        return list(map(try_json_load, data))
-    return data
-
-
-def _make_columns_from_virtual(
-    batch: dict[str, list],
-    *args,
-    wrapper_col: str,
-    virtual_cols: list[str],
-    conversation_id_col: str | None = None,
-) -> dict[str, list]:
-    """Intended to be used with `datasets.Dataset.map()`."""
-    indices = args[0] if args else []
-    json_dicts = []
-    conv_ids = []
-    for batch_idx, json_dicts_list in enumerate(batch[wrapper_col]):
-        parsed = _get_json_dicts(json_dicts_list)
-        json_dicts.extend(parsed)
-        if conversation_id_col:
-            conv_ids.extend([indices[batch_idx]] * len(parsed))
-    result = {c: [row[c] for row in json_dicts] for c in virtual_cols}
-    if conversation_id_col:
-        result[conversation_id_col] = conv_ids
-    return result
-
-
-def _make_dataset_from_virtual(
-    dataset: Dataset,
-    columns: list[VirtualColumnLocation],
-    conversation_id_col: str | None = None,
-) -> Dataset:
-    """Assumes all virtual columns are stored inside the same column.
-    (Currently ensured by `_is_supported_json_data_type`)."""
-    wrapper_cols, virt_cols = unzip_virtual_column_locations(columns)
-    return dataset.map(
-        _make_columns_from_virtual,
-        batched=True,
-        with_indices=conversation_id_col is not None,
-        remove_columns=dataset.column_names,
-        fn_kwargs={
-            "wrapper_col": wrapper_cols[0],
-            "virtual_cols": virt_cols,
-            "conversation_id_col": conversation_id_col,
-        },
-    )
-
-
-def _handle_column_search_result(
-    result: ColumnSearchResult,
-    dataset: Dataset,
-    conversation_id_col: str | None = None,
-) -> Dataset:
-    """Returns an updated dataset where any required columns found wrapped inside
-    JSON dicts are unwrapped and added as columns to the dataset.
-
-    :raises KeyError: If a required column is missing in the dataset."""
-    if result.status is Status.FAILURE:
-        additional_info = ""
-        if result.checked_json_columns:
-            additional_info = (
-                "Note: GuideLLM searched columns with lists of JSON objects after "
-                "failing to find them at the top level. "
-                "Ensure that all required columns are wrapped in the same column if "
-                "this is where they are intended to be found."
-            )
-        raise KeyError(
-            f"Trace row missing required columns: {result.relevant_column_names} "
-            f"{additional_info}"
-        )
-    if not result.checked_json_columns:
-        return dataset
-    return _make_dataset_from_virtual(
-        dataset,
-        cast("list[VirtualColumnLocation]", result.relevant_column_names),
-        conversation_id_col,
-    )
-
-
-def _load_trace_rows(
-    dataset: Dataset,
-    timestamp_column_name: str,
-    required_columns: Features,
-    conversation_id_column_name: str | None = None,
-) -> Dataset:
-    """
-    Load trace file rows as a HuggingFace Dataset.
-
-    Every column in required_columns must exist in the dataset;
-    otherwise KeyError is raised with a descriptive message.
-    Rows are sorted by column timestamp_column_name.
-
-    :param dataset: The dataset to load.
-    :param timestamp_column_name: Name of the timestamp column used to sort trace rows.
-    :param required_columns: List of column/fields that each row must have. Must contain
-    the timestamp column.
-    :param conversation_id_column_name: The conversation id column used to sort rows,
-    if applicable.
-    :return: HuggingFace Dataset (iterable as dicts, column-accessible).
-    :raises DataNotSupportedError: For any of the following reasons:
-    - A required column contains a NoneType
-    - A required column failed during cast to feature type
-    """
-    result = _find_required_columns(
-        list(required_columns.keys()), dataset, conversation_id_column_name
-    )
-    dataset = _handle_column_search_result(result, dataset, conversation_id_column_name)
-
-    for name, val in required_columns.items():
-        if dataset.data[name].null_count != 0:
-            raise DataNotSupportedError(f"Missing column values in {name}")
-        try:
-            dataset.cast_column(name, val)
-        except ValueError as e:
-            raise DataNotSupportedError(str(e)) from e
-
-    if conversation_id_column_name:
-        return dataset.sort([conversation_id_column_name, timestamp_column_name])
-    return dataset.sort(timestamp_column_name)
-
-
-def validate_path(path: Path) -> None:
+def _validate_path(path: Path) -> None:
     if not path.exists():
         raise DataNotSupportedError(f"Trace file not found: {path}")
     if not path.is_file():
         raise DataNotSupportedError(f"Trace path is not a file: {path}")
     if path.stat().st_size == 0:
         raise DataNotSupportedError(f"Trace file is empty: {path}")
-
-
-def try_load_trace(config: TraceDataArgs, dataset: Dataset) -> Dataset:
-    trace_format = TraceFormatRegistry.dispatch(config)
-    try:
-        return _load_trace_rows(
-            dataset,
-            config.timestamp_column,
-            required_columns=Features(
-                {
-                    config.timestamp_column: Value("float"),
-                    config.prompt_tokens_column: Value("int32"),
-                    config.output_tokens_column: Value("int32"),
-                    **dict(trace_format.required_columns(config)),
-                }
-            ),
-            conversation_id_column_name=config.conversation_id_column,
-        )
-    except (DatasetGenerationError, KeyError, ValueError) as e:
-        raise DataNotSupportedError(str(e)) from e
 
 
 def _validate_row(row: dict, config: TraceDataArgs) -> None:
@@ -528,11 +344,80 @@ def _validate_row(row: dict, config: TraceDataArgs) -> None:
         )
 
 
-def validate_rows(config: TraceDataArgs, trace_rows: Dataset) -> None:
-    trace_format = TraceFormatRegistry.dispatch(config)
-    for row in trace_rows:
-        _validate_row(row, config)
-        trace_format.validate_row(config, row)
+def _raise_if_nonetype_found(dataset: Dataset) -> None:
+    for col in dataset.column_names:
+        if dataset.data[col].null_count != 0:
+            raise DataNotSupportedError(f"Missing column values in {col}")
+
+
+def _raise_if_incorrect_types(dataset: Dataset, features: Features) -> None:
+    try:
+        dataset.cast(features)
+    except ValueError as e:
+        raise DataNotSupportedError(str(e)) from e
+
+
+def _validate_dataset(
+    config: TraceDataArgs, dataset: Dataset, trace_format: TraceFormatBase
+) -> None:
+    conversations = trace_format.get_conversation_iter(config, dataset)
+    features = Features(
+        {
+            config.timestamp_column: Value("float"),
+            config.prompt_tokens_column: Value("int32"),
+            config.output_tokens_column: Value("int32"),
+            **dict(trace_format.required_columns(config)),
+        }
+    )
+    for conv in conversations:
+        if config.conversation_id_column in features.keys():
+            features.pop(config.conversation_id_column)
+        _raise_if_nonetype_found(conv)
+        _raise_if_incorrect_types(conv, features)
+        for row in conv:
+            _validate_row(row, config)
+            trace_format.validate_row(config, row)
+
+
+def _handle_column_search(
+    config: TraceDataArgs, dataset: Dataset, trace_format: TraceFormatBase
+) -> None:
+    features = Features(
+        {
+            config.timestamp_column: Value("float"),
+            config.prompt_tokens_column: Value("int32"),
+            config.output_tokens_column: Value("int32"),
+            **dict(trace_format.required_columns(config)),
+        }
+    )
+    missing = trace_format.find_required_columns(
+        config, list(features.keys()), dataset
+    )
+    if missing:
+        raise DataNotSupportedError(f"Trace missing required columns: {missing}")
+
+
+def _load_all_json_strings(data: list | dict) -> list | dict:
+    iterable = enumerate(data) if isinstance(data, list) else data.items()
+    for k, v in iterable:
+        if isinstance(v, str):
+            res = try_json_load(v)
+            if isinstance(res, (list, dict)):
+                data[k] = res
+        if isinstance(v, (list, dict)):
+            data[k] = _load_all_json_strings(data[k])
+    return data
+
+
+def _deserialize_nested_data(batch: dict[str, list]) -> dict[str, list]:
+    """Intended to be used with `datasets.Dataset.map()`."""
+    sample = {k: v[0] for k, v in batch.items()}
+    for col, val in sample.items():
+        if isinstance(val, str) and isinstance(try_json_load(val), (list, dict)):
+            batch[col] = list(map(try_json_load, batch[col]))
+        if isinstance(val, (list, dict)):
+            batch[col] = list(map(_load_all_json_strings, batch[col]))
+    return batch
 
 
 @DatasetDeserializerFactory.register(["trace_synthetic"])
@@ -545,13 +430,17 @@ class TraceDatasetDeserializer(DatasetDeserializer):
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int = 42,
     ) -> IterableDataset:
-        validate_path(config.path)
+        _validate_path(config.path)
         try:
             dataset = load_dataset_from_file(config.path, **config.load_kwargs)
         except ValueError as e:
             raise DataNotSupportedError(str(e)) from e
         if not dataset:
             raise DataNotSupportedError(f"Trace file has no valid rows: {config.path}")
-        trace_rows = try_load_trace(config, dataset)
-        validate_rows(config, trace_rows)
-        return TraceDataset(config, trace_rows, processor_factory(), random_seed)
+        dataset.map(_deserialize_nested_data, batched=True)
+        trace_format = TraceFormatRegistry.dispatch(config, dataset)
+        _handle_column_search(config, dataset, trace_format)
+        _validate_dataset(config, dataset, trace_format)
+        return TraceDataset(
+            config, dataset, trace_format, processor_factory(), random_seed
+        )

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -127,8 +127,6 @@ def create_distinct_token_block(
 
 
 class TraceFormatBase(Protocol):
-    conversation_locations: list[list[int]]
-
     def __init__(self, config, dataset: Dataset) -> None: ...
 
     def __iter__(self) -> Iterable[Dataset]:
@@ -142,12 +140,6 @@ class TraceFormatBase(Protocol):
     def find_required_columns(self, columns: list[str]) -> list[str]:
         """Checks if all required columns needed by the format exist
         and are located in the expected place."""
-
-    def get_conversation_id_trace(
-        self, conversation_location: list[int]
-    ) -> list[str] | None:
-        """Returns a trace to a specified location within conversations. Returns
-        `None` if the location does not exist, or if not applicable."""
 
     def validate_row(self, row: dict) -> None:
         """Called during initialization, immediately after doing

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -417,7 +417,11 @@ def _deserialize_nested_data(batch: dict[str, list]) -> dict[str, list]:
     for col, val in sample.items():
         if isinstance(val, str) and isinstance(try_json_load(val), (list, dict)):
             batch[col] = list(map(try_json_load, batch[col]))
-        if isinstance(val, (list, dict)):
+        if isinstance(val, dict) or (
+            isinstance(val, list)
+            and len(val) > 0
+            and isinstance(val[0], (str, list, dict))
+        ):
             batch[col] = list(map(_load_all_json_strings, batch[col]))
     return batch
 

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -7,10 +7,9 @@ requested input_length for replay benchmarks."""
 from __future__ import annotations
 
 import dataclasses
-import enum
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 import numpy as np
 from datasets import (
@@ -20,7 +19,6 @@ from datasets import (
     IterableDataset,
     Value,
 )
-from datasets.exceptions import DatasetGenerationError
 from datasets.iterable_dataset import _BaseExamplesIterable
 from faker import Faker
 from pydantic import Field
@@ -33,13 +31,7 @@ from guidellm.data.deserializers.deserializer import (
 )
 from guidellm.data.schemas import DataArgs
 from guidellm.utils.hf_datasets import load_dataset_from_file
-from guidellm.utils.json_unwrap import (
-    VirtualColumnLocation,
-    construct_virtual_column_locations,
-    get_json_column_names,
-    try_json_load,
-    unzip_virtual_column_locations,
-)
+from guidellm.utils.json_unwrap import try_json_load
 from guidellm.utils.registry import RegistryMixin
 
 __all__ = [
@@ -125,7 +117,7 @@ def create_distinct_token_block(
 class TraceFormatBase(Protocol):
     conversation_locations: list[list[int]]
 
-    def __init__(sel, dataset: Dataset) -> None: ...
+    def __init__(self, dataset: Dataset) -> None: ...
 
     def reset(self) -> None:
         pass
@@ -370,7 +362,7 @@ def _validate_dataset(
         }
     )
     for conv in conversations:
-        if config.conversation_id_column in features.keys():
+        if config.conversation_id_column in features:
             features.pop(config.conversation_id_column)
         _raise_if_nonetype_found(conv)
         _raise_if_incorrect_types(conv, features)
@@ -390,9 +382,7 @@ def _handle_column_search(
             **dict(trace_format.required_columns(config)),
         }
     )
-    missing = trace_format.find_required_columns(
-        config, list(features.keys()), dataset
-    )
+    missing = trace_format.find_required_columns(config, list(features.keys()), dataset)
     if missing:
         raise DataNotSupportedError(f"Trace missing required columns: {missing}")
 

--- a/src/guidellm/data/deserializers/trace_minimal.py
+++ b/src/guidellm/data/deserializers/trace_minimal.py
@@ -10,7 +10,7 @@ line with a synthetic prompt matching the requested input_length for replay benc
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, Literal
+from typing import Literal
 
 from datasets import Dataset, Features
 from faker import Faker
@@ -56,7 +56,7 @@ class MinimalTraceFormat(TraceFormatBase):
         self,
         config: MinimalTraceFormatArgs,  # noqa: ARG002
         columns: list[str],
-        dataset: Dataset
+        dataset: Dataset,
     ) -> list[str]:
         return get_missing_columns(columns, dataset.column_names)
 
@@ -67,11 +67,11 @@ class MinimalTraceFormat(TraceFormatBase):
         dataset: Dataset,  # noqa: ARG002
     ) -> list[str] | None:
         return None
-    
+
     def get_conversation_iter(
         self,
-        config: MinimalTraceFormat,  # noqa: ARG002
-        dataset: Dataset
+        config: MinimalTraceFormatArgs,  # noqa: ARG002
+        dataset: Dataset,
     ) -> Iterable[Dataset]:
         yield dataset.sort(config.timestamp_column)
 

--- a/src/guidellm/data/deserializers/trace_minimal.py
+++ b/src/guidellm/data/deserializers/trace_minimal.py
@@ -40,56 +40,36 @@ class MinimalTraceFormatArgs(TraceDataArgs):
 
 @TraceFormatRegistry.register("trace_synthetic")
 class MinimalTraceFormat(TraceFormatBase):
-    def __init__(
-        self,
-        dataset: Dataset,  # noqa: ARG002
-    ) -> None:
+    def __init__(self, config: MinimalTraceFormatArgs, dataset: Dataset) -> None:
+        self.config = config
+        self.dataset = dataset
         self.conversation_locations = [[0]]
 
-    def required_columns(
-        self,
-        config: MinimalTraceFormatArgs,  # noqa: ARG002
-    ) -> Features:
-        return []
+    def __iter__(self) -> Iterable[Dataset]:
+        yield self.dataset.sort(self.config.timestamp_column)
 
-    def find_required_columns(
-        self,
-        config: MinimalTraceFormatArgs,  # noqa: ARG002
-        columns: list[str],
-        dataset: Dataset,
-    ) -> list[str]:
-        return get_missing_columns(columns, dataset.column_names)
+    def required_columns(self) -> Features:
+        return {}
+
+    def find_required_columns(self, columns: list[str]) -> list[str]:
+        return get_missing_columns(columns, self.dataset.column_names)
 
     def get_conversation_id_trace(
         self,
-        config: MinimalTraceFormatArgs,  # noqa: ARG002
         conversation_location: list[int],  # noqa: ARG002
-        dataset: Dataset,  # noqa: ARG002
     ) -> list[str] | None:
         return None
 
-    def get_conversation_iter(
-        self,
-        config: MinimalTraceFormatArgs,  # noqa: ARG002
-        dataset: Dataset,
-    ) -> Iterable[Dataset]:
-        yield dataset.sort(config.timestamp_column)
-
     def validate_row(
         self,
-        config: MinimalTraceFormatArgs,  # noqa: ARG002
         row: dict,  # noqa: ARG002
     ) -> None:
         return
 
     def create_prompt(
-        self,
-        config: MinimalTraceFormatArgs,
-        row: dict,
-        processor: PreTrainedTokenizerBase,
-        faker: Faker,
+        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
     ) -> str:
         token_ids = generate_token_ids(
-            row[config.prompt_tokens_column], processor, faker
+            row[self.config.prompt_tokens_column], processor, faker
         )
         return decode_prompt(processor, list(token_ids))

--- a/src/guidellm/data/deserializers/trace_minimal.py
+++ b/src/guidellm/data/deserializers/trace_minimal.py
@@ -9,9 +9,10 @@ line with a synthetic prompt matching the requested input_length for replay benc
 
 from __future__ import annotations
 
-from typing import Literal
+from collections.abc import Iterable
+from typing import Any, Literal
 
-from datasets import Features
+from datasets import Dataset, Features
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -22,6 +23,7 @@ from guidellm.data.deserializers.trace_common import (
     TraceFormatRegistry,
     decode_prompt,
     generate_token_ids,
+    get_missing_columns,
 )
 from guidellm.data.schemas import DataArgs
 
@@ -38,14 +40,40 @@ class MinimalTraceFormatArgs(TraceDataArgs):
 
 @TraceFormatRegistry.register("trace_synthetic")
 class MinimalTraceFormat(TraceFormatBase):
-    def __init__(self) -> None:
-        pass
+    def __init__(
+        self,
+        dataset: Dataset,  # noqa: ARG002
+    ) -> None:
+        self.conversation_locations = [[0]]
 
     def required_columns(
         self,
         config: MinimalTraceFormatArgs,  # noqa: ARG002
     ) -> Features:
         return []
+
+    def find_required_columns(
+        self,
+        config: MinimalTraceFormatArgs,  # noqa: ARG002
+        columns: list[str],
+        dataset: Dataset
+    ) -> list[str]:
+        return get_missing_columns(columns, dataset.column_names)
+
+    def get_conversation_id_trace(
+        self,
+        config: MinimalTraceFormatArgs,  # noqa: ARG002
+        conversation_location: list[int],  # noqa: ARG002
+        dataset: Dataset,  # noqa: ARG002
+    ) -> list[str] | None:
+        return None
+    
+    def get_conversation_iter(
+        self,
+        config: MinimalTraceFormat,  # noqa: ARG002
+        dataset: Dataset
+    ) -> Iterable[Dataset]:
+        yield dataset.sort(config.timestamp_column)
 
     def validate_row(
         self,

--- a/src/guidellm/data/deserializers/trace_minimal.py
+++ b/src/guidellm/data/deserializers/trace_minimal.py
@@ -43,7 +43,6 @@ class MinimalTraceFormat(TraceFormatBase):
     def __init__(self, config: MinimalTraceFormatArgs, dataset: Dataset) -> None:
         self.config = config
         self.dataset = dataset
-        self.conversation_locations = [[0]]
 
     def __iter__(self) -> Iterable[Dataset]:
         yield self.dataset.sort(self.config.timestamp_column)
@@ -53,12 +52,6 @@ class MinimalTraceFormat(TraceFormatBase):
 
     def find_required_columns(self, columns: list[str]) -> list[str]:
         return get_missing_columns(columns, self.dataset.column_names)
-
-    def get_conversation_id_trace(
-        self,
-        conversation_location: list[int],  # noqa: ARG002
-    ) -> list[str] | None:
-        return None
 
     def validate_row(
         self,

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -95,12 +95,12 @@ class MooncakeTraceFormat(TraceFormatBase):
 
     def required_columns(self, config: MooncakeTraceFormatArgs) -> Features:
         return Features({config.hash_ids_column: List(Value("int32"))})
-    
+
     def find_required_columns(
         self,
         config: MooncakeTraceFormatArgs,  # noqa: ARG002
         columns: list[str],
-        dataset: Dataset
+        dataset: Dataset,
     ) -> list[str]:
         return get_missing_columns(columns, dataset.column_names)
 
@@ -114,8 +114,8 @@ class MooncakeTraceFormat(TraceFormatBase):
 
     def get_conversation_iter(
         self,
-        config: MooncakeTraceFormat,  # noqa: ARG002
-        dataset: Dataset
+        config: MooncakeTraceFormatArgs,  # noqa: ARG002
+        dataset: Dataset,
     ) -> Iterable[Dataset]:
         yield dataset.sort(config.timestamp_column)
 

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -87,7 +87,6 @@ class MooncakeTraceFormat(TraceFormatBase):
     def __init__(self, config: MooncakeTraceFormatArgs, dataset: Dataset) -> None:
         self.config = config
         self.dataset = dataset
-        self.conversation_locations = [[0]]
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
@@ -100,12 +99,6 @@ class MooncakeTraceFormat(TraceFormatBase):
 
     def find_required_columns(self, columns: list[str]) -> list[str]:
         return get_missing_columns(columns, self.dataset.column_names)
-
-    def get_conversation_id_trace(
-        self,
-        conversation_location: list[int],  # noqa: ARG002
-    ) -> list[str] | None:
-        return None
 
     def validate_row(self, row: dict) -> None:
         n_in = row[self.config.prompt_tokens_column]

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -84,69 +84,56 @@ class MooncakeTraceFormat(TraceFormatBase):
 
     Generated prompts match the prompt token count of the row."""
 
-    def __init__(
-        self,
-        dataset: Dataset,  # noqa: ARG002
-    ) -> None:
+    def __init__(self, config: MooncakeTraceFormatArgs, dataset: Dataset) -> None:
+        self.config = config
+        self.dataset = dataset
         self.conversation_locations = [[0]]
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
+    
+    def __iter__(self) -> Iterable[Dataset]:
+        yield self.dataset.sort(self.config.timestamp_column)
 
-    def required_columns(self, config: MooncakeTraceFormatArgs) -> Features:
-        return Features({config.hash_ids_column: List(Value("int32"))})
+    def required_columns(self) -> Features:
+        return Features({self.config.hash_ids_column: List(Value("int32"))})
 
-    def find_required_columns(
-        self,
-        config: MooncakeTraceFormatArgs,  # noqa: ARG002
-        columns: list[str],
-        dataset: Dataset,
-    ) -> list[str]:
-        return get_missing_columns(columns, dataset.column_names)
+    def find_required_columns(self, columns: list[str]) -> list[str]:
+        return get_missing_columns(columns, self.dataset.column_names)
 
     def get_conversation_id_trace(
         self,
-        config: MooncakeTraceFormatArgs,  # noqa: ARG002
         conversation_location: list[int],  # noqa: ARG002
-        dataset: Dataset,  # noqa: ARG002
     ) -> list[str] | None:
         return None
 
-    def get_conversation_iter(
-        self,
-        config: MooncakeTraceFormatArgs,  # noqa: ARG002
-        dataset: Dataset,
-    ) -> Iterable[Dataset]:
-        yield dataset.sort(config.timestamp_column)
-
-    def validate_row(self, config: MooncakeTraceFormatArgs, row: dict) -> None:
-        n_in = row[config.prompt_tokens_column]
-        n_blocks = len(row[config.hash_ids_column])
-        for hash_id in row[config.hash_ids_column]:
+    def validate_row(self, row: dict) -> None:
+        n_in = row[self.config.prompt_tokens_column]
+        n_blocks = len(row[self.config.hash_ids_column])
+        block_size = self.config.hash_id_block_size
+        for hash_id in row[self.config.hash_ids_column]:
             if hash_id < 0:
                 raise DataNotSupportedError(
                     f"Hash ID must be non-negative, got {hash_id}"
                 )
-        if math.ceil(n_in / config.hash_id_block_size) != n_blocks:
+        if math.ceil(n_in / block_size) != n_blocks:
             raise DataNotSupportedError(
                 f"Input token count of {n_in} split into blocks of size "
-                f"{config.hash_id_block_size} does not match given {n_blocks} blocks"
+                f"{block_size} does not match given {n_blocks} blocks"
             )
 
     def create_prompt(
-        self,
-        config: MooncakeTraceFormatArgs,
-        row: dict,
-        processor: PreTrainedTokenizerBase,
-        faker: Faker,
+        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
     ) -> str:
         """Before generating the prompt, this first generates a block of tokens for
         each hash ID that has not already been seen."""
-        ids = row[config.hash_ids_column]
+        ids = row[self.config.hash_ids_column]
         for idx, hash_id in enumerate(ids):
             if hash_id not in self.hash_id_table:
                 prev_id = None if idx == 0 else ids[idx - 1]
-                num_tokens = _calculate_required_prompt_tokens(config, row, hash_id)
+                num_tokens = _calculate_required_prompt_tokens(
+                    self.config, row, hash_id
+                )
                 self.sibling_token_blocks.setdefault(prev_id, set())
                 self.hash_id_table[hash_id] = create_distinct_token_block(
                     num_tokens,

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -91,7 +91,7 @@ class MooncakeTraceFormat(TraceFormatBase):
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
-    
+
     def __iter__(self) -> Iterable[Dataset]:
         yield self.dataset.sort(self.config.timestamp_column)
 

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -10,9 +10,10 @@ same previous hash ID.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable
 from typing import Any, Literal
 
-from datasets import Features, List, Value
+from datasets import Dataset, Features, List, Value
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -28,6 +29,7 @@ from guidellm.data.deserializers.trace_common import (
     TraceFormatRegistry,
     create_distinct_token_block,
     create_prompt_from_hash_ids,
+    get_missing_columns,
 )
 from guidellm.data.schemas import DataArgs
 
@@ -82,12 +84,40 @@ class MooncakeTraceFormat(TraceFormatBase):
 
     Generated prompts match the prompt token count of the row."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        dataset: Dataset,  # noqa: ARG002
+    ) -> None:
+        self.conversation_locations = [[0]]
+
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
 
     def required_columns(self, config: MooncakeTraceFormatArgs) -> Features:
         return Features({config.hash_ids_column: List(Value("int32"))})
+    
+    def find_required_columns(
+        self,
+        config: MooncakeTraceFormatArgs,  # noqa: ARG002
+        columns: list[str],
+        dataset: Dataset
+    ) -> list[str]:
+        return get_missing_columns(columns, dataset.column_names)
+
+    def get_conversation_id_trace(
+        self,
+        config: MooncakeTraceFormatArgs,  # noqa: ARG002
+        conversation_location: list[int],  # noqa: ARG002
+        dataset: Dataset,  # noqa: ARG002
+    ) -> list[str] | None:
+        return None
+
+    def get_conversation_iter(
+        self,
+        config: MooncakeTraceFormat,  # noqa: ARG002
+        dataset: Dataset
+    ) -> Iterable[Dataset]:
+        yield dataset.sort(config.timestamp_column)
 
     def validate_row(self, config: MooncakeTraceFormatArgs, row: dict) -> None:
         n_in = row[config.prompt_tokens_column]

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -133,17 +133,9 @@ class WEKATraceFormat(TraceFormatBase):
             )
 
     def __iter__(self) -> Iterable[Dataset]:
-        curr_conv = 0
-        while True:
-            try:
-                trace_rows = self.dataset[self.requests_col][
-                    self.conversation_locations[curr_conv][0]
-                ]
-                trace_rows = Dataset.from_list(trace_rows)
-                trace_rows.sort(self.config.timestamp_column)
-            except IndexError:
-                break
-            curr_conv += 1
+        for row in self.dataset:
+            trace_rows = Dataset.from_list(row[self.requests_col])
+            trace_rows.sort(self.config.timestamp_column)
             yield trace_rows
 
     def reset(self) -> None:

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -119,7 +119,9 @@ class WEKATraceFormat(TraceFormatBase):
 
     Generated prompts match the prompt token count of the row."""
 
-    def __init__(self, dataset: Dataset) -> None:
+    def __init__(self, config: WEKATraceFormatArgs, dataset: Dataset) -> None:
+        self.config = config
+        self.dataset = dataset
         self.conversation_locations = [[loc] for loc in list(range(len(dataset)))]
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
@@ -130,81 +132,69 @@ class WEKATraceFormat(TraceFormatBase):
                 "WEKA format: Failed to find requests column or requests was empty"
             )
 
-    def reset(self) -> None:
-        self.hash_id_table = {}
-        self.sibling_token_blocks = {}
-
-    def required_columns(self, config: WEKATraceFormatArgs) -> Features:
-        return Features(
-            {
-                config.conversation_id_column: Value("string"),
-                config.hash_ids_column: List(Value("int32")),
-            }
-        )
-
-    def find_required_columns(
-        self, config: WEKATraceFormatArgs, columns: list[str], dataset: Dataset
-    ) -> list[str]:
-        """TODO: Handle edge cases"""
-        conv_col = config.conversation_id_column
-        if conv_col not in dataset.column_names:
-            return [config.conversation_id_column]
-        columns.remove(conv_col)
-        return get_missing_columns(columns, dataset[self.requests_col][0][0].keys())
-
-    def get_conversation_id_trace(
-        self,
-        config: WEKATraceFormatArgs,
-        conversation_location: list[int],
-        dataset: Dataset,
-    ) -> list[str] | None:
-        return [dataset[conversation_location[0]][config.conversation_id_column]]
-
-    def get_conversation_iter(
-        self, config: WEKATraceFormatArgs, dataset: Dataset
-    ) -> Iterable[Dataset]:
+    def __iter__(self) -> Iterable[Dataset]:
         curr_conv = 0
         while True:
             try:
-                trace_rows = dataset[self.requests_col][
+                trace_rows = self.dataset[self.requests_col][
                     self.conversation_locations[curr_conv][0]
                 ]
                 trace_rows = Dataset.from_list(trace_rows)
-                trace_rows.sort(config.timestamp_column)
+                trace_rows.sort(self.config.timestamp_column)
             except IndexError:
                 break
             curr_conv += 1
             yield trace_rows
 
-    def validate_row(self, config: WEKATraceFormatArgs, row: dict) -> None:
-        """WEKA format drops what would be the partially filled hash ID at the end of
-        the chain. Some popular datasets
-        (e.g. `semianalysisai/cc-traces-weka-no-subagents-051226`) still contain the
-        trailing hash ID.
-        In this case, `validate_row` tolerates the addition, and handles it in
-        `create_prompt`."""
-        n_in = row[config.prompt_tokens_column]
-        n_blocks = len(row[config.hash_ids_column])
-        for hash_id in row[config.hash_ids_column]:
+    def reset(self) -> None:
+        self.hash_id_table = {}
+        self.sibling_token_blocks = {}
+
+    def required_columns(self) -> Features:
+        return Features(
+            {
+                self.config.conversation_id_column: Value("string"),
+                self.config.hash_ids_column: List(Value("int32")),
+            }
+        )
+
+    def find_required_columns(self, columns: list[str]) -> list[str]:
+        """TODO: Handle edge cases"""
+        conv_col = self.config.conversation_id_column
+        if conv_col not in self.dataset.column_names:
+            return [self.config.conversation_id_column]
+        columns.remove(conv_col)
+        return get_missing_columns(
+            columns, self.dataset[self.requests_col][0][0].keys()
+        )
+
+    def get_conversation_id_trace(
+        self, conversation_location: list[int]
+    ) -> list[str] | None:
+        return [
+            self.dataset[conversation_location[0]][self.config.conversation_id_column]
+        ]
+
+    def validate_row(self, row: dict) -> None:
+        n_in = row[self.config.prompt_tokens_column]
+        n_blocks = len(row[self.config.hash_ids_column])
+        block_size = self.config.hash_id_block_size
+        for hash_id in row[self.config.hash_ids_column]:
             if hash_id < 0:
                 raise DataNotSupportedError(
                     f"Hash ID must be non-negative, got {hash_id}"
                 )
-        expected = n_in / config.hash_id_block_size
+        expected = n_in / block_size
         if math.floor(expected) != n_blocks and math.ceil(expected) != n_blocks:
             raise DataNotSupportedError(
                 f"Input token count of {n_in} split into blocks of size "
-                f"{config.hash_id_block_size} full blocks and "
-                f"{config.hash_id_block_size} full blocks + partially filled "
+                f"{block_size} full blocks and "
+                f"{block_size} full blocks + partially filled "
                 f"trailing block does not match given {n_blocks} blocks"
             )
 
     def create_prompt(
-        self,
-        config: WEKATraceFormatArgs,
-        row: dict,
-        processor: PreTrainedTokenizerBase,
-        faker: Faker,
+        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
     ) -> str:
         """Before generating the prompt, this first generates a block of tokens for
         each hash ID that has not already been seen.
@@ -212,8 +202,10 @@ class WEKATraceFormat(TraceFormatBase):
         Hash IDs that are partially filled are discarded to match the specification.
         Remainder of the prompt is created after the creation via hash IDs token
         blocks."""
-        ids = row[config.hash_ids_column]
-        expected = row[config.prompt_tokens_column] / config.hash_id_block_size
+        ids = row[self.config.hash_ids_column]
+        n_in = row[self.config.prompt_tokens_column]
+        block_size = self.config.hash_id_block_size
+        expected = n_in / block_size
         if math.floor(expected) != len(ids) and math.ceil(expected) == len(ids):
             ids.pop()
         for idx, hash_id in enumerate(ids):
@@ -221,18 +213,14 @@ class WEKATraceFormat(TraceFormatBase):
                 prev_id = None if idx == 0 else ids[idx - 1]
                 self.sibling_token_blocks.setdefault(prev_id, set())
                 self.hash_id_table[hash_id] = create_distinct_token_block(
-                    config.hash_id_block_size,
+                    block_size,
                     self.sibling_token_blocks[prev_id],
                     processor,
                     faker,
                 )
                 self.sibling_token_blocks[prev_id].add(self.hash_id_table[hash_id])
         prompt = create_prompt_from_hash_ids(ids, self.hash_id_table, processor)
-        remainder = _generate_remaining_prompt(
-            row[config.prompt_tokens_column] % config.hash_id_block_size,
-            processor,
-            faker,
-        )
+        remainder = _generate_remaining_prompt(n_in % block_size, processor, faker)
         if not prompt:
             return remainder
         if not remainder:

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -17,9 +17,10 @@ The results from datasets including these features will be unreliable.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable
 from typing import Any, Literal
 
-from datasets import Features, List, Value
+from datasets import Dataset, Features, List, Value
 from faker import Faker
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
@@ -37,10 +38,19 @@ from guidellm.data.deserializers.trace_common import (
     create_prompt_from_hash_ids,
     decode_prompt,
     generate_token_ids,
+    get_missing_columns,
 )
 from guidellm.data.schemas import DataArgs
 
 __all__ = ["WEKATraceFormatArgs"]
+
+
+def _find_requests_column(dataset: Dataset) -> str | None:
+    for name, val in dataset.features.items():
+        if isinstance(val, List):
+            if len(dataset[name][0]) > 0 and isinstance(dataset[name][0][0], dict):
+                return name
+    return None
 
 
 def _generate_remaining_prompt(
@@ -106,9 +116,16 @@ class WEKATraceFormat(TraceFormatBase):
 
     Generated prompts match the prompt token count of the row."""
 
-    def __init__(self) -> None:
+    def __init__(self, dataset: Dataset) -> None:
+        self.conversation_locations = [[loc] for loc in list(range(len(dataset)))]
+
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
+        self.requests_col = _find_requests_column(dataset)
+        if self.requests_col is None:
+            raise DataNotSupportedError(
+                "WEKA format: Failed to find requests column or requests was empty"
+            )
 
     def reset(self) -> None:
         self.hash_id_table = {}
@@ -121,6 +138,40 @@ class WEKATraceFormat(TraceFormatBase):
                 config.hash_ids_column: List(Value("int32")),
             }
         )
+
+    def find_required_columns(
+        self, config: WEKATraceFormatArgs, columns: list[str], dataset: Dataset
+    ) -> list[str]:
+        """TODO: Handle edge cases"""
+        conv_col = config.conversation_id_column
+        if conv_col not in dataset.column_names:
+            return [config.conversation_id_column]
+        columns.remove(conv_col)
+        return get_missing_columns(columns, dataset[self.requests_col][0][0].keys())
+
+    def get_conversation_id_trace(
+        self,
+        config: WEKATraceFormatArgs,
+        conversation_location: list[int],
+        dataset: Dataset,
+    ) -> list[str] | None:
+        return [dataset[conversation_location[0]][config.conversation_id_column]]
+
+    def get_conversation_iter(
+        self, config: WEKATraceFormatArgs, dataset: Dataset
+    ) -> Iterable[Dataset]:
+        curr_conv = 0
+        while True:
+            try:
+                trace_rows = dataset[self.requests_col][
+                    self.conversation_locations[curr_conv][0]
+                ]
+                trace_rows = Dataset.from_list(trace_rows)
+                trace_rows.sort(config.timestamp_column)
+            except IndexError:
+                break
+            curr_conv += 1
+            yield trace_rows
 
     def validate_row(self, config: WEKATraceFormatArgs, row: dict) -> None:
         """WEKA format drops what would be the partially filled hash ID at the end of

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -47,9 +47,12 @@ __all__ = ["WEKATraceFormatArgs"]
 
 def _find_requests_column(dataset: Dataset) -> str | None:
     for name, val in dataset.features.items():
-        if isinstance(val, List):
-            if len(dataset[name][0]) > 0 and isinstance(dataset[name][0][0], dict):
-                return name
+        if (
+            isinstance(val, List)
+            and len(dataset[name][0]) > 0
+            and isinstance(dataset[name][0][0], dict)
+        ):
+            return name
     return None
 
 

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -122,7 +122,6 @@ class WEKATraceFormat(TraceFormatBase):
     def __init__(self, config: WEKATraceFormatArgs, dataset: Dataset) -> None:
         self.config = config
         self.dataset = dataset
-        self.conversation_locations = [[loc] for loc in list(range(len(dataset)))]
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
@@ -159,13 +158,6 @@ class WEKATraceFormat(TraceFormatBase):
         return get_missing_columns(
             columns, self.dataset[self.requests_col][0][0].keys()
         )
-
-    def get_conversation_id_trace(
-        self, conversation_location: list[int]
-    ) -> list[str] | None:
-        return [
-            self.dataset[conversation_location[0]][self.config.conversation_id_column]
-        ]
 
     def validate_row(self, row: dict) -> None:
         n_in = row[self.config.prompt_tokens_column]

--- a/src/guidellm/utils/json_unwrap.py
+++ b/src/guidellm/utils/json_unwrap.py
@@ -1,31 +1,7 @@
-import dataclasses
 import json
 from typing import Any
 
 from datasets import Dataset, IterableDataset
-
-
-@dataclasses.dataclass
-class VirtualColumnLocation:
-    wrapper_column: str
-    virtual_column: str
-
-
-def construct_virtual_column_locations(
-    wrapper_column: str, virtual_columns: list[str]
-) -> list[VirtualColumnLocation]:
-    return [VirtualColumnLocation(wrapper_column, c) for c in virtual_columns]
-
-
-def unzip_virtual_column_locations(
-    column_locations: list[VirtualColumnLocation],
-) -> tuple[tuple[str], tuple[str]]:
-    """Returns a tuple of wrapper columns and a tuple of virtual columns,
-    in that order."""
-    wrapper_cols, virt_cols = tuple(
-        zip(*(dataclasses.astuple(c) for c in column_locations), strict=True)
-    ) or ((), ())
-    return (wrapper_cols, virt_cols)
 
 
 def try_json_load(json_string: str) -> Any:

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -35,6 +35,7 @@ from guidellm.scheduler import (
     TraceReplayStrategy,
     WorkerProcessGroup,
 )
+from guidellm.scheduler.schemas import ConversationGraph, ConversationNode
 from guidellm.schemas import GenerationRequest, RequestSettings
 from guidellm.schemas.conversation_graph import GenerativeConversationGraph
 from tests.unit.testing_utils import async_timeout
@@ -62,7 +63,7 @@ def _write_trace(path: Path, lines: list[str]) -> Path:
 
 def _requests_from_trace(
     trace_path: Path,
-) -> tuple[list[GenerativeConversationGraph], list[float]]:
+) -> tuple[list[ConversationGraph[GenerationRequest]], list[float]]:
     deserializer = TraceDatasetDeserializer()
     dataset = deserializer(
         config=MinimalTraceFormatArgs(path=trace_path),
@@ -74,21 +75,35 @@ def _requests_from_trace(
     mapper.setup_data([dataset])
     finalizer = GenerativeRequestFinalizer(GenerativeRequestFinalizerArgs())
 
-    conversations: list[GenerativeConversationGraph] = []
     relative_timestamps: list[float] = []
-    for idx, row in enumerate(dataset):
-        mapped = mapper([{"dataset": row}])
-        graph = finalizer(mapped)
-        assert isinstance(graph, GenerativeConversationGraph)
-        assert len(graph.nodes) == 1
-        node = next(iter(graph.nodes.values()))
+    conv = next(iter(dataset))
+    mapped = mapper([{"dataset": conv}])
+    graph = finalizer(mapped)
+    assert isinstance(graph, GenerativeConversationGraph)
+    assert len(graph.nodes) == 10
+
+    graphs: list[ConversationGraph[GenerationRequest]] = []
+    for idx, node in enumerate(graph.nodes.values()):
         node.request.request_id = f"req_{idx}"
-        conversations.append(graph)
         offset = node.settings.relative_timestamp
         assert offset is not None
         relative_timestamps.append(offset)
+        graphs.append(
+            ConversationGraph(
+                graph_id=f"graph_req_{idx}",
+                nodes={
+                    node.node_id: ConversationNode(
+                        node_id=node.node_id,
+                        agent_id=node.agent_id,
+                        request=node.request,
+                        settings=node.settings,
+                    )
+                },
+                edges=[],
+            )
+        )
 
-    return conversations, relative_timestamps
+    return graphs, relative_timestamps
 
 
 class FastMockBackend(BackendInterface):
@@ -117,14 +132,21 @@ class FastMockBackend(BackendInterface):
     async def process_shutdown(self):
         pass
 
-    async def resolve(self, request, request_info, request_history):
-        _ = request_history
+    async def resolve(self, request, request_info, history=None):
         await asyncio.sleep(self._resolve_delay)
-        yield f"ok_{request.request_id}", request_info
+        rid = (
+            request.request_id
+            if hasattr(request, "request_id")
+            else request["request_id"]
+        )
+        yield f"ok_{rid}", request_info
 
 
-def _request_index(request: GenerationRequest) -> int:
-    return int(request.request_id.removeprefix("req_"))
+def _request_index(request) -> int:
+    rid = (
+        request.request_id if hasattr(request, "request_id") else request["request_id"]
+    )
+    return int(rid.removeprefix("req_"))
 
 
 @pytest.mark.smoke

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -149,9 +149,9 @@ class TestTraceDatasetDeserializer:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for i, turn in enumerate(conv):
-            assert turn.columns["relative_timestamp"] == i
-            assert turn.columns["prompt_tokens_count"] == (i + 1) * 10
-            assert turn.columns["output_tokens_count"] == i + 1
+            assert turn.columns["relative_timestamp_column"][0] == i
+            assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
+            assert turn.columns["output_tokens_count_column"][0] == i + 1
 
     @pytest.mark.sanity
     def test_loads_csv(self, tmp_path: Path, deserializer):
@@ -163,9 +163,9 @@ class TestTraceDatasetDeserializer:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for i, turn in enumerate(conv):
-            assert turn.columns["relative_timestamp"] == i
-            assert turn.columns["prompt_tokens_count"] == (i + 1) * 10
-            assert turn.columns["output_tokens_count"] == i + 1
+            assert turn.columns["relative_timestamp_column"][0] == i
+            assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
+            assert turn.columns["output_tokens_count_column"][0] == i + 1
 
     @pytest.mark.smoke
     def test_loads_sorted_rows_and_keeps_token_columns_aligned(
@@ -188,13 +188,13 @@ class TestTraceDatasetDeserializer:
         conv = load_graph_turns(next(iter(ds)))
         proc = mock_processor()
         for i, turn in enumerate(conv):
-            n_in = turn.columns["prompt_tokens_count"]
+            n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == i + 1
-            assert turn.columns["output_tokens_count"] == (i + 1) * 10
-            assert len(proc.encode(turn.columns["prompt"])) == n_in
+            assert turn.columns["output_tokens_count_column"][0] == (i + 1) * 10
+            assert len(proc.encode(turn.columns["text_column"][0])) == n_in
 
     @pytest.mark.smoke
-    def test_emits_relative_timestamp_column_sorted_from_trace(
+    def test_emits_relative_timestamp_column_column_sorted_from_trace(
         self, tmp_path: Path, deserializer
     ):
         n_rows = 5
@@ -212,7 +212,7 @@ class TestTraceDatasetDeserializer:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for i, turn in enumerate(conv):
-            assert turn.columns["relative_timestamp"] == i
+            assert turn.columns["relative_timestamp_column"][0] == i
 
     @pytest.mark.smoke
     def test_rejects_invalid_path(self, deserializer):

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,10 @@ from guidellm.data.deserializers.trace_common import (
     generate_token_ids,
 )
 from guidellm.data.deserializers.trace_minimal import MinimalTraceFormatArgs
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationTurnData,
+)
 from guidellm.utils.hf_datasets import load_dataset_from_file
 
 
@@ -99,6 +104,11 @@ def generate_trace(num_rows: int, columns: list[TraceColumnGenerator]) -> str:
     )
 
 
+def load_graph_turns(row: dict) -> list[ConversationTurnData]:
+    graph = ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
+    return graph.turns
+
+
 def get_from_kwargs(keys, kwargs) -> dict:
     return {k: v for k, v in kwargs.items() if k in keys}
 
@@ -137,10 +147,11 @@ class TestTraceDatasetDeserializer:
             suffix=suffix,
         )
         ds = self.deserialize(deserializer, trace)
-        for i, row in enumerate(ds):
-            assert row["relative_timestamp"] == i
-            assert row["prompt_tokens_count"] == (i + 1) * 10
-            assert row["output_tokens_count"] == i + 1
+        conv = load_graph_turns(next(iter(ds)))
+        for i, turn in enumerate(conv):
+            assert turn.columns["relative_timestamp"] == i
+            assert turn.columns["prompt_tokens_count"] == (i + 1) * 10
+            assert turn.columns["output_tokens_count"] == i + 1
 
     @pytest.mark.sanity
     def test_loads_csv(self, tmp_path: Path, deserializer):
@@ -150,10 +161,11 @@ class TestTraceDatasetDeserializer:
             suffix=".csv",
         )
         ds = self.deserialize(deserializer, trace)
-        for i, row in enumerate(ds):
-            assert row["relative_timestamp"] == i
-            assert row["prompt_tokens_count"] == (i + 1) * 10
-            assert row["output_tokens_count"] == i + 1
+        conv = load_graph_turns(next(iter(ds)))
+        for i, turn in enumerate(conv):
+            assert turn.columns["relative_timestamp"] == i
+            assert turn.columns["prompt_tokens_count"] == (i + 1) * 10
+            assert turn.columns["output_tokens_count"] == i + 1
 
     @pytest.mark.smoke
     def test_loads_sorted_rows_and_keeps_token_columns_aligned(
@@ -173,11 +185,13 @@ class TestTraceDatasetDeserializer:
         )
         ds = self.deserialize(deserializer, trace)
         assert isinstance(ds, IterableDataset)
+        conv = load_graph_turns(next(iter(ds)))
         proc = mock_processor()
-        for i, row in enumerate(ds):
-            assert row["prompt_tokens_count"] == i + 1
-            assert row["output_tokens_count"] == (i + 1) * 10
-            assert len(proc.encode(row["prompt"])) == row["prompt_tokens_count"]
+        for i, turn in enumerate(conv):
+            n_in = turn.columns["prompt_tokens_count"]
+            assert n_in == i + 1
+            assert turn.columns["output_tokens_count"] == (i + 1) * 10
+            assert len(proc.encode(turn.columns["prompt"])) == n_in
 
     @pytest.mark.smoke
     def test_emits_relative_timestamp_column_sorted_from_trace(
@@ -196,8 +210,9 @@ class TestTraceDatasetDeserializer:
             ),
         )
         ds = self.deserialize(deserializer, trace)
-        for i, row in enumerate(ds):
-            assert row["relative_timestamp"] == i
+        conv = load_graph_turns(next(iter(ds)))
+        for i, turn in enumerate(conv):
+            assert turn.columns["relative_timestamp"] == i
 
     @pytest.mark.smoke
     def test_rejects_invalid_path(self, deserializer):

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -19,6 +19,7 @@ from guidellm.data.deserializers.trace_common import (
     generate_token_ids,
 )
 from guidellm.data.deserializers.trace_minimal import MinimalTraceFormatArgs
+from guidellm.utils.hf_datasets import load_dataset_from_file
 
 
 def mock_processor() -> Mock:
@@ -64,9 +65,14 @@ def test_generate_token_ids(token_count, expected):
 
 class TestTraceFormatRegistry:
     def test_unknown_kind_raises(self, tmp_path: Path):
+        trace = write_trace(
+            tmp_path,
+            '{"timestamp": 1, "input_length": 10, "output_length": 1}\n',
+        )
         config = TraceDataArgs(kind="unknown_kind", path=tmp_path)
+        dataset = load_dataset_from_file(trace)
         with pytest.raises(DataNotSupportedError, match="not registered"):
-            TraceFormatRegistry.dispatch(config)
+            TraceFormatRegistry.dispatch(config, dataset)
 
 
 @dataclasses.dataclass
@@ -165,30 +171,30 @@ class TestTraceDatasetDeserializer:
 
         return generator
 
-    @pytest.fixture
-    def example_list_json_trace(self):
-        def generator(tmp_path: Path, n_rows: int) -> str:
-            trace_rows = generate_trace(
-                n_rows,
-                [
-                    TraceColumnGenerator("timestamp", lambda i: n_rows - i),
-                    TraceColumnGenerator("input_length", lambda i: n_rows - i),
-                    TraceColumnGenerator("output_length", lambda i: (n_rows - i) * 10),
-                ],
-            )
-            json_data = [json.loads(s) for s in trace_rows.split("\n")]
-            return write_trace(
-                tmp_path,
-                generate_trace(
-                    1, [TraceColumnGenerator("requests", lambda _: json_data)]
-                ),
-            )
-
-        return generator
+    # @pytest.fixture
+    # def example_list_json_trace(self):
+    #     def generator(tmp_path: Path, n_rows: int) -> str:
+    #         trace_rows = generate_trace(
+    #             n_rows,
+    #             [
+    #                 TraceColumnGenerator("timestamp", lambda i: n_rows - i),
+    #                 TraceColumnGenerator("input_length", lambda i: n_rows - i),
+    #                 TraceColumnGenerator("output_length", lambda i: (n_rows - i) * 10),
+    #             ],
+    #         )
+    #         json_data = [json.loads(s) for s in trace_rows.split("\n")]
+    #         return write_trace(
+    #             tmp_path,
+    #             generate_trace(
+    #                 1, [TraceColumnGenerator("requests", lambda _: json_data)]
+    #             ),
+    #         )
+    #
+    #    return generator
 
     @pytest.mark.parametrize(
         "example",
-        ["example_trace", "example_list_json_trace"],
+        ["example_trace", ],#"example_list_json_trace"],
     )
     @pytest.mark.smoke
     def test_loads_sorted_rows_and_keeps_token_columns_aligned(
@@ -204,27 +210,27 @@ class TestTraceDatasetDeserializer:
             assert row["output_tokens_count"] == (i + 1) * 10
             assert len(proc.encode(row["prompt"])) == row["prompt_tokens_count"]
 
-    @pytest.mark.sanity
-    def test_loads_requests_column_stored_as_json_string(
-        self, tmp_path: Path, deserializer
-    ):
-        """Unwrap when the wrapper column is a JSON string of a list, not a native list.
+    # @pytest.mark.sanity
+    # def test_loads_requests_column_stored_as_json_string(
+    #     self, tmp_path: Path, deserializer
+    # ):
+    #     """Unwrap when the wrapper column is a JSON string of a list, not a native list.
 
-        ## WRITTEN BY AI ##
-        """
-        trace = write_trace(
-            tmp_path,
-            '{"requests": "[{\\"timestamp\\": 0, \\"input_length\\": 10,'
-            ' \\"output_length\\": 5}, {\\"timestamp\\": 1, \\"input_length\\": 20,'
-            ' \\"output_length\\": 10}]"}\n',
-        )
-        ds = self.deserialize(deserializer, trace)
-        rows = list(ds)
-        assert len(rows) == 2
-        assert rows[0]["prompt_tokens_count"] == 10
-        assert rows[0]["output_tokens_count"] == 5
-        assert rows[1]["prompt_tokens_count"] == 20
-        assert rows[1]["output_tokens_count"] == 10
+    #     ## WRITTEN BY AI ##
+    #     """
+    #     trace = write_trace(
+    #         tmp_path,
+    #         '{"requests": "[{\\"timestamp\\": 0, \\"input_length\\": 10,'
+    #         ' \\"output_length\\": 5}, {\\"timestamp\\": 1, \\"input_length\\": 20,'
+    #         ' \\"output_length\\": 10}]"}\n',
+    #     )
+    #     ds = self.deserialize(deserializer, trace)
+    #     rows = list(ds)
+    #     assert len(rows) == 2
+    #     assert rows[0]["prompt_tokens_count"] == 10
+    #     assert rows[0]["output_tokens_count"] == 5
+    #     assert rows[1]["prompt_tokens_count"] == 20
+    #     assert rows[1]["output_tokens_count"] == 10
 
     @pytest.mark.smoke
     def test_emits_relative_timestamp_column_sorted_from_trace(
@@ -312,15 +318,15 @@ class TestTraceDatasetDeserializer:
         with pytest.raises(DataNotSupportedError, match=match):
             self.deserialize(deserializer, trace, **kwargs)
 
-    @pytest.mark.sanity
-    def test_malformed_json_columns_raises(
-        self, tmp_path: Path, deserializer, example_list_json_trace
-    ):
-        trace = example_list_json_trace(tmp_path, 2)
-        data = trace.read_text().replace("timestamp", "ts")
-        trace.write_text(data)
-        with pytest.raises(DataNotSupportedError, match="lists of JSON objects"):
-            self.deserialize(deserializer, trace)
+    # @pytest.mark.sanity
+    # def test_malformed_json_columns_raises(
+    #     self, tmp_path: Path, deserializer, example_list_json_trace
+    # ):
+    #     trace = example_list_json_trace(tmp_path, 2)
+    #     data = trace.read_text().replace("timestamp", "ts")
+    #     trace.write_text(data)
+    #     with pytest.raises(DataNotSupportedError, match="lists of JSON objects"):
+    #         self.deserialize(deserializer, trace)
 
     @pytest.mark.sanity
     def test_unsupported_file_suffix_raises(self, tmp_path: Path, deserializer):

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -1,5 +1,4 @@
 import dataclasses
-import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -156,52 +155,22 @@ class TestTraceDatasetDeserializer:
             assert row["prompt_tokens_count"] == (i + 1) * 10
             assert row["output_tokens_count"] == i + 1
 
-    @pytest.fixture
-    def example_trace(self):
-        def generator(tmp_path: Path, n_rows: int) -> str:
-            trace_rows = generate_trace(
+    @pytest.mark.smoke
+    def test_loads_sorted_rows_and_keeps_token_columns_aligned(
+        self, tmp_path: Path, deserializer
+    ):
+        n_rows = 10
+        trace = write_trace(
+            tmp_path,
+            generate_trace(
                 n_rows,
                 [
                     TraceColumnGenerator("timestamp", lambda i: n_rows - i),
                     TraceColumnGenerator("input_length", lambda i: n_rows - i),
                     TraceColumnGenerator("output_length", lambda i: (n_rows - i) * 10),
                 ],
-            )
-            return write_trace(tmp_path, trace_rows)
-
-        return generator
-
-    # @pytest.fixture
-    # def example_list_json_trace(self):
-    #     def generator(tmp_path: Path, n_rows: int) -> str:
-    #         trace_rows = generate_trace(
-    #             n_rows,
-    #             [
-    #                 TraceColumnGenerator("timestamp", lambda i: n_rows - i),
-    #                 TraceColumnGenerator("input_length", lambda i: n_rows - i),
-    #                 TraceColumnGenerator("output_length", lambda i: (n_rows - i) * 10),
-    #             ],
-    #         )
-    #         json_data = [json.loads(s) for s in trace_rows.split("\n")]
-    #         return write_trace(
-    #             tmp_path,
-    #             generate_trace(
-    #                 1, [TraceColumnGenerator("requests", lambda _: json_data)]
-    #             ),
-    #         )
-    #
-    #    return generator
-
-    @pytest.mark.parametrize(
-        "example",
-        ["example_trace", ],#"example_list_json_trace"],
-    )
-    @pytest.mark.smoke
-    def test_loads_sorted_rows_and_keeps_token_columns_aligned(
-        self, tmp_path: Path, deserializer, example, request
-    ):
-        trace_factory = request.getfixturevalue(example)
-        trace = trace_factory(tmp_path, 10)
+            ),
+        )
         ds = self.deserialize(deserializer, trace)
         assert isinstance(ds, IterableDataset)
         proc = mock_processor()
@@ -209,28 +178,6 @@ class TestTraceDatasetDeserializer:
             assert row["prompt_tokens_count"] == i + 1
             assert row["output_tokens_count"] == (i + 1) * 10
             assert len(proc.encode(row["prompt"])) == row["prompt_tokens_count"]
-
-    # @pytest.mark.sanity
-    # def test_loads_requests_column_stored_as_json_string(
-    #     self, tmp_path: Path, deserializer
-    # ):
-    #     """Unwrap when the wrapper column is a JSON string of a list, not a native list.
-
-    #     ## WRITTEN BY AI ##
-    #     """
-    #     trace = write_trace(
-    #         tmp_path,
-    #         '{"requests": "[{\\"timestamp\\": 0, \\"input_length\\": 10,'
-    #         ' \\"output_length\\": 5}, {\\"timestamp\\": 1, \\"input_length\\": 20,'
-    #         ' \\"output_length\\": 10}]"}\n',
-    #     )
-    #     ds = self.deserialize(deserializer, trace)
-    #     rows = list(ds)
-    #     assert len(rows) == 2
-    #     assert rows[0]["prompt_tokens_count"] == 10
-    #     assert rows[0]["output_tokens_count"] == 5
-    #     assert rows[1]["prompt_tokens_count"] == 20
-    #     assert rows[1]["output_tokens_count"] == 10
 
     @pytest.mark.smoke
     def test_emits_relative_timestamp_column_sorted_from_trace(
@@ -317,16 +264,6 @@ class TestTraceDatasetDeserializer:
         trace = write_trace(tmp_path, content)
         with pytest.raises(DataNotSupportedError, match=match):
             self.deserialize(deserializer, trace, **kwargs)
-
-    # @pytest.mark.sanity
-    # def test_malformed_json_columns_raises(
-    #     self, tmp_path: Path, deserializer, example_list_json_trace
-    # ):
-    #     trace = example_list_json_trace(tmp_path, 2)
-    #     data = trace.read_text().replace("timestamp", "ts")
-    #     trace.write_text(data)
-    #     with pytest.raises(DataNotSupportedError, match="lists of JSON objects"):
-    #         self.deserialize(deserializer, trace)
 
     @pytest.mark.sanity
     def test_unsupported_file_suffix_raises(self, tmp_path: Path, deserializer):

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -104,9 +104,12 @@ def generate_trace(num_rows: int, columns: list[TraceColumnGenerator]) -> str:
     )
 
 
+def load_graph(row: dict) -> ConversationGraphData:
+    return ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
+
+
 def load_graph_turns(row: dict) -> list[ConversationTurnData]:
-    graph = ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
-    return graph.turns
+    return load_graph(row).turns
 
 
 def get_from_kwargs(keys, kwargs) -> dict:
@@ -185,9 +188,13 @@ class TestTraceDatasetDeserializer:
         )
         ds = self.deserialize(deserializer, trace)
         assert isinstance(ds, IterableDataset)
-        conv = load_graph_turns(next(iter(ds)))
+        conv = load_graph(next(iter(ds)))
         proc = mock_processor()
-        for i, turn in enumerate(conv):
+        assert len(conv.turns) == n_rows
+        for i, turn in enumerate(conv.turns):
+            assert turn.node_id == f"main_{i}"
+            if i > 0:
+                assert turn.parents[0].parent_node_id == f"main_{i - 1}"
             n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == i + 1
             assert turn.columns["output_tokens_count_column"][0] == (i + 1) * 10

--- a/tests/unit/data/deserializers/test_trace_minimal.py
+++ b/tests/unit/data/deserializers/test_trace_minimal.py
@@ -110,11 +110,11 @@ class TestMinimalTraceFormat:
         )
         conv = load_graph_turns(next(iter(ds)))
 
-        expected_prompt_count = [2, 4]
-        expected_output_count = [20, 40]
+        prompt_counts = [2, 4]
+        output_counts = [20, 40]
         for i, turn in enumerate(conv):
-            assert turn.columns["prompt_tokens_count"] == expected_prompt_count[i]
-            assert turn.columns["output_tokens_count"] == expected_output_count[i]
+            assert turn.columns["prompt_tokens_count_column"][0] == prompt_counts[i]
+            assert turn.columns["output_tokens_count_column"][0] == output_counts[i]
 
     @pytest.mark.smoke
     def test_generates_large_trace_prompts_from_reusable_base(
@@ -148,10 +148,10 @@ class TestMinimalTraceFormat:
 
         assert processor.encode.call_count <= len(prompt_lengths) + 4
         for i, turn in enumerate(conv):
-            n_in = turn.columns["prompt_tokens_count"]
+            n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == prompt_lengths[i]
-            assert turn.columns["output_tokens_count"] == output_lengths[i]
+            assert turn.columns["output_tokens_count_column"][0] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != n_in:
-                pytest.fail(f"{actual_prompt_length} != {n_in}")
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != n_in:
+                pytest.fail(f"{actual_length} != {n_in}")

--- a/tests/unit/data/deserializers/test_trace_minimal.py
+++ b/tests/unit/data/deserializers/test_trace_minimal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import random
 from collections.abc import Callable
 from pathlib import Path
@@ -12,6 +13,10 @@ import pytest
 from guidellm.data.deserializers import DatasetDeserializerFactory
 from guidellm.data.deserializers.trace_common import TraceDatasetDeserializer
 from guidellm.data.deserializers.trace_minimal import MinimalTraceFormatArgs
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationTurnData,
+)
 
 
 def mock_processor() -> Mock:
@@ -44,6 +49,11 @@ def generate_trace(num_rows: int, columns: list[TraceColumnGenerator]) -> str:
         + "}"
         for idx in range(num_rows)
     )
+
+
+def load_graph_turns(row: dict) -> list[ConversationTurnData]:
+    graph = ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
+    return graph.turns
 
 
 def get_from_kwargs(keys, kwargs) -> dict:
@@ -98,12 +108,13 @@ class TestMinimalTraceFormat:
             prompt_tokens_column="input_tokens",
             output_tokens_column="generated_tokens",
         )
+        conv = load_graph_turns(next(iter(ds)))
 
         expected_prompt_count = [2, 4]
         expected_output_count = [20, 40]
-        for i, row in enumerate(ds):
-            assert row["prompt_tokens_count"] == expected_prompt_count[i]
-            assert row["output_tokens_count"] == expected_output_count[i]
+        for i, turn in enumerate(conv):
+            assert turn.columns["prompt_tokens_count"] == expected_prompt_count[i]
+            assert turn.columns["output_tokens_count"] == expected_output_count[i]
 
     @pytest.mark.smoke
     def test_generates_large_trace_prompts_from_reusable_base(
@@ -133,13 +144,14 @@ class TestMinimalTraceFormat:
             processor_factory=lambda: processor,
             random_seed=42,
         )
+        conv = load_graph_turns(next(iter(ds)))
 
         assert processor.encode.call_count <= len(prompt_lengths) + 4
-        for i, row in enumerate(ds):
-            in_cnt = row["prompt_tokens_count"]
-            assert in_cnt == prompt_lengths[i]
-            assert row["output_tokens_count"] == output_lengths[i]
+        for i, turn in enumerate(conv):
+            n_in = turn.columns["prompt_tokens_count"]
+            assert n_in == prompt_lengths[i]
+            assert turn.columns["output_tokens_count"] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != n_in:
+                pytest.fail(f"{actual_prompt_length} != {n_in}")

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -58,7 +58,7 @@ def write_trace(tmp_path: Path, content: str, suffix: str = ".jsonl") -> Path:
 def make_valid_hash_ids(prompt_lengths: list[int], block_size: int) -> list[list[int]]:
     """The final token block of every row may be less than the hash id block
     size due to the prompt length not being divisible by it. Use this
-    when testing large trace prompts to avoid including token blocks with
+    when testing large trace prompt to avoid including token blocks with
     less than the block size in the middle of later rows."""
     tail_hash_ids = []
     n_rows = len(prompt_lengths)
@@ -222,13 +222,13 @@ class TestMooncakeTraceFormat:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for i, turn in enumerate(conv):
-            n_in = turn.columns["prompt_tokens_count"]
+            n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == prompt_lengths[i]
-            assert turn.columns["output_tokens_count"] == output_lengths[i]
+            assert turn.columns["output_tokens_count_column"][0] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != n_in:
-                pytest.fail(f"{actual_prompt_length} != {n_in}")
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != n_in:
+                pytest.fail(f"{actual_length} != {n_in}")
 
     @pytest.mark.smoke
     def test_prompt_matching_or_bordering_block_size(
@@ -257,10 +257,10 @@ class TestMooncakeTraceFormat:
         )
         conv = load_graph_turns(next(iter(ds)))
         for turn in conv:
-            in_cnt = turn.columns["prompt_tokens_count"]
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            in_cnt = turn.columns["prompt_tokens_count_column"][0]
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != in_cnt:
+                pytest.fail(f"{actual_length} != {in_cnt}")
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -339,8 +339,8 @@ class TestMooncakeTraceFormat:
         root_blocks, sibling_blocks = zip(
             *[
                 (
-                    turn.columns["prompt"][: n_in // 2],
-                    turn.columns["prompt"][n_in // 2 :],
+                    turn.columns["text_column"][0][: n_in // 2],
+                    turn.columns["text_column"][0][n_in // 2 :],
                 )
                 for turn in conv
             ],

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -264,28 +264,26 @@ class TestMooncakeTraceFormat:
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
-        ("content", "kwargs", "match"),
+        ("content", "match"),
         [
             (
                 '{"timestamp": 0, "input_length": 10, "output_length": 5, '
                 '"hash_ids": [-1]}\n',
-                {},
                 "non-negative",
             ),
             (
                 '{"timestamp": 0, "input_length": 1024, "output_length": 5, '
                 '"hash_ids": [0]}\n',
-                {},
                 "given 1 blocks",
             ),
         ],
     )
     def test_trace_validation_raises(
-        self, tmp_path: Path, deserializer, content, kwargs, match
+        self, tmp_path: Path, deserializer, content, match
     ):
         trace = write_trace(tmp_path, content)
         with pytest.raises(DataNotSupportedError, match=match):
-            self.deserialize(deserializer, trace, **kwargs)
+            self.deserialize(deserializer, trace)
 
     @pytest.mark.sanity
     def test_incompatible_encoding_raises(

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -1,5 +1,6 @@
 import copy
 import dataclasses
+import json
 import math
 import random
 from collections.abc import Callable
@@ -13,6 +14,10 @@ from guidellm.data.deserializers import DatasetDeserializerFactory
 from guidellm.data.deserializers.trace_common import TraceDatasetDeserializer
 from guidellm.data.deserializers.trace_mooncake import MooncakeTraceFormatArgs
 from guidellm.data.schemas import DataNotSupportedError
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationTurnData,
+)
 
 
 def ascending_processor() -> Mock:
@@ -95,6 +100,11 @@ def generate_trace(num_rows: int, columns: list[TraceColumnGenerator]) -> str:
         + "}"
         for idx in range(num_rows)
     )
+
+
+def load_graph_turns(row: dict) -> list[ConversationTurnData]:
+    graph = ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
+    return graph.turns
 
 
 def get_from_kwargs(keys, kwargs) -> dict:
@@ -210,14 +220,15 @@ class TestMooncakeTraceFormat:
         )
         processor = ascending_processor()
         ds = self.deserialize(deserializer, trace)
-        for i, row in enumerate(ds):
-            in_cnt = row["prompt_tokens_count"]
-            assert in_cnt == prompt_lengths[i]
-            assert row["output_tokens_count"] == output_lengths[i]
+        conv = load_graph_turns(next(iter(ds)))
+        for i, turn in enumerate(conv):
+            n_in = turn.columns["prompt_tokens_count"]
+            assert n_in == prompt_lengths[i]
+            assert turn.columns["output_tokens_count"] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != n_in:
+                pytest.fail(f"{actual_prompt_length} != {n_in}")
 
     @pytest.mark.smoke
     def test_prompt_matching_or_bordering_block_size(
@@ -244,10 +255,12 @@ class TestMooncakeTraceFormat:
             processor_factory=lambda: processor,
             random_seed=42,
         )
-        for row in ds:
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != row["prompt_tokens_count"]:
-                pytest.fail(f"{actual_prompt_length} != {row['prompt_tokens_count']}")
+        conv = load_graph_turns(next(iter(ds)))
+        for turn in conv:
+            in_cnt = turn.columns["prompt_tokens_count"]
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != in_cnt:
+                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -299,8 +312,7 @@ class TestMooncakeTraceFormat:
             random_seed=42,
         )
         with pytest.raises(ValueError, match="generate distinct"):
-            for _ in ds:
-                ...
+            load_graph_turns(next(iter(ds)))
 
     @pytest.mark.smoke
     def test_token_block_distinctness(self, tmp_path: Path, deserializer):
@@ -323,8 +335,15 @@ class TestMooncakeTraceFormat:
             processor_factory=compatible_processor,
             random_seed=42,
         )
+        conv = load_graph_turns(next(iter(ds)))
         root_blocks, sibling_blocks = zip(
-            *[(row["prompt"][: n_in // 2], row["prompt"][n_in // 2 :]) for row in ds],
+            *[
+                (
+                    turn.columns["prompt"][: n_in // 2],
+                    turn.columns["prompt"][n_in // 2 :],
+                )
+                for turn in conv
+            ],
             strict=False,
         )
         assert all_equal(root_blocks)

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -13,6 +13,10 @@ from guidellm.data.deserializers import DatasetDeserializerFactory
 from guidellm.data.deserializers.trace_common import TraceDatasetDeserializer
 from guidellm.data.deserializers.trace_weka import WEKATraceFormatArgs
 from guidellm.data.schemas import DataNotSupportedError
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationTurnData,
+)
 
 
 def ascending_processor() -> Mock:
@@ -89,6 +93,11 @@ def generate_weka_trace(
     json_data = [json.loads(s) for s in trace_rows.split("\n")]
     cols = non_wrapper_cols + [TraceColumnGenerator("requests", lambda _: json_data)]
     return generate_trace(num_rows, cols)
+
+
+def load_graph_turns(row: dict) -> list[ConversationTurnData]:
+    graph = ConversationGraphData.model_validate(json.loads(row["conversation_turns"]))
+    return graph.turns
 
 
 def get_from_kwargs(keys, kwargs) -> dict:
@@ -226,14 +235,15 @@ class TestWEKATraceFormat:
         )
         processor = ascending_processor()
         ds = self.deserialize(deserializer, trace)
-        for i, row in enumerate(ds):
-            in_cnt = row["prompt_tokens_count"]
-            assert in_cnt == prompt_lengths[i]
-            assert row["output_tokens_count"] == output_lengths[i]
+        conv = load_graph_turns(next(iter(ds)))
+        for i, turn in enumerate(conv):
+            n_in = turn.columns["prompt_tokens_count"]
+            assert n_in == prompt_lengths[i]
+            assert turn.columns["output_tokens_count"] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != n_in:
+                pytest.fail(f"{actual_prompt_length} != {n_in}")
 
     @pytest.mark.smoke
     def test_prompt_matching_or_bordering_block_size(
@@ -259,10 +269,12 @@ class TestWEKATraceFormat:
         )
         processor = ascending_processor()
         ds = self.deserialize(deserializer, trace)
-        for row in ds:
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != row["prompt_tokens_count"]:
-                pytest.fail(f"{actual_prompt_length} != {row['prompt_tokens_count']}")
+        conv = load_graph_turns(next(iter(ds)))
+        for turn in conv:
+            in_cnt = turn.columns["prompt_tokens_count"]
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != in_cnt:
+                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
 
     @pytest.mark.sanity
     def test_removes_partially_filled_hash_ids(
@@ -288,10 +300,12 @@ class TestWEKATraceFormat:
         )
         processor = ascending_processor()
         ds = self.deserialize(deserializer, trace)
-        for row in ds:
-            actual_prompt_length = len(processor.encode(row["prompt"]))
-            if actual_prompt_length != row["prompt_tokens_count"]:
-                pytest.fail(f"{actual_prompt_length} != {row['prompt_tokens_count']}")
+        conv = load_graph_turns(next(iter(ds)))
+        for turn in conv:
+            in_cnt = turn.columns["prompt_tokens_count"]
+            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
+            if actual_prompt_length != in_cnt:
+                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -345,8 +359,7 @@ class TestWEKATraceFormat:
             random_seed=42,
         )
         with pytest.raises(ValueError, match="generate distinct"):
-            for _ in ds:
-                ...
+            load_graph_turns(next(iter(ds)))
 
     @pytest.mark.smoke
     def test_token_block_distinctness(
@@ -374,8 +387,15 @@ class TestWEKATraceFormat:
             processor_factory=compatible_processor,
             random_seed=42,
         )
+        conv = load_graph_turns(next(iter(ds)))
         root_blocks, sibling_blocks = zip(
-            *[(row["prompt"][: n_in // 2], row["prompt"][n_in // 2 :]) for row in ds],
+            *[
+                (
+                    turn.columns["prompt"][: n_in // 2],
+                    turn.columns["prompt"][n_in // 2 :],
+                )
+                for turn in conv
+            ],
             strict=False,
         )
         assert all_equal(root_blocks)
@@ -402,10 +422,14 @@ class TestWEKATraceFormat:
             ),
         )
         ds = self.deserialize(deserializer, trace)
-        timestamps = [row["relative_timestamp"] for row in ds]
-        assert timestamps[0] == 0.0
-        assert timestamps[1] != 0.0
-        assert timestamps[3] == 0.0
+        ds_iter = iter(ds)
+        conv1 = load_graph_turns(next(ds_iter))
+        conv2 = load_graph_turns(next(ds_iter))
+        timestamps1 = [turn.columns["relative_timestamp"] for turn in conv1]
+        timestamps2 = [turn.columns["relative_timestamp"] for turn in conv2]
+        assert timestamps1[0] == 0.0
+        assert timestamps1[1] != 0.0
+        assert timestamps2[0] == 0.0
 
     @pytest.mark.sanity
     def test_multi_conversation_resets_hash_id_state(
@@ -433,8 +457,12 @@ class TestWEKATraceFormat:
             processor_factory=compatible_processor,
             random_seed=42,
         )
-        prompts = [row["prompt"] for row in ds]
-        assert prompts[0] != prompts[2]
+        ds_iter = iter(ds)
+        conv1 = load_graph_turns(next(ds_iter))
+        conv2 = load_graph_turns(next(ds_iter))
+        prompts1 = [turn.columns["prompt"] for turn in conv1]
+        prompts2 = [turn.columns["prompt"] for turn in conv2]
+        assert prompts1[0] != prompts2[0]
 
     @pytest.mark.sanity
     def test_zero_prompt_tokens_empty_hash_ids(self, tmp_path: Path, deserializer):
@@ -453,6 +481,7 @@ class TestWEKATraceFormat:
             ),
         )
         ds = self.deserialize(deserializer, trace)
-        rows = list(ds)
-        assert rows[0]["prompt_tokens_count"] == 0
-        assert rows[0]["output_tokens_count"] == 5
+        conv = load_graph_turns(next(iter(ds)))
+        turns = list(conv)
+        assert turns[0].columns["prompt_tokens_count"] == 0
+        assert turns[0].columns["output_tokens_count"] == 5

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -237,13 +237,13 @@ class TestWEKATraceFormat:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for i, turn in enumerate(conv):
-            n_in = turn.columns["prompt_tokens_count"]
+            n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == prompt_lengths[i]
-            assert turn.columns["output_tokens_count"] == output_lengths[i]
+            assert turn.columns["output_tokens_count_column"][0] == output_lengths[i]
 
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != n_in:
-                pytest.fail(f"{actual_prompt_length} != {n_in}")
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != n_in:
+                pytest.fail(f"{actual_length} != {n_in}")
 
     @pytest.mark.smoke
     def test_prompt_matching_or_bordering_block_size(
@@ -271,10 +271,10 @@ class TestWEKATraceFormat:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for turn in conv:
-            in_cnt = turn.columns["prompt_tokens_count"]
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            in_cnt = turn.columns["prompt_tokens_count_column"][0]
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != in_cnt:
+                pytest.fail(f"{actual_length} != {in_cnt}")
 
     @pytest.mark.sanity
     def test_removes_partially_filled_hash_ids(
@@ -302,10 +302,10 @@ class TestWEKATraceFormat:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         for turn in conv:
-            in_cnt = turn.columns["prompt_tokens_count"]
-            actual_prompt_length = len(processor.encode(turn.columns["prompt"]))
-            if actual_prompt_length != in_cnt:
-                pytest.fail(f"{actual_prompt_length} != {in_cnt}")
+            in_cnt = turn.columns["prompt_tokens_count_column"][0]
+            actual_length = len(processor.encode(turn.columns["text_column"][0]))
+            if actual_length != in_cnt:
+                pytest.fail(f"{actual_length} != {in_cnt}")
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
@@ -391,8 +391,8 @@ class TestWEKATraceFormat:
         root_blocks, sibling_blocks = zip(
             *[
                 (
-                    turn.columns["prompt"][: n_in // 2],
-                    turn.columns["prompt"][n_in // 2 :],
+                    turn.columns["text_column"][0][: n_in // 2],
+                    turn.columns["text_column"][0][n_in // 2 :],
                 )
                 for turn in conv
             ],
@@ -425,8 +425,8 @@ class TestWEKATraceFormat:
         ds_iter = iter(ds)
         conv1 = load_graph_turns(next(ds_iter))
         conv2 = load_graph_turns(next(ds_iter))
-        timestamps1 = [turn.columns["relative_timestamp"] for turn in conv1]
-        timestamps2 = [turn.columns["relative_timestamp"] for turn in conv2]
+        timestamps1 = [turn.columns["relative_timestamp_column"][0] for turn in conv1]
+        timestamps2 = [turn.columns["relative_timestamp_column"][0] for turn in conv2]
         assert timestamps1[0] == 0.0
         assert timestamps1[1] != 0.0
         assert timestamps2[0] == 0.0
@@ -460,8 +460,8 @@ class TestWEKATraceFormat:
         ds_iter = iter(ds)
         conv1 = load_graph_turns(next(ds_iter))
         conv2 = load_graph_turns(next(ds_iter))
-        prompts1 = [turn.columns["prompt"] for turn in conv1]
-        prompts2 = [turn.columns["prompt"] for turn in conv2]
+        prompts1 = [turn.columns["text_column"][0] for turn in conv1]
+        prompts2 = [turn.columns["text_column"][0] for turn in conv2]
         assert prompts1[0] != prompts2[0]
 
     @pytest.mark.sanity
@@ -483,5 +483,5 @@ class TestWEKATraceFormat:
         ds = self.deserialize(deserializer, trace)
         conv = load_graph_turns(next(iter(ds)))
         turns = list(conv)
-        assert turns[0].columns["prompt_tokens_count"] == 0
-        assert turns[0].columns["output_tokens_count"] == 5
+        assert turns[0].columns["prompt_tokens_count_column"][0] == 0
+        assert turns[0].columns["output_tokens_count_column"][0] == 5

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -309,28 +309,35 @@ class TestWEKATraceFormat:
 
     @pytest.mark.sanity
     @pytest.mark.parametrize(
-        ("content", "kwargs", "match"),
+        ("content", "match"),
         [
             (
                 '{"id": "conv0", "requests": [{"t": 0, "in": 10,'
                 '"out": 5, "hash_ids": [-1]}]}\n',
-                {},
                 "non-negative",
             ),
             (
                 '{"id": "conv0", "requests": [{"t": 0, "in": 1024,'
                 '"out": 5, "hash_ids": [1]}]}\n',
-                {},
                 "given 1 blocks",
+            ),
+            (
+                '{"id": "conv0", "requests": [[{"t": 0, "in": 10,'
+                '"out": 5, "hash_ids": []}]]}\n',
+                "Failed to find requests",
+            ),
+            (
+                '{"id": "conv0", "requests": []}\n',
+                "requests was empty",
             ),
         ],
     )
     def test_trace_validation_raises(
-        self, tmp_path: Path, deserializer, content, kwargs, match
+        self, tmp_path: Path, deserializer, content, match
     ):
         trace = write_trace(tmp_path, content)
         with pytest.raises(DataNotSupportedError, match=match):
-            self.deserialize(deserializer, trace, **kwargs)
+            self.deserialize(deserializer, trace)
 
     @pytest.mark.sanity
     def test_incompatible_encoding_raises(

--- a/tests/unit/utils/test_json_unwrap.py
+++ b/tests/unit/utils/test_json_unwrap.py
@@ -3,47 +3,17 @@ import datetime
 import pytest
 from datasets import Dataset, IterableDataset
 
-from guidellm.utils.json_unwrap import (
-    VirtualColumnLocation,
-    construct_virtual_column_locations,
-    get_json_column_names,
-    try_json_load,
-    unzip_virtual_column_locations,
-)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    ("wrapper_col", "virtual_cols", "expected"),
-    [
-        ("", [], []),
-        (
-            "wrapper",
-            ["field_1", "field_2"],
-            [
-                VirtualColumnLocation("wrapper", "field_1"),
-                VirtualColumnLocation("wrapper", "field_2"),
-            ],
-        ),
-        ("wrapper", [], []),
-    ],
-)
-def test_construct_virtual_column_locations(wrapper_col, virtual_cols, expected):
-    actual = construct_virtual_column_locations(wrapper_col, virtual_cols)
-    if not actual:
-        assert actual == expected
-    for location in actual:
-        assert isinstance(location, VirtualColumnLocation)
+from guidellm.utils.json_unwrap import get_json_column_names, try_json_load
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     ("arg", "expected"),
     [
-        (r'', None),
+        (r"", None),
         (r"{}", {}),
         (r'"string"', "string"),
-        (r'1', 1),
+        (r"1", 1),
         (
             r'{"field_1": 1, "field_2": "two", "field_3": [3, 4]}',
             {"field_1": 1, "field_2": "two", "field_3": [3, 4]},
@@ -102,27 +72,3 @@ def test_get_json_column_names(data, expected):
     )
     for ds in (dataset, iterable_dataset):
         assert get_json_column_names(ds) == expected
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    ("locations", "expected"),
-    [
-        ([], ((), ())),
-        (
-            [
-                VirtualColumnLocation("wrapper", "field_1"),
-                VirtualColumnLocation("wrapper_2", "field_1"),
-                VirtualColumnLocation("wrapper", "field_2"),
-            ],
-            (("wrapper", "wrapper_2", "wrapper"), ("field_1", "field_1", "field_2")),
-        ),
-        ([VirtualColumnLocation("wrapper", "field")], (("wrapper",), ("field",))),
-    ],
-)
-def test_unzip_virtual_column_locations(locations, expected):
-    actual = unzip_virtual_column_locations(locations)
-    assert isinstance(actual, tuple)
-    for idx in range(len(actual)):
-        assert isinstance(actual[idx], tuple)
-        assert actual[idx] == expected[idx]

--- a/tests/unit/utils/test_json_unwrap.py
+++ b/tests/unit/utils/test_json_unwrap.py
@@ -40,10 +40,10 @@ def test_construct_virtual_column_locations(wrapper_col, virtual_cols, expected)
 @pytest.mark.parametrize(
     ("arg", "expected"),
     [
-        ("", None),
+        (r'', None),
         (r"{}", {}),
-        ("'string'", None),
-        ("'1'", None),
+        (r'"string"', "string"),
+        (r'1', 1),
         (
             r'{"field_1": 1, "field_2": "two", "field_3": [3, 4]}',
             {"field_1": 1, "field_2": "two", "field_3": [3, 4]},


### PR DESCRIPTION
## Summary
Restructures all preexisting trace formats to work with the DAG, switching to a non-flattened approach to dataset validation and grabbing conversations. Done as a step towards full WEKA trace format support ([#992](https://github.com/vllm-project/guidellm/issues/992)). I'll make a PR in the future if I find the time to finish the WEKA trace replay, containing the features still missing for full support.

The following still needs to be implemented for WEKA:
- Subagent conversations for WEKA
- Handling input/output types and stop reason columns for added context when making nodes
- Nonlinear histories (context/token collapse -> hash-ids becoming incorrect mid-conversation)
- Tool call events

## Details
Current (changed) approach for trace formats:
- JSON load the whole dataset. Yes it's probably inefficient, but it makes the rest of the validation chain significantly simpler. The processes are also self-contained, which should make optimizations easier.
- Added a `conversation_locations` field to TraceFormatBase. This is a list of a list of ints which point to the start of every conversation. Each integer acts as an index to somewhere in the dataset. The number of ints indicates depth. It's the responsibility of the format to generate these locations and interpret them.
- Finding required columns has been moved to formats. The benefit is that instead of searching for required columns with no context, formats can instead just search in the place where the columns are supposed to be.
- Conversations are served as an `Iterable[Dataset]` to abstract away getting the next conversation via conversation locations, which trace_common will not know how to interpret.

Other
- Repaired tests
- Switched Minimal, Mooncake, and partial WEKA to using the DAG format instead of the flattened datasets
- Removed VirtualColumnLocation & helpers, as they've been replaced by format-specific handling
- Removed format-agnostic JSON unwrapping. I overall regretted adding this feature, as it added the responsibility of needing to support ad-hoc trace formats and format variants.

## Test Plan
NOTE: This PR has not been fully tested for performance in comparison to the current setup.

python -m pytest tests/unit/data/deserializers/
tox -e test-unit
tox -e test-integration
tox -e lint-fix && tox -e type-check

## Related Issues

- Related to [#992](https://github.com/vllm-project/guidellm/issues/992)

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 67b17b4c77e18d398115b4555c5b26e2e53c12b7
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Aug 4 09:29:54 2026 -0400

    Update _load_trace_rows docstring
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit e95994d2f6ddca65ef2f77ed53e053c58e74f136
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Tue Aug 4 12:02:01 2026 -0400

    Fix json_unwrap test
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit fe7673286ac5e9f1f3b0a780215b73c815a7374f
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Aug 6 08:20:09 2026 -0400

    Rework dataset validation
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 6a5fae757018e8a5049bdbdb7220d40dd951acaf
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Aug 6 09:18:52 2026 -0400

    Cleanup & remove old code
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 4c2b8c98ba9f0121db86899652cca32daf524f97
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Thu Aug 6 10:51:48 2026 -0400

    Update TraceFormatBase
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 7fc0ff8f16ef053b6a08133b212f2a4dd61bd87e
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 10:27:36 2026 -0400

    Repair tests
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 20b25baa5306d0a5b490be93200654261b244aed
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 11:36:15 2026 -0400

    Repair tests again
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 57b197d29837c4b4b9e0334bcc82f5088e9d1096
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 11:46:16 2026 -0400

    Optimize json loading slightly
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 7d202823dd266f83b2e23b958875eef2abe45554
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 16:15:54 2026 -0400

    Improve test coverage
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 7ee8f862316feca138e23ba2fcb57a55eaf7cd89
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 16:19:17 2026 -0400

    Update docs
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 01fbd656bc39f779e862a500c180b67a0b3b9b96
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Fri Aug 7 16:20:03 2026 -0400

    Fix typo
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit d2a080817dba2a0a3bc7c7a41c6f20df0a6e302c
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Aug 12 16:42:13 2026 -0400

    Simplify iter loop
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 82a07834d1f4b6a17703dfdebdf2edc531d016d0
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Aug 12 16:57:36 2026 -0400

    Update TraceFormatBase docstrings
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit 6d06191645c6f75c852a647c3d2aa965d739cc9a
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Aug 12 17:03:49 2026 -0400

    Fix dataset not being updated after map
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

commit eb1491447716b505bbea27b53d865a0e8ed3c3a7
Author: SkiHatDuckie <SkiHatDuckie@gmail.com>
Date:   Wed Aug 12 17:21:34 2026 -0400

    Remove unused features
    
    Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>

---------

Signed-off-by: SkiHatDuckie <SkiHatDuckie@gmail.com>
