### PR TITLE
fix: return a Dataset from file dataset deserializers

### DIFF
--- a/src/guidellm/data/deserializers/file.py
+++ b/src/guidellm/data/deserializers/file.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
-from datasets import Dataset, load_dataset
+from datasets import Dataset, IterableDataset, load_dataset
 from pydantic import Field
 from transformers import PreTrainedTokenizerBase
 
@@ -15,6 +15,7 @@ from guidellm.data.deserializers.deserializer import (
     DatasetDeserializerFactory,
 )
 from guidellm.data.schemas import DataArgs
+from guidellm.data.utils import resolve_dataset_split
 
 __all__ = [
     "ArrowFileDatasetDeserializer",
@@ -27,6 +28,25 @@ __all__ = [
     "TarFileDatasetDeserializer",
     "TextFileDatasetDeserializer",
 ]
+
+
+def _load_file_dataset(
+    loader: str, path: Path, **load_kwargs: Any
+) -> Dataset | IterableDataset:
+    """
+    Load a local data file and return a single dataset split.
+
+    ``load_dataset`` returns a ``DatasetDict`` keyed by split for file-based
+    loaders, which downstream preprocessing does not expect. This resolves the
+    result to a single ``Dataset`` (or ``IterableDataset``) split.
+
+    :param loader: The ``datasets`` loader name (e.g. ``"json"``, ``"csv"``).
+    :param path: Path to the local data file.
+    :param load_kwargs: Additional keyword arguments forwarded to ``load_dataset``.
+    :return: The resolved dataset split.
+    """
+    dataset = load_dataset(loader, data_files=str(path), **load_kwargs)
+    return resolve_dataset_split(dataset)
 
 
 @DataArgs.register(
@@ -94,7 +114,7 @@ class CSVFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> Dataset | IterableDataset:
         _ = (processor_factory, random_seed)
 
         if (
@@ -107,7 +127,7 @@ class CSVFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a valid local .csv file, got {path}"
             )
 
-        return load_dataset("csv", data_files=str(path), **config.load_kwargs)
+        return _load_file_dataset("csv", path, **config.load_kwargs)
 
 
 @DatasetDeserializerFactory.register("json_file")
@@ -117,7 +137,7 @@ class JSONFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> Dataset | IterableDataset:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -129,7 +149,7 @@ class JSONFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a local .json or .jsonl file, got {path}"
             )
 
-        return load_dataset("json", data_files=str(path), **config.load_kwargs)
+        return _load_file_dataset("json", path, **config.load_kwargs)
 
 
 @DatasetDeserializerFactory.register("parquet_file")
@@ -139,7 +159,7 @@ class ParquetFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> Dataset | IterableDataset:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -151,7 +171,7 @@ class ParquetFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a local .parquet file, got {path}"
             )
 
-        return load_dataset("parquet", data_files=str(path), **config.load_kwargs)
+        return _load_file_dataset("parquet", path, **config.load_kwargs)
 
 
 @DatasetDeserializerFactory.register("arrow_file")
@@ -161,7 +181,7 @@ class ArrowFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> Dataset | IterableDataset:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -173,7 +193,7 @@ class ArrowFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a local .arrow file, got {path}"
             )
 
-        return load_dataset("arrow", data_files=str(path), **config.load_kwargs)
+        return _load_file_dataset("arrow", path, **config.load_kwargs)
 
 
 @DatasetDeserializerFactory.register("hdf5_file")
@@ -227,7 +247,7 @@ class TarFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> dict[str, list]:
+    ) -> Dataset | IterableDataset:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -239,4 +259,4 @@ class TarFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a local .tar file, got {path}"
             )
 
-        return load_dataset("webdataset", data_files=str(path), **config.load_kwargs)
+        return _load_file_dataset("webdataset", path, **config.load_kwargs)

--- a/tests/unit/data/deserializers/test_file.py
+++ b/tests/unit/data/deserializers/test_file.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from datasets import Dataset, DatasetDict
+from datasets import Dataset
 from pyarrow import ipc
 
 from guidellm.data.deserializers.deserializer import DataNotSupportedError
@@ -137,10 +137,10 @@ def test_parquet_file_deserializer_success(tmp_path):
         config=config, processor_factory=processor_factory(), random_seed=42
     )
 
-    assert isinstance(dataset, DatasetDict)
-    assert dataset["train"].column_names == ["text"]
-    assert dataset["train"]["text"] == ["hello", "world"]
-    assert len(dataset["train"]["text"]) == 2
+    assert isinstance(dataset, Dataset)
+    assert dataset.column_names == ["text"]
+    assert dataset["text"] == ["hello", "world"]
+    assert len(dataset["text"]) == 2
 
 
 @pytest.mark.sanity
@@ -188,9 +188,9 @@ def test_csv_file_deserializer_success(tmp_path):
         config=config, processor_factory=processor_factory(), random_seed=43
     )
 
-    assert isinstance(dataset, DatasetDict)
-    assert dataset["train"]["text"] == ["hello world"]
-    assert len(["train"]) == 1
+    assert isinstance(dataset, Dataset)
+    assert dataset["text"] == ["hello world"]
+    assert len(dataset) == 1
 
 
 ###################
