### PR TITLE
Reject duplicate unrepeatable kind-type registry-backed click options

### DIFF
--- a/src/guidellm/utils/click_pydantic.py
+++ b/src/guidellm/utils/click_pydantic.py
@@ -123,16 +123,21 @@ class RegistryAwareCommand(click.Command):
     When Click's parser raises ``BadOptionUsage`` for a registry-backed option
     (e.g. bare ``--constraint`` with no value), this override catches it and
     re-raises a ``BadParameter`` with the expected format and valid kinds.
+
+    Also rejects duplicate occurrences of non-repeatable registry options
+    (e.g. two ``--backend`` flags) before Click's last-wins overwrite.
     """
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """
-        Override to intercept missing-value errors for registry options.
+        Override to reject duplicate single registry options and enrich
+        missing-value errors.
 
         :param ctx: Click context
         :param args: Command-line arguments to parse
         :return: Remaining arguments after parsing
         """
+        self._reject_duplicate_single_registry_options(ctx, args)
         try:
             return super().parse_args(ctx, args)
         except click.BadOptionUsage as e:
@@ -150,6 +155,64 @@ class RegistryAwareCommand(click.Command):
                         param=param,
                     ) from e
             raise
+
+    def _reject_duplicate_single_registry_options(
+        self, ctx: click.Context, args: list[str]
+    ) -> None:
+        """
+        Fail if a non-``multiple`` registry option appears more than once.
+
+        Click silently keeps the last value for non-repeatable options; scanning
+        the raw argv catches duplicates before that overwrite.
+
+        :param ctx: Click context
+        :param args: Raw argument list passed to the command
+        :raises click.BadParameter: When a non-repeatable registry option repeats
+        """
+        single_opts = self._non_repeatable_registry_opt_map()
+        if not single_opts:
+            return
+
+        seen: set[str] = set()
+        for arg in args:
+            if arg == "--":
+                break
+            matched = self._match_single_registry_opt(arg, single_opts)
+            if matched is None:
+                continue
+            if matched in seen:
+                raise click.BadParameter(
+                    f"Option {matched} cannot be specified multiple times.",
+                    ctx=ctx,
+                    param=single_opts[matched],
+                )
+            seen.add(matched)
+
+    def _non_repeatable_registry_opt_map(self) -> dict[str, RegistryConfigOption]:
+        """Map CLI flags to non-repeatable registry options."""
+        mapping: dict[str, RegistryConfigOption] = {}
+        for param in self.params:
+            # Non-repeatable iff Click multiple=False (from non-list Pydantic fields).
+            if (
+                isinstance(param, RegistryConfigOption)
+                and not param.multiple
+                and param.registry_type is not None
+            ):
+                for opt in param.opts:
+                    mapping[opt] = param
+        return mapping
+
+    @staticmethod
+    def _match_single_registry_opt(
+        arg: str, single_opts: dict[str, RegistryConfigOption]
+    ) -> str | None:
+        """Return the matched option flag if ``arg`` is a known single registry opt."""
+        if arg.startswith("--") and "=" in arg:
+            flag = arg.split("=", 1)[0]
+            return flag if flag in single_opts else None
+        if arg in single_opts:
+            return arg
+        return None
 
 
 def _parse_and_check_kind_config(

--- a/src/guidellm/utils/click_pydantic.py
+++ b/src/guidellm/utils/click_pydantic.py
@@ -104,6 +104,9 @@ class RegistryConfigOption(click.Option):
 
     Used by :class:`RegistryAwareCommand` to enrich missing-argument errors
     with the expected format and valid kinds.
+
+    For non-``multiple`` options, also rejects duplicate flag occurrences at
+    parse time (Click would otherwise keep only the last value).
     """
 
     def __init__(
@@ -115,6 +118,41 @@ class RegistryConfigOption(click.Option):
         self.registry_type = registry_type
         super().__init__(*args, **kwargs)
 
+    def add_to_parser(self, parser: Any, ctx: click.Context) -> None:
+        """
+        Register with Click's parser and reject duplicate non-repeatable uses.
+
+        When ``multiple`` is false, wraps the parser's ``process`` callback so a
+        second occurrence raises instead of overwriting (Click's default
+        last-wins behavior).
+
+        :param parser: Click option parser receiving this option
+        :param ctx: Click context for the active command
+        """
+        super().add_to_parser(parser, ctx)
+        if self.multiple:
+            return
+
+        # Hook process at the store site so Click's option matching handles
+        # --flag, --flag=value, and short forms; reject before last-wins overwrite.
+        def process(value: Any, state: Any) -> None:
+            if self.name in state.opts:
+                raise click.BadParameter(
+                    f"Option {self.opts[0]} cannot be specified multiple times.",
+                    ctx=ctx,
+                    param=self,
+                )
+            previous(value, state)
+
+        for name in self.opts:
+            # Click has no public API to wrap option process; this is the
+            # established Option.add_to_parser extension pattern.
+            opt = parser._long_opt.get(name) or parser._short_opt.get(name)  # noqa: SLF001
+            if opt is not None:
+                previous = opt.process
+                opt.process = process
+                break
+
 
 class RegistryAwareCommand(click.Command):
     """
@@ -123,21 +161,16 @@ class RegistryAwareCommand(click.Command):
     When Click's parser raises ``BadOptionUsage`` for a registry-backed option
     (e.g. bare ``--constraint`` with no value), this override catches it and
     re-raises a ``BadParameter`` with the expected format and valid kinds.
-
-    Also rejects duplicate occurrences of non-repeatable registry options
-    (e.g. two ``--backend`` flags) before Click's last-wins overwrite.
     """
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         """
-        Override to reject duplicate single registry options and enrich
-        missing-value errors.
+        Override to enrich missing-value errors for registry options.
 
         :param ctx: Click context
         :param args: Command-line arguments to parse
         :return: Remaining arguments after parsing
         """
-        self._reject_duplicate_single_registry_options(ctx, args)
         try:
             return super().parse_args(ctx, args)
         except click.BadOptionUsage as e:
@@ -155,64 +188,6 @@ class RegistryAwareCommand(click.Command):
                         param=param,
                     ) from e
             raise
