### PR TITLE
Pull pending requests into a worker only when a consumer is waiting

### DIFF
--- a/src/guidellm/utils/messaging.py
+++ b/src/guidellm/utils/messaging.py
@@ -133,6 +133,8 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
         self.shutdown_event: ThreadingEvent | None = None
         self.buffer_send_queue: culsans.Queue[SendMessageT] | None = None
         self.buffer_receive_queue: culsans.Queue[ReceiveMessageT] | None = None
+        self.receive_demand_event: ThreadingEvent | None = None
+        self._receive_demand: int = 0
         self.send_task: asyncio.Task | None = None
         self.receive_task: asyncio.Task | None = None
         self.running = False
@@ -218,6 +220,8 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
         self.buffer_receive_queue = culsans.Queue[ReceiveMessageT](
             maxsize=self.max_buffer_receive_size or 0
         )
+        self.receive_demand_event = ThreadingEvent()
+        self._receive_demand = 0
 
         message_encoding: MessageEncoding = MessageEncoding(
             serialization=self.serialization,
@@ -271,6 +275,7 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
                 await self.buffer_receive_queue.aclose()
         self.buffer_send_queue = None
         self.buffer_receive_queue = None
+        self.receive_demand_event = None
         self.send_stopped_event = None
         self.receive_stopped_event = None
         self.shutdown_event = None
@@ -361,9 +366,13 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
             raise RuntimeError(
                 "buffer receive queue is None; check start()/stop() calls"
             )
-        return await asyncio.wait_for(
-            self.buffer_receive_queue.async_get(), timeout=timeout
-        )
+        self._signal_receive_demand()
+        try:
+            return await asyncio.wait_for(
+                self.buffer_receive_queue.async_get(), timeout=timeout
+            )
+        finally:
+            self._receive_demand -= 1
 
     def get_sync(self, timeout: float | None = None) -> ReceiveMessageT:
         """
@@ -376,10 +385,14 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
             raise RuntimeError(
                 "buffer receive queue is None; check start()/stop() calls"
             )
-        if timeout is not None and timeout <= 0:
-            return self.buffer_receive_queue.get_nowait()
-        else:
-            return self.buffer_receive_queue.sync_get(timeout=timeout)
+        self._signal_receive_demand()
+        try:
+            if timeout is not None and timeout <= 0:
+                return self.buffer_receive_queue.get_nowait()
+            else:
+                return self.buffer_receive_queue.sync_get(timeout=timeout)
+        finally:
+            self._receive_demand -= 1
 
     async def put(self, item: SendMessageT, timeout: float | None = None):
         """
@@ -409,6 +422,27 @@ class InterProcessMessaging(Generic[SendMessageT, ReceiveMessageT], ABC):
             self.buffer_send_queue.put_nowait(item)
         else:
             self.buffer_send_queue.sync_put(item, timeout=timeout)
+
+    def _signal_receive_demand(self):
+        """
+        Register a consumer waiting on the receive buffer and wake the receive
+        thread so it can fetch a message for it.
+        """
+        self._receive_demand += 1
+        if self.receive_demand_event is not None:
+            self.receive_demand_event.set()
+
+    def _has_receive_demand(self) -> bool:
+        """
+        Check whether a consumer is waiting on the receive buffer for a message
+        that is not already buffered.
+
+        :return: True if more consumers are waiting than messages are buffered
+        """
+        if self.buffer_receive_queue is None:
+            return False
+
+        return self._receive_demand > self.buffer_receive_queue.qsize()
 
     def _create_check_stop_callable(
         self,
@@ -670,7 +704,7 @@ class InterProcessMessagingQueue(InterProcessMessaging[SendMessageT, ReceiveMess
 
             time.sleep(0)  # Yield to other threads
 
-    def _receive_messages_task_thread(  # noqa: C901
+    def _receive_messages_task_thread(  # noqa: C901, PLR0912
         self,
         receive_callback: Callable[[Any], Any] | None,
         message_encoding: MessageEncoding,
@@ -682,6 +716,21 @@ class InterProcessMessagingQueue(InterProcessMessaging[SendMessageT, ReceiveMess
 
         while not check_stop(pending_item is not None, queue_empty_count):
             if pending_item is None:
+                if self.worker_index is not None and not self._has_receive_demand():
+                    # Worker: only take from the shared pending queue when a
+                    # consumer is waiting. Otherwise the item is stuck in this
+                    # worker's buffer while other workers with free capacity
+                    # have nothing to process.
+                    if self.shutdown_event is not None and self.shutdown_event.is_set():
+                        # Count as an empty poll so check_stop can terminate
+                        queue_empty_count += 1
+                    elif self.receive_demand_event is not None:
+                        # Block until a consumer signals demand (or poll interval)
+                        self.receive_demand_event.clear()
+                        if not self._has_receive_demand():
+                            self.receive_demand_event.wait(timeout=self.poll_interval)
+                    continue
+
                 try:
                     if self.worker_index is None:
                         # Main publisher
@@ -696,7 +745,10 @@ class InterProcessMessagingQueue(InterProcessMessaging[SendMessageT, ReceiveMess
                             raise RuntimeError(
                                 "pending_queue is None; check start()/stop() calls"
                             )
-                        item = self.pending_queue.get(timeout=self.poll_interval)
+                        # Queue.get holds the read lock while it polls, so a
+                        # worker waiting on an empty queue blocks the others;
+                        # keep that window short.
+                        item = self.pending_queue.get(timeout=self.poll_interval / 10)
                     pending_item = message_encoding.decode(item)
                     queue_empty_count = 0
                 except (culsans.QueueEmpty, queue.Empty):

--- a/tests/unit/utils/test_messaging.py
+++ b/tests/unit/utils/test_messaging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import multiprocessing
+import queue
 import threading
 from typing import Any, TypeVar
 
@@ -285,6 +286,53 @@ class TestInterProcessMessagingQueue:
         assert instance.buffer_receive_queue is None
         assert instance.send_task is None
         assert instance.receive_task is None
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_worker_receive_pulls_only_on_demand(self, valid_instances):
+        """
+        A worker must not take messages off the shared pending queue unless one
+        of its consumers is waiting for a message. Otherwise messages sit in a
+        busy worker's receive buffer while other workers with free capacity idle
+        (https://github.com/vllm-project/guidellm/issues/1041).
+
+        ## WRITTEN BY AI ##
+        """
+        instance, constructor_args, manager, context = valid_instances
+        worker = instance.create_worker_copy(0, max_buffer_receive_size=1)
+        num_messages = 5
+
+        await instance.start(pydantic_models=[MockMessage])
+        await worker.start(pydantic_models=[MockMessage])
+
+        try:
+            for num in range(num_messages):
+                await instance.put(MockMessage(content="test", num=num), timeout=2.0)
+            await asyncio.sleep(0.2)
+
+            # No consumer is waiting: nothing should have been buffered locally
+            assert worker.buffer_receive_queue is not None
+            assert worker.buffer_receive_queue.qsize() == 0
+
+            # One consumer receives exactly one message, nothing is prefetched
+            received = await worker.get(timeout=2.0)
+            assert received.num == 0
+            await asyncio.sleep(0.2)
+            assert worker.buffer_receive_queue.qsize() == 0
+
+            # All remaining messages are still on the shared pending queue
+            remaining = 0
+            while True:
+                try:
+                    instance.pending_queue.get(timeout=0.2)
+                    remaining += 1
+                except queue.Empty:
+                    break
+            assert remaining == num_messages - 1
+        finally:
+            await worker.stop()
+            await instance.stop()
 
     @pytest.mark.xfail(reason="old and broken", run=False)
     @pytest.mark.smoke


### PR DESCRIPTION
## Summary

When `max_concurrency == max_requests` (a simultaneous burst) with multiple worker processes, a few requests do not start immediately. They wait until an earlier request **on the same worker** finishes, even though other workers have free slots, and which requests stall differs run to run (#1041).

The scheduler side is fine: `WorkerProcess._process_requests_loop` acquires the `asyncio.Semaphore(async_limit)` before creating each request task, and each task blocks in `messaging.get()`. The over-fetch happens one layer down, in `InterProcessMessagingQueue._receive_messages_task_thread`, which pulls from the shared `pending_queue` **unconditionally**:

1. The item goes into the worker's local `buffer_receive_queue` (`max_buffer_receive_size=1`, set in `WorkerProcessGroup.create_processes`).
2. When that buffer is full, the thread keeps the next item in its local `pending_item` variable and retries `sync_put` until space frees up.

So a worker whose `async_limit` slots are all busy still removes **two extra** requests from the shared queue (one buffered, one in hand). They are no longer visible to other workers and can only start once a slot on *this* worker frees. A standalone check confirms it: a worker copy with no consumer at all pulls 2 of 10 queued items. This matches the reporter's "2 more than slots" observation, and in my runs every over-limit worker held exactly `async_limit + 1` or `async_limit + 2` requests, never more.

```
Before:  pending_queue → receive thread (always pulls) → local buffer[1] + in-hand[1] → task
Why:     the pull is not tied to any free slot on this worker
After:   pending_queue → receive thread (pulls only if a task is waiting) → task
```

This PR makes the worker's receive thread take a request off the shared queue only when one of that worker's request tasks is actually waiting for it.

## Details

- Add `InterProcessMessaging._has_receive_demand()`: true when more consumers are waiting on `buffer_receive_queue` than there are items already buffered. Demand is tracked by a counter that `get()`/`get_sync()` increment before waiting and decrement in `finally`; all production callers use `get()` from the worker's event loop, so the counter has a single writer.
- `get()` also sets a `threading.Event` (`receive_demand_event`, created in `start()` so the object stays picklable for `spawn`). In `InterProcessMessagingQueue._receive_messages_task_thread`, workers (`worker_index is not None`) skip `pending_queue.get()` while there is no demand and block on that event with `poll_interval` as the backstop — no polling while idle. The clear-then-recheck ordering makes a wake-up impossible to lose: a consumer that registers after the recheck sets the event after the clear, so `wait()` returns immediately. The main-process side (receiving from `done_queue`) is unchanged.
- `stop()` relies on the thread observing an empty source `STOP_REQUIRED_QUEUE_EMPTY_COUNT` times, so while gated the thread counts toward that only once `shutdown_event` is set. The `requests_generated_event` stop path is unaffected: the thread keeps waiting for demand and exits once it actually observes the shared queue empty.
- `InterProcessMessagingManagerQueue` inherits the same thread, so it is covered. `InterProcessMessagingPipe` is untouched: it assigns work to a worker's pipe at send time, which is a separate concern.
- `# noqa: PLR0912` added to the queue receive thread; the sibling send thread already carries the same marker.
- `multiprocessing.Queue.get(timeout)` acquires the queue's read lock and keeps it while it polls, so one worker waiting on a momentarily empty shared queue blocks the others for the whole timeout. With demand-gated pulls workers arrive at the queue in bursts, so the worker-side `get` now uses `poll_interval / 10`; the stop logic is unaffected (`STOP_REQUIRED_QUEUE_EMPTY_COUNT` empty polls still gate every exit path).
- Under load the receive thread never idles: as long as any request task on the worker is waiting it pulls back-to-back exactly as before. The only buffering removed is the 1 buffered + 1 in-hand item that a fully busy worker used to hold — which is what starves the other workers.

## Test Plan

**Reproduction (before the fix)** with guidellm's own `mock-server` (no model needed), Apple M1, 10 worker processes, `async_limit=5` each:

```bash
guidellm mock-server --port 8010 --model mock-model --request-latency 3.0 --ttft-ms 200 --itl-ms 20 --output-tokens 32
guidellm run \
  --backend "kind=openai_http,target=http://127.0.0.1:8010,model=mock-model" \
  --data "kind=synthetic_text,prompt_tokens=64,output_tokens=32" \
  --tokenizer "kind=hf_auto,model=gpt2" \
  --profile "kind=throughput,max_concurrency=50" \
  --constraint "kind=max_requests,count=50" \
  --output "kind=json,path=run.json"
```

| run | started immediately (before) | started immediately (after) |
| --- | --- | --- |
| 1 | 44/50 (workers 1,2,3 held 7 requests each) | 50/50 |
| 2 | 46/50 (workers 5,8 held 7 each) | 50/50 |
| 3 | 44/50 (workers 1,2,7,9 held 6–7 each) | 50/50 |
| `GUIDELLM__MAX_WORKER_PROCESSES=1` control | 50/50 | 50/50 |

Reporter's second scenario, `--profile kind=concurrent,streams=17 --constraint kind=max_requests,count=17` (15–16/17 in the issue): **17/17, 17/17, 17/17** after the fix.

**Regression test** `tests/unit/utils/test_messaging.py::TestInterProcessMessagingQueue::test_worker_receive_pulls_only_on_demand` (6 parametrizations: 3 configs × fork/spawn):

- fails on `main` (the worker buffers an item with no consumer; `stop()` then hangs because the thread is holding a second item);
- passes with this change.

**Unit tests, lint, types:**

```
python -m pytest tests/unit/utils/test_messaging.py tests/unit/scheduler/ -q
# 644 passed, 160 xfailed  (the xfails are pre-existing on main)
ruff check / ruff format --check on both files: clean
mypy --check-untyped-defs src/guidellm/utils/messaging.py: no issues found
```

**High concurrency + `max_duration`** (real `WorkerProcessGroup`, 10 processes, in-process backend sleeping 1 s per request, 10 s runs; the mock-server saturates an M1 above ~300 streams so HTTP was taken out of the loop):

| | `main` @500 | PR @500 | `main` @2000 | PR @2000 |
| --- | --- | --- | --- | --- |
| completed req/s | 451.7 | 453.3 | 1803.7 | 1802.4 |
| mean in-flight | 486.9 | 486.0 | 1848 | 1845 |
| peak in-flight | 500 | 500 | 2000 | 2000 |
| worker-tree CPU (avg) | 105% | 97% | 246% | 228% |

Burst case (`max_concurrency = max_requests = 50`, 6 runs each): `main` 42–45/50 started immediately, ~1.0 s to dispatch all 50; PR 50/50 ×6, 0.05–0.15 s.

Caveat: at the `max_duration` cutoff, roughly half of the runs on **both** `main` and this PR either raise `Error processing received update: '<id>'` (a KeyError in `_update_state_request_counts`) or never return from `scheduler.run()`. That is a pre-existing cancel-ordering race in `WorkerProcess._cancel_requests_loop` (it `abort()`s nodes that in-flight tasks still own before those tasks have processed their cancellation); this PR neither causes nor fixes it — reported separately.

## Related Issues

- Resolves #1041

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Investigation, code, and tests were produced with Claude Code under my direction and review; the commit carries the `Generated-by:` trailer. I reproduced the bug and verified the fix end-to-end locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit 2f23fd70c8ea6ce319909e435ea3a4b3fd56601d
Author: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>
Date:   Mon Aug 24 23:07:26 2026 +0530

    Pull pending requests into a worker only when a consumer is waiting
    
    With multiple worker processes, a worker's messaging receive thread pulled
    from the shared pending queue unconditionally: one item into its local
    receive buffer (size 1) and, when that was full, a second one held in the
    thread while it retried the put. A worker whose async_limit slots were all
    busy therefore still removed two extra requests from the shared queue, and
    idle workers could not start them. In a burst with
    max_concurrency == max_requests this left a few requests waiting on a busy
    worker while other workers had free slots.
    
    Gate the worker-side pull on real demand: get()/get_sync() register a
    waiting consumer (a counter plus a threading.Event) and the receive thread
    only takes from the shared queue when more consumers are waiting than
    items are buffered. While there is no demand it blocks on the event
    (poll_interval as the backstop) instead of polling, and only counts toward
    the stop condition once shutdown_event is set, so stop() still terminates
    the thread.
    
    Because Queue.get(timeout) holds the queue's read lock while it polls, a
    worker waiting on a momentarily empty shared queue blocks the others; use
    a shorter timeout for the worker-side get to keep that window small.
    
    Adds a regression test that fails on main: a worker copy with no consumer
    must not take messages off the shared pending queue.
    
    Fixes #1041
    
    Generated-by: Claude Code
    Co-Authored-By: Claude <noreply@anthropic.com>
    Signed-off-by: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>

---------

Co-Authored-By: Claude <noreply@anthropic.com>
Generated-by: Claude Code
Signed-off-by: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>