@@ -215,9 +215,41 @@ def test_json_file_deserializer_success(tmp_path):
         config=config, processor_factory=processor_factory(), random_seed=123
     )
 
-    assert isinstance(dataset, DatasetDict)
-    assert dataset["train"]["text"] == ["hello world"]
+    assert isinstance(dataset, Dataset)
+    assert dataset["text"] == ["hello world"]
     assert len(dataset) == 1
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    ("kind", "suffix", "content"),
+    [
+        ("json_file", ".json", '{"text": "hello world"}\n'),
+        ("csv_file", ".csv", "text\nhello world\n"),
+    ],
+)
+def test_file_deserializers_return_dataset_with_info(tmp_path, kind, suffix, content):
+    """File deserializers return a Dataset exposing ``.info`` (regression for the
+    'DatasetDict' object has no attribute 'info' error during column mapping).
+
+    ### WRITTEN BY AI ###
+    """
+    file_path = tmp_path / f"sample{suffix}"
+    file_path.write_text(content)
+
+    deserializer_cls = {
+        "json_file": JSONFileDatasetDeserializer,
+        "csv_file": CSVFileDatasetDeserializer,
+    }[kind]
+    config = FileDataArgs(kind=kind, path=file_path)
+
+    dataset = deserializer_cls()(
+        config=config, processor_factory=processor_factory(), random_seed=7
+    )
+
+    assert isinstance(dataset, Dataset)
+    # The column mapper accesses dataset.info.dataset_name; DatasetDict lacks .info.
+    assert dataset.info is not None
 
 
 ###################
@@ -247,10 +279,8 @@ def test_arrow_file_deserializer_success(monkeypatch, tmp_path):
         config=config, processor_factory=processor_factory(), random_seed=42
     )
 
-    assert isinstance(dataset, DatasetDict)
-    assert "train" in dataset
-    assert isinstance(dataset["train"], Dataset)
-    assert dataset["train"].num_rows == 2
+    assert isinstance(dataset, Dataset)
+    assert dataset.num_rows == 2
 
 
 ###################
@@ -362,7 +392,5 @@ def test_tar_file_deserializer_success(tmp_path):
         config=config, processor_factory=processor_factory(), random_seed=43
     )
 
-    assert isinstance(dataset, DatasetDict)
-    assert "train" in dataset
-    assert isinstance(dataset["train"], Dataset)
-    assert dataset["train"].num_rows == 1
+    assert isinstance(dataset, Dataset)
+    assert dataset.num_rows == 1


### PR DESCRIPTION
## Summary

Running a benchmark with a `json_file`, `csv_file`, or `parquet_file` data source crashed during dataset preprocessing with:

```
AttributeError: 'DatasetDict' object has no attribute 'info'
  at guidellm/data/preprocessors/mappers.py
```

The file deserializers call `load_dataset(loader, data_files=...)`, which returns a `DatasetDict` (keyed by split), not a `Dataset` — contradicting their `-> Dataset` annotation. The column mapper then accesses `dataset.info`, which a `DatasetDict` does not have.

The same `load_dataset` pattern is used by five deserializers, so `arrow_file` and `tar_file` were affected by the same latent bug, not just the three in the report.

## Details

- Added a small `_load_file_dataset` helper in `data/deserializers/file.py` that loads the file and resolves the result to a single split via the existing `guidellm.data.utils.resolve_dataset_split`.
- Routed all five affected deserializers through it: `csv_file`, `json_file`, `parquet_file`, `arrow_file`, `tar_file`.
- Widened their return annotations from `Dataset` to `Dataset | IterableDataset` to match `resolve_dataset_split`'s return type.
- Reuses the project's existing split-resolution utility rather than adding new logic. `text_file`, `hdf5_file`, and `db_file` already returned a `Dataset` and are unchanged.

## Test Plan

- Updated `tests/unit/data/deserializers/test_file.py`: the csv/json/parquet/arrow/tar success tests previously asserted a `DatasetDict` return (which had encoded the buggy behavior) and now assert a `Dataset`.
- Added a regression test asserting the deserialized dataset exposes `.info` — the attribute whose absence caused the reported crash.
- `tox -e lint-check`, `tox -e type-check`, and `tox -e test-unit` all pass (2848 passed).
- Manually drove the reported crash path end to end (deserialize a `.jsonl` file → `GenerativeColumnMapper.setup_data` → `datasets_mappings`); it completes and maps `prompt` to `text_column` instead of raising.

## Related Issues

- Fixes #1002

Thanks to @Basster for the detailed report and root-cause analysis.

<!-- begin:squash-data -->

---

# git log

commit e3015d1ee6cdf345737919288f5c355028cdeb75
Author: Pragadeesh122 <pragan189@gmail.com>
Date:   Fri Aug 7 21:24:17 2026 -0500

    fix: return a Dataset from file deserializers (#1002)
    
    load_dataset returns a DatasetDict for csv/json/parquet/arrow/tar file
    sources, which crashed column mapping with 'DatasetDict object has no
    attribute info'. Resolve the loaded result to a single dataset split via
    resolve_dataset_split so the deserializers return a Dataset as annotated.
    
    Signed-off-by: Pragadeesh122 <pragan189@gmail.com>

---------

Signed-off-by: Pragadeesh122 <pragan189@gmail.com>