-
-    def _reject_duplicate_single_registry_options(
-        self, ctx: click.Context, args: list[str]
-    ) -> None:
-        """
-        Fail if a non-``multiple`` registry option appears more than once.
-
-        Click silently keeps the last value for non-repeatable options; scanning
-        the raw argv catches duplicates before that overwrite.
-
-        :param ctx: Click context
-        :param args: Raw argument list passed to the command
-        :raises click.BadParameter: When a non-repeatable registry option repeats
-        """
-        single_opts = self._non_repeatable_registry_opt_map()
-        if not single_opts:
-            return
-
-        seen: set[str] = set()
-        for arg in args:
-            if arg == "--":
-                break
-            matched = self._match_single_registry_opt(arg, single_opts)
-            if matched is None:
-                continue
-            if matched in seen:
-                raise click.BadParameter(
-                    f"Option {matched} cannot be specified multiple times.",
-                    ctx=ctx,
-                    param=single_opts[matched],
-                )
-            seen.add(matched)
-
-    def _non_repeatable_registry_opt_map(self) -> dict[str, RegistryConfigOption]:
-        """Map CLI flags to non-repeatable registry options."""
-        mapping: dict[str, RegistryConfigOption] = {}
-        for param in self.params:
-            # Non-repeatable iff Click multiple=False (from non-list Pydantic fields).
-            if (
-                isinstance(param, RegistryConfigOption)
-                and not param.multiple
-                and param.registry_type is not None
-            ):
-                for opt in param.opts:
-                    mapping[opt] = param
-        return mapping
-
-    @staticmethod
-    def _match_single_registry_opt(
-        arg: str, single_opts: dict[str, RegistryConfigOption]
-    ) -> str | None:
-        """Return the matched option flag if ``arg`` is a known single registry opt."""
-        if arg.startswith("--") and "=" in arg:
-            flag = arg.split("=", 1)[0]
-            return flag if flag in single_opts else None
-        if arg in single_opts:
-            return arg
-        return None
 
 
 def _parse_and_check_kind_config(

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -152,3 +152,34 @@ def test_run_constraint_missing_field_stays_specific():
     assert result.exit_code != 0
     assert "count" in result.output or "Field required" in result.output
     assert "Expected format" not in result.output
+
+
+@pytest.mark.regression
+def test_run_rejects_duplicate_backend_flags():
+    """
+    Passing ``--backend`` twice is illegal (no silent last-wins override).
+
+    ## WRITTEN BY AI ##
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "run",
+            "--backend",
+            "kind=openai_http,target=http://127.0.0.1:8000",
+            "--backend",
+            (
+                "kind=openai_http,target=http://127.0.0.1:8000,"
+                "request_format=/v1/responses"
+            ),
+            "--data",
+            "kind=synthetic_text,prompt_tokens=16,output_tokens=8",
+            "--constraint",
+            "kind=max_requests,count=1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "cannot be specified multiple times" in result.output
+    assert "--backend" in result.output

--- a/tests/unit/utils/test_click_pydantic.py
+++ b/tests/unit/utils/test_click_pydantic.py
@@ -366,6 +366,43 @@ class TestRegistryOptionErrors:
         assert "requires a value" in result.output
         assert "Expected format" in result.output
 
+    def test_duplicate_non_repeatable_option_rejected(self):
+        """Non-repeatable registry options cannot be specified twice.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            self._make_command(multiple=False),
+            [
+                "--cfg",
+                "kind=max_requests,count=1",
+                "--cfg",
+                "kind=max_duration,seconds=1",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "cannot be specified multiple times" in result.output
+
+    def test_repeatable_option_allows_multiple(self):
+        """Repeatable registry options still accept multiple values.
+
+        ## WRITTEN BY AI ##
+        """
+        runner = CliRunner()
+        result = runner.invoke(
+            self._make_command(multiple=True),
+            [
+                "--cfg",
+                "kind=max_requests,count=1",
+                "--cfg",
+                "kind=max_duration,seconds=1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "max_requests" in result.output
+        assert "max_duration" in result.output
+
 
 @pytest.mark.sanity
 class TestFormatValidationErrorsRegistryHints:


### PR DESCRIPTION
## Summary

This PR simplify errors if you specify multiple inputs to a non-repeatable option.

Previously, it silently ignored all but the last input. This could help users who specify multiple options and are confused why the first argument doesn't do anything.

## Test Plan

Make sure CI passes, and try passing in a second --backend input, for example.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Related issues

- Depends on #1017 (since an E2E test uses a repeated option)

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 75524736f9d546d7d5a585a598f65cd043bd57e5
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Mon Aug 10 23:58:25 2026 -0400

    Reject duplicate unrepeatable kind-type registry-backed click options
    
    Previously, it silently ignored all but the last input. This could help users who specify multiple options and are confused why the first argument doesn't do anything.
    
    Generated-by: Cursor AI Grok 4.5
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 53a7b368206a15a82319e8ed209ca295682a7f80
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Aug 13 14:00:03 2026 -0400

    Improve solution for rejecting duplicate options
    
    Generated-by: Cursor AI Grok 4.5
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Grok 4.5
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
