### PR TITLE
fix: splice mid-chain last-edge merges into walk-back position

### DIFF
--- a/src/guidellm/scheduler/dag.py
+++ b/src/guidellm/scheduler/dag.py
@@ -345,8 +345,10 @@ class DAGExecutionState(Generic[_RequestT, _ResponseT]):
         the chain of ``full`` parents, stopping when a node has no ``full``
         incoming edge (i.e., it was reached via ``new``, ``last``, or is a
         root). At intermediate nodes where the walk continues, also collects
-        ``last`` parent outputs. ``last`` parents at the stopping node are
-        NOT collected -- they belong to the stopping node's own context.
+        ``last`` parent outputs, positioned immediately before that node's
+        own pair (the point in the chain where the merge occurred). ``last``
+        parents at the stopping node are NOT collected -- they belong to the
+        stopping node's own context.
 
         Every node on the walk (and its mid-chain ``last`` parents) must
         already be in ``_completed``.
@@ -356,8 +358,10 @@ class DAGExecutionState(Generic[_RequestT, _ResponseT]):
         :raises ValueError: If a required ancestor or mid-chain ``last``
             parent has not completed.
         """
-        chain_reversed: list[tuple[_RequestT, _ResponseT | None]] = []
-        interleaved_last: list[tuple[_RequestT, _ResponseT | None]] = []
+        # Segment = a node's mid-chain last-parent pairs (if any) plus its
+        # own pair. Reversing the segment list, not the flattened pairs,
+        # keeps each merge adjacent to the node it merged into.
+        segments: list[list[tuple[_RequestT, _ResponseT | None]]] = []
         current_id: str | None = start_node_id
 
         while current_id is not None:
@@ -367,21 +371,22 @@ class DAGExecutionState(Generic[_RequestT, _ResponseT]):
                     f"Cannot assemble history: parent '{current_id}' has not completed"
                 )
 
-            chain_reversed.append((completed.request, completed.response))
-
             current_incoming = self._incoming_edges.get(current_id, [])
             full_edge = self._find_full_parent_edge(current_incoming)
 
             # Only collect last parents at nodes where the walk CONTINUES
             # (has a full parent). At the stopping node, last parents are
             # the node's own context, not part of downstream history.
+            segment: list[tuple[_RequestT, _ResponseT | None]] = []
             if full_edge is not None:
-                interleaved_last.extend(self._collect_last_pairs(current_incoming))
+                segment.extend(self._collect_last_pairs(current_incoming))
+            segment.append((completed.request, completed.response))
+            segments.append(segment)
 
             current_id = full_edge.source_node_id if full_edge is not None else None
 
-        chain_reversed.reverse()
-        return chain_reversed + interleaved_last
+        segments.reverse()
+        return [pair for segment in segments for pair in segment]
 
     def get_remaining_node_ids(self) -> list[str]:
         """

--- a/src/guidellm/scheduler/dag.py
+++ b/src/guidellm/scheduler/dag.py
@@ -358,10 +358,12 @@ class DAGExecutionState(Generic[_RequestT, _ResponseT]):
         :raises ValueError: If a required ancestor or mid-chain ``last``
             parent has not completed.
         """
-        # Segment = a node's mid-chain last-parent pairs (if any) plus its
-        # own pair. Reversing the segment list, not the flattened pairs,
-        # keeps each merge adjacent to the node it merged into.
-        segments: list[list[tuple[_RequestT, _ResponseT | None]]] = []
+        # Each node contributes a segment: its mid-chain last-parent pairs
+        # (if any) plus its own pair, in that order. The walk visits nodes
+        # newest-first, so each segment is prepended rather than appended,
+        # which keeps a merge adjacent to the node it merged into without a
+        # separate segment-level reverse pass.
+        segments: list[tuple[_RequestT, _ResponseT | None]] = []
         current_id: str | None = start_node_id
 
         while current_id is not None:
@@ -381,12 +383,11 @@ class DAGExecutionState(Generic[_RequestT, _ResponseT]):
             if full_edge is not None:
                 segment.extend(self._collect_last_pairs(current_incoming))
             segment.append((completed.request, completed.response))
-            segments.append(segment)
+            segments = segment + segments
 
             current_id = full_edge.source_node_id if full_edge is not None else None
 
-        segments.reverse()
-        return [pair for segment in segments for pair in segment]
+        return segments
 
     def get_remaining_node_ids(self) -> list[str]:
         """

--- a/tests/unit/scheduler/test_dag.py
+++ b/tests/unit/scheduler/test_dag.py
@@ -328,6 +328,51 @@ class TestDAGExecutionStateWalkBack:
         ]
         assert hist == expected
 
