### PR TITLE
Report worker 0 correctly in RequestInfo.scheduler_node_id

### DIFF
--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -329,7 +329,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 node = state.graph.nodes[node_id]
                 request_info = state.request_infos.get(node_id)
                 if request_info is not None:
-                    request_info.scheduler_node_id = self.messaging.worker_index or -1
+                    request_info.scheduler_node_id = self.worker_index
                     request_info.error = "Request was cancelled"
                     request_info.timings.resolve_end = time.time()
                     self._send_update("cancelled", None, node.request, request_info)
@@ -345,7 +345,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
             for node_id, node in graph.nodes.items():
                 request_info = graph.request_infos.get(node_id)
                 if request_info is not None:
-                    request_info.scheduler_node_id = self.messaging.worker_index or -1
+                    request_info.scheduler_node_id = self.worker_index
                     request_info.error = "Request was cancelled"
                     request_info.timings.resolve_end = time.time()
                     self._send_update("cancelled", None, node.request, request_info)
@@ -438,7 +438,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 f"No RequestInfo for node '{node_id}' in graph '{state.graph.graph_id}'"
             )
         request_info.timings.dequeued = time.time()
-        request_info.scheduler_node_id = self.messaging.worker_index or -1
+        request_info.scheduler_node_id = self.worker_index
         request_info.timings.targeted_start = target_start
         self._send_update("pending", None, request, request_info)
         return request, request_info

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -1012,3 +1012,57 @@ class TestWorkerProcessMultiturn:
             pass
         assert info_m2.history_len == 3
         assert info_m2.turn_index == 2
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_worker_index_zero_reported_as_scheduler_node_id(self):
+        """Worker 0 must report scheduler_node_id 0, not the unknown sentinel -1.
+
+        ## WRITTEN BY AI ##
+        """
+        worker = WorkerProcess(
+            worker_index=0,
+            messaging=MockMessaging(worker_index=0),
+            backend=MockBackend(),
+            strategy=SynchronousStrategy(),
+            async_limit=5,
+            fut_scheduling_time_limit=10.0,
+            startup_barrier=Barrier(2),
+            requests_generated_event=Event(),
+            constraint_reached_event=Event(),
+            shutdown_event=Event(),
+            error_event=Event(),
+        )
+        graph = ConversationGraph(
+            graph_id="worker_zero",
+            nodes={
+                "n0": ConversationNode(node_id="n0", agent_id="a", request="r0"),
+                "n1": ConversationNode(node_id="n1", agent_id="a", request="r1"),
+            },
+            edges=[],
+            request_infos={
+                "n0": RequestInfo(request_id="id0", node_id="n0"),
+                "n1": RequestInfo(request_id="id1", node_id="n1"),
+            },
+        )
+        state = DAGExecutionState(graph)
+
+        # Dequeue path
+        _, request_info = worker._prepare_node(state, "n0", target_start=time.time())
+        assert request_info.scheduler_node_id == 0
+
+        # Cancel path for graphs still queued on the worker
+        worker.turns_queue.append(state)
+        cancel_task = asyncio.create_task(worker._cancel_requests_loop())
+        await asyncio.sleep(0.05)
+        cancel_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cancel_task
+
+        cancelled = [
+            info
+            for _, _, info in worker.messaging._sent_items
+            if info.status == "cancelled"
+        ]
+        assert cancelled
+        assert all(info.scheduler_node_id == 0 for info in cancelled)


### PR DESCRIPTION
## Summary

Every request handled by worker **0** is reported with `scheduler_node_id == -1` instead of `0` (#1043).

The three assignments in `src/guidellm/scheduler/worker.py` use `self.messaging.worker_index or -1`. The `or -1` is meant as a fallback for `worker_index is None`, but `0` is falsy too, so the first worker's index is replaced by the "unknown" sentinel. This corrupts the per-worker view of the benchmark output that you need when debugging scheduling behaviour (I hit it while working on #1041 / #1042).

## Details

- `_prepare_node`, and both loops in `_cancel_requests_loop`, now use the worker's own `self.worker_index` (an `int` that is always set in `__init__` and already used for `strategy.next_request_time(worker_index=self.worker_index)`), so no `None` fallback is needed at these sites.
- Regression test `TestWorkerProcessMultiturn::test_worker_index_zero_reported_as_scheduler_node_id` builds a worker with `worker_index=0` and checks `scheduler_node_id == 0` on both the dequeue path and the cancel path.

## Test Plan

- Regression test fails on `main` (`AssertionError: assert -1 == 0`) and passes with this change.
- `python -m pytest tests/unit/scheduler/test_worker.py -q` → 11 passed, 12 xfailed (main: 10 passed, 12 xfailed; the xfails are pre-existing).
- `ruff check` / `ruff format --check` on both files: clean.
- `mypy --check-untyped-defs src/guidellm/scheduler/worker.py`: no issues.

## Related Issues

- Resolves #1043

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Code and test were produced with Claude Code under my direction and review; the commit carries the `Generated-by:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- begin:squash-data -->

---

# git log

commit 2132b8943e6e31134c91d3ca787949668ff35e05
Author: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>
Date:   Mon Aug 24 23:10:57 2026 +0530

    Report worker 0 correctly in RequestInfo.scheduler_node_id
    
    `self.messaging.worker_index or -1` treats worker index 0 as missing
    because 0 is falsy, so every request handled by the first worker was
    reported with the -1 "unknown" sentinel. Use the worker's own
    `self.worker_index`, which is always set, at the three sites.
    
    Adds a regression test covering both the dequeue path (_prepare_node)
    and the cancel path (_cancel_requests_loop) for worker 0.
    
    Fixes #1043
    
    Generated-by: Claude Code
    Co-Authored-By: Claude <noreply@anthropic.com>
    Signed-off-by: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>

---------

Co-Authored-By: Claude <noreply@anthropic.com>
Generated-by: Claude Code
Signed-off-by: Himanshu Prajapati <himanshuprajapati15072003@gmail.com>
