### PR TITLE
fix: use spawn multiprocessing context on macOS

### DIFF
--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import math
+import sys
 import threading
 import time
 import uuid
@@ -185,7 +186,9 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         per_proc_max_buffer_size = 1
 
         # Initialize multiprocessing components
-        self.mp_context = get_context(settings.mp_context_type)
+        self.mp_context = get_context(
+            "spawn" if sys.platform == "darwin" else settings.mp_context_type
+        )
         self.mp_manager = self.mp_context.Manager()
         self.startup_barrier = self.mp_context.Barrier(num_processes + 1)
         self.requests_generated_event = self.mp_context.Event()
@@ -299,7 +302,10 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             if dead:
                 message = "; ".join(dead)
                 if killed_by_signal:
-                    message += ". Check system logs for details"
+                    message += (
+                        ". Check system logs and "
+                        "docs/guides/troubleshooting.md for details"
+                    )
                 self._worker_error_details = message
                 if self.error_event is not None:
                     self.error_event.set()

--- a/tests/unit/scheduler/test_worker_group.py
+++ b/tests/unit/scheduler/test_worker_group.py
@@ -105,6 +105,22 @@ class TestWorkerProcessGroup:
     def teardown_method(self):
         pass
 
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    @patch("guidellm.scheduler.worker_group.sys.platform", "darwin")
+    @patch("guidellm.scheduler.worker_group.get_context")
+    async def test_macos_uses_spawn_context(self, mock_get_context):
+        """Use the safe multiprocessing context on macOS. ## WRITTEN BY AI ##"""
+        mock_get_context.side_effect = RuntimeError("context selected")
+        instance = WorkerProcessGroup(
+            requests=["request"], backend=MockBackend(), strategy=SynchronousStrategy()
+        )
+
+        with pytest.raises(RuntimeError, match="context selected"):
+            await instance.create_processes()
+
+        mock_get_context.assert_called_once_with("spawn")
+
     @pytest.fixture(
         params=[
             {


### PR DESCRIPTION
## Summary

Use the `spawn` multiprocessing context on macOS so worker startup does not
override CPython's platform-safe default with `fork`. Signal-related startup
errors now also point users to the existing troubleshooting guide.

## Details

- [x] Force `spawn` when `sys.platform == "darwin"` while preserving the configured context elsewhere.
- [x] Restore an actionable troubleshooting reference for signal-killed workers.
- [x] Add regression coverage for macOS context selection.

## Test Plan

- `tox -e test-unit` — full unit invocation completed successfully (3,053 collected).
- `tox -e test-unit -- -k macos_uses_spawn_context` — 1 passed, 3,052 deselected.
- `tox -e lint-check` — Ruff format/check and mdformat passed.
- `tox -e type-check` — Mypy passed for 162 source files.
- `git diff --check` — passed.

## Related Issues

- Resolves #1022

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

The commit includes the required `Generated-by: OpenAI Codex GPT-5` trailer,
and the generated regression test includes the marker required by `AGENTS.md`.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 7b8941efa0966a862ac4ecc15d9198d97cdad503
Author: nightcityblade <nightcityblade@gmail.com>
Date:   Thu Aug 13 23:29:10 2026 +0800

    fix: use spawn multiprocessing context on macOS
    
    Generated-by: OpenAI Codex GPT-5
    Signed-off-by: nightcityblade <nightcityblade@gmail.com>

---------

Generated-by: OpenAI Codex GPT-5
Signed-off-by: nightcityblade <nightcityblade@gmail.com>