+    @pytest.mark.regression
+    def test_mid_chain_last_edge_preserves_chronological_position(self):
+        """
+        A ``last`` edge merging into a mid-chain node (not the queried
+        node's immediate full parent) must appear right after that node's
+        own predecessor and before the main-chain turns that followed it,
+        not lumped after the entire main chain.
+
+        Graph: M1 -full-> M2 -full-> M3 -full-> M4, with a sub-agent
+        branch X1 merging into M2 via a ``last`` edge. M4's history must
+        read M1, X1, M2, M3 in the order the merge actually happened.
+
+        ## WRITTEN BY AI ##
+        """
+        nodes = {nid: _make_node(nid) for nid in ["M1", "M2", "M3", "M4", "X1"]}
+        edges = [
+            ConversationEdge(
+                source_node_id="M1", target_node_id="M2", history_context="full"
+            ),
+            ConversationEdge(
+                source_node_id="X1", target_node_id="M2", history_context="last"
+            ),
+            ConversationEdge(
+                source_node_id="M2", target_node_id="M3", history_context="full"
+            ),
+            ConversationEdge(
+                source_node_id="M3", target_node_id="M4", history_context="full"
+            ),
+        ]
+        g = ConversationGraph(graph_id="mid_chain_merge", nodes=nodes, edges=edges)
+        state = DAGExecutionState(g)
+        state.mark_completed("M1", "r_M1", "resp_M1")
+        state.mark_completed("X1", "r_X1", "resp_X1")
+        state.mark_completed("M2", "r_M2", "resp_M2")
+        state.mark_completed("M3", "r_M3", "resp_M3")
+
+        hist = state.assemble_history("M4")
+        expected = [
+            ("r_M1", "resp_M1"),
+            ("r_X1", "resp_X1"),
+            ("r_M2", "resp_M2"),
+            ("r_M3", "resp_M3"),
+        ]
+        assert hist == expected
+
     @pytest.mark.sanity
     def test_compaction_boundary(self):
         """


### PR DESCRIPTION
## Summary

`DAGExecutionState._walk_back_full` assembles a node's conversation history by walking
backwards through `full` edges. At each intermediate node it also collects that node's
`last`-edge parents (sub-agent branch merges), but it appended all of them after the entire
main chain instead of at the point where the merge happened. Any main-chain turn that came
after the merge point ended up ordered ahead of the merged turn in the history sent to the
backend.

## Details

- [x] Build each walked node's own pair together with its own mid-chain `last`-edge pairs as
  one segment, then reverse the list of segments (not the flattened pairs) to restore
  chronological order. This keeps a merge adjacent to the node it merged into instead of
  pushed to the end.

## Test Plan

- `tests/unit/scheduler/test_dag.py::TestDAGExecutionStateWalkBack::test_mid_chain_last_edge_preserves_chronological_position`
  fails on `main` (returns `[M1, M2, M3, X1]`) and passes with this fix (`[M1, X1, M2, M3]`),
  verified in a clean `python:3.10-slim` container.
- Full `tests/unit/scheduler` suite passes (539 passed), including the existing
  `test_fork_join_history_assembly`, which exercises the case where the merge is the queried
  node's own immediate parent rather than a mid-chain node.
- `ruff format --check`, `ruff check`, and `mypy --check-untyped-defs` are clean on both
  changed files.
- Not checked: the wider `tests/unit` suite has 14 pre-existing failures unrelated to this
  change (`tests/unit/utils/test_audio.py`, `libtorchcodec`/ffmpeg shared-library loading in
  the slim container image), reproduced identically on both `python:3.10-slim` and
  `python:3.13-slim` before this diff was applied.

## Related Issues

- Fixes #1029

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit 8a9326a62fe61874c516d23478aace10cfcef1a8
Author: Amir Fathi <amirfathi.me@gmail.com>
Date:   Fri Aug 14 07:05:27 2026 +0000

    fix: splice mid-chain last-edge merges into walk-back position
    
    _walk_back_full collected each mid-chain node's last-edge (sub-agent
    branch merge) pairs into a separate list and appended it after the
    whole main chain, instead of at the point in the walk where the merge
    happened. Any main-chain turn that followed the merge point ended up
    ordered ahead of the merged turn in the assembled history sent to the
    backend.
    
    Build each node's own pair plus its own mid-chain last-edge pairs as
    one segment while walking backwards, then reverse the list of segments
    (not the flattened pairs) to restore chronological order. This keeps
    each merge adjacent to the node it merged into.
    
    Fixes #1029
    
    Generated-by: Claude Code claude-sonnet-5
    Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>

commit 729bbb58e837be980ebd9341a8b4729254cd3f20
Author: Amir Fathi <amirfathi.me@gmail.com>
Date:   Mon Aug 24 17:25:31 2026 +0000

    fix: simplify walk-back to a single flat list via segment prepend
    
    Per review feedback, extending directly into a flat list and reversing
    once at the end breaks the mid-chain merge test: reversing the whole
    flat sequence also reverses each node's own last-pairs/own-pair
    ordering, not just the node visit order (M2 and X1 swap in the
    mid-chain-merge regression test). Prepending each node's segment as it
    is built keeps the per-node internal order correct while dropping the
    separate list-of-lists plus final flatten step.
    
    Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>

---------

Generated-by: Claude Code claude-sonnet-5
Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>
