### PR TITLE
fix(openai): capture cached_tokens for Responses API usage metrics

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -2232,6 +2232,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                 or usage_metrics.get("input_tokens")
                 or 0
             ),
+            cached_tokens=input_details.get("cached_tokens"),
             image_tokens=input_details.get("image_tokens"),
             video_tokens=input_details.get("video_tokens"),
             audio_tokens=input_details.get("audio_tokens"),

--- a/src/guidellm/schemas/request.py
+++ b/src/guidellm/schemas/request.py
@@ -126,9 +126,7 @@ class UsageMetrics(StandardBaseDict):
     cached_tokens: int | None = Field(
         default=None,
         description=(
-            "Number of input tokens served from the prefix cache"
-            " (KV cache hit). Populated from the server's"
-            " prompt_tokens_details.cached_tokens field."
+            "Number of input tokens served from the prefix cache (KV cache hit)."
         ),
     )
     text_words: int | None = Field(

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -3501,17 +3501,27 @@ class TestResponsesRequestHandler:
         assert output_metrics.text_characters == len(text)
 
     @pytest.mark.smoke
-    def test_extract_metrics_cached_tokens(self, valid_instances):
+    @pytest.mark.parametrize(
+        ("input_tokens_details", "expected_cached_tokens"),
+        [
+            ({"cached_tokens": 8}, 8),
+            ({"cached_tokens": 0}, 0),
+            ({}, None),
+            (None, None),
+        ],
+    )
+    def test_extract_metrics_cached_tokens(
+        self, valid_instances, input_tokens_details, expected_cached_tokens
+    ):
         """Test extract_metrics captures input_tokens_details.cached_tokens."""
-        usage = {
-            "input_tokens": 10,
-            "input_tokens_details": {"cached_tokens": 8},
-            "output_tokens": 5,
-        }
+        usage = {"input_tokens": 10, "output_tokens": 5}
+        if input_tokens_details is not None:
+            usage["input_tokens_details"] = input_tokens_details
+
         input_metrics, _ = valid_instances.extract_metrics(usage, "Test response")
 
         assert input_metrics.text_tokens == 10
-        assert input_metrics.cached_tokens == 8
+        assert input_metrics.cached_tokens == expected_cached_tokens
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -3501,6 +3501,19 @@ class TestResponsesRequestHandler:
         assert output_metrics.text_characters == len(text)
 
     @pytest.mark.smoke
+    def test_extract_metrics_cached_tokens(self, valid_instances):
+        """Test extract_metrics captures input_tokens_details.cached_tokens."""
+        usage = {
+            "input_tokens": 10,
+            "input_tokens_details": {"cached_tokens": 8},
+            "output_tokens": 5,
+        }
+        input_metrics, _ = valid_instances.extract_metrics(usage, "Test response")
+
+        assert input_metrics.text_tokens == 10
+        assert input_metrics.cached_tokens == 8
+
+    @pytest.mark.smoke
     @pytest.mark.parametrize(
         ("line", "expected_output"),
         [


### PR DESCRIPTION
## Summary

`ResponsesRequestHandler` drops `usage.input_tokens_details.cached_tokens`, so `/v1/responses` benchmarks report `cached_tokens=None` even when the server reports prefix-cache hits.

Capture the field the same way as the chat/text and vLLM-Python handlers.

Follow-up to #994.

## Tests

* Responses handler tests: 68 passed
* Backend unit tests: 439 passed
* Regression cases cover positive, zero, missing field, and missing details

<!-- begin:squash-data -->

---

# git log

commit 27372a770286fac86abd1e3fb167ccb6b6d91804
Author: Smallfu666 <nick20350@gmail.com>
Date:   Sun Aug 9 19:03:28 2026 +0800

    fix(openai): capture cached_tokens for Responses API usage metrics
    
    The Responses API reports prefix-cache hits under
    usage.input_tokens_details.cached_tokens, mirroring chat/text
    completions' prompt_tokens_details.cached_tokens. The Responses
    handler's extract_metrics dropped this field, so cached_tokens was
    always None for /v1/responses benchmarks.
    
    Signed-off-by: Smallfu666 <nick20350@gmail.com>
    Generated-by: Claude Code

commit 3ca4d1f7ce6a515afb8324fe0ad1315c24757b41
Author: Smallfu666 <nick20350@gmail.com>
Date:   Sun Aug 9 19:10:30 2026 +0800

    test: cover cached_tokens None/absent/zero for Responses handler
    
    Signed-off-by: Smallfu666 <nick20350@gmail.com>
    Generated-by: Claude Code

commit 35ec4218bc42bef40f3f27413e9822ee0a83de10
Author: Smallfu666 <nick20350@gmail.com>
Date:   Sun Aug 9 23:56:10 2026 +0800

    fix(schemas): generalize cached_tokens field description
    
    The field is now populated by multiple handlers reading different wire paths (chat/text prompt_tokens_details, Responses input_tokens_details); drop the transport-specific path so the schema is not tied to one backend wire format.
    
    Signed-off-by: Smallfu666 <nick20350@gmail.com>
    Generated-by: Claude Code

---------

Generated-by: Claude Code
Signed-off-by: Smallfu666 <nick20350@gmail.com>
