### PR TITLE
Add scheduler dispatch delay and schedule-relative latency metrics

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -66,23 +66,7 @@ These metrics provide a breakdown of the overall request statuses, helping users
 - **Definition**: `request_scheduled_latency` is `request_end - targeted_start`: request latency measured from the scheduled arrival time rather than from dispatch. When all three timestamps are present it equals Dispatch Delay plus Request Latency.
 - **Use Case**: Describes what a client holding to the configured arrival schedule would have experienced, including time spent waiting to be dispatched. When the benchmark keeps up this matches Request Latency; when it falls behind, the gap between the two is latency that Request Latency alone does not show.
 
-### Applicability of Dispatch Delay and Scheduled Latency
-
-Both metrics are derived from `targeted_start`, so they only describe arrival-schedule delay for strategies that define an arrival schedule:
-
-- `constant` and `poisson` derive each target from the configured rate.
-- `trace` derives each target from the replayed dataset timestamps. Trace requests that carry no relative timestamp fall back to the benchmark start time and take on the `throughput` caveat below.
-
-The `synchronous`, `concurrent`, and `throughput` strategies set an ASAP-style target instead, and each is unusable for a different reason:
-
-- `synchronous` and `concurrent` target the previous request's completion, apart from the requests staggered across a configured rampup. The target is therefore derived from the system's own responses, so a delay measured against it is circular: it describes harness turnaround rather than lag against an arrival schedule.
-- `throughput` targets the benchmark start time for every request, so the value grows with elapsed run time and is not a delay at all.
-
-For those three strategies **both metrics are reported as `null`** rather than as zero, and their columns do not appear in the CSV. Reporting zero would read as "no delay measured", which is a stronger and more misleading claim than "not applicable". This matters for the default `sweep` profile, which runs `synchronous` and `throughput` alongside its rate-based strategies.
-
-For multi-turn conversation datasets, a turn's target is fixed when a scheduler slot opens rather than when the preceding turn completes, so configured think time between turns is counted as Dispatch Delay.
-
-Where the metrics do apply they are recorded in the serialized report and the CSV output for offline analysis. They are omitted from the final console latency table in all cases, since that table is shared across every profile in a run.
+Dispatch Delay and Scheduled Latency only apply to some of the scheduling strategies. See [Applicability of Dispatch Delay and Scheduled Latency](#applicability-of-dispatch-delay-and-scheduled-latency) below.
 
 ### Time to First Token (TTFT)
 
@@ -148,3 +132,21 @@ GuideLLM calculates a comprehensive set of percentiles for each metric, includin
 - **Percentiles**: Offer a detailed view of the distribution, helping identify outliers and performance at different levels of service.
 
 By combining these metrics and statistical summaries, GuideLLM enables users to gain a deep understanding of their LLM deployments, optimize performance, and ensure scalability and cost-effectiveness.
+
+## Applicability of Dispatch Delay and Scheduled Latency
+
+Both metrics are derived from `targeted_start`, so they only describe arrival-schedule delay for strategies that define an arrival schedule:
+
+- `constant` and `poisson` derive each target from the configured rate.
+- `trace` derives each target from the replayed dataset timestamps. Trace requests that carry no relative timestamp fall back to the benchmark start time and take on the `throughput` caveat below.
+
+The `synchronous`, `concurrent`, and `throughput` strategies set an ASAP-style target instead, and each is unusable for a different reason:
+
+- `synchronous` and `concurrent` target the previous request's completion, apart from the requests staggered across a configured rampup. The target is therefore derived from the system's own responses, so a delay measured against it is circular: it describes harness turnaround rather than lag against an arrival schedule.
+- `throughput` targets the benchmark start time for every request, so the value grows with elapsed run time and is not a delay at all.
+
+For those three strategies **both metrics are reported as `null`** rather than as zero, and their columns do not appear in the CSV. Reporting zero would read as "no delay measured", which is a stronger and more misleading claim than "not applicable". This matters for the default `sweep` profile, which runs `synchronous` and `throughput` alongside its rate-based strategies.
+
+For multi-turn conversation datasets, a turn's target is fixed when a scheduler slot opens rather than when the preceding turn completes, so configured think time between turns is counted as Dispatch Delay.
+
+Where the metrics do apply they are recorded in the serialized report and the CSV output for offline analysis. They are omitted from the final console latency table in all cases, since that table is shared across every profile in a run.

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -56,6 +56,34 @@ These metrics provide a breakdown of the overall request statuses, helping users
 - **Definition**: The time taken to process a single request, from start to finish.
 - **Use Case**: A critical metric for evaluating the responsiveness of the system.
 
+### Dispatch Delay
+
+- **Definition**: `request_dispatch_delay` is `request_start - targeted_start`: the time between when a request was scheduled to arrive and when it was actually sent.
+- **Use Case**: Reveals whether the benchmark itself kept up with the configured arrival schedule. A request cannot be dispatched while the concurrency limit is saturated, and that wait is not part of Request Latency. A delay near zero means the reported latencies reflect the full picture; a large delay means the load generator fell behind and the server saw a lower arrival rate than was requested.
+
+### Scheduled Latency
+
+- **Definition**: `request_scheduled_latency` is `request_end - targeted_start`: request latency measured from the scheduled arrival time rather than from dispatch. When all three timestamps are present it equals Dispatch Delay plus Request Latency.
+- **Use Case**: Describes what a client holding to the configured arrival schedule would have experienced, including time spent waiting to be dispatched. When the benchmark keeps up this matches Request Latency; when it falls behind, the gap between the two is latency that Request Latency alone does not show.
+
+### Applicability of Dispatch Delay and Scheduled Latency
+
+Both metrics are derived from `targeted_start`, so they only describe arrival-schedule delay for strategies that define an arrival schedule:
+
+- `constant` and `poisson` derive each target from the configured rate.
+- `trace` derives each target from the replayed dataset timestamps. Trace requests that carry no relative timestamp fall back to the benchmark start time and take on the `throughput` caveat below.
+
+The `synchronous`, `concurrent`, and `throughput` strategies set an ASAP-style target instead, and each is unusable for a different reason:
+
+- `synchronous` and `concurrent` target the previous request's completion, apart from the requests staggered across a configured rampup. The target is therefore derived from the system's own responses, so a delay measured against it is circular: it describes harness turnaround rather than lag against an arrival schedule.
+- `throughput` targets the benchmark start time for every request, so the value grows with elapsed run time and is not a delay at all.
+
+For those three strategies **both metrics are reported as `null`** rather than as zero, and their columns do not appear in the CSV. Reporting zero would read as "no delay measured", which is a stronger and more misleading claim than "not applicable". This matters for the default `sweep` profile, which runs `synchronous` and `throughput` alongside its rate-based strategies.
+
+For multi-turn conversation datasets, a turn's target is fixed when a scheduler slot opens rather than when the preceding turn completes, so configured think time between turns is counted as Dispatch Delay.
+
+Where the metrics do apply they are recorded in the serialized report and the CSV output for offline analysis. They are omitted from the final console latency table in all cases, since that table is shared across every profile in a run.
+
 ### Time to First Token (TTFT)
 
 - **Definition**: The time taken to generate the first token of the output.

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -405,6 +405,23 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
         self._add_stats_for_metric(
             headers, values, benchmark.metrics.request_latency, "Request Latency", "Sec"
         )
+        # None for strategies without an arrival schedule; emit no columns.
+        if benchmark.metrics.request_dispatch_delay is not None:
+            self._add_stats_for_metric(
+                headers,
+                values,
+                benchmark.metrics.request_dispatch_delay,
+                "Dispatch Delay",
+                "Sec",
+            )
+        if benchmark.metrics.request_scheduled_latency is not None:
+            self._add_stats_for_metric(
+                headers,
+                values,
+                benchmark.metrics.request_scheduled_latency,
+                "Scheduled Latency",
+                "Sec",
+            )
         self._add_stats_for_metric(
             headers,
             values,

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -790,7 +790,7 @@ class GenerativeMetrics(StandardBaseDict):
             "Distribution of delays between a request's targeted start and the "
             "time it was dispatched. Grows when the scheduler cannot keep up "
             "with the configured rate. None when the strategy does not define "
-            "an arrival schedule, or for reports predating this field"
+            "an arrival schedule"
         ),
     )
     request_scheduled_latency: StatusDistributionSummary | None = Field(
@@ -799,7 +799,7 @@ class GenerativeMetrics(StandardBaseDict):
             "Distribution of request latencies measured from each request's "
             "targeted start rather than its dispatch, including scheduler "
             "delay. None when the strategy does not define an arrival "
-            "schedule, or for reports predating this field"
+            "schedule"
         ),
     )
     request_streaming_iterations_count: StatusDistributionSummary = Field(

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -784,6 +784,24 @@ class GenerativeMetrics(StandardBaseDict):
     request_latency: StatusDistributionSummary = Field(
         description="Distribution of request latencies for completed requests"
     )
+    request_dispatch_delay: StatusDistributionSummary | None = Field(
+        default=None,
+        description=(
+            "Distribution of delays between a request's targeted start and the "
+            "time it was dispatched. Grows when the scheduler cannot keep up "
+            "with the configured rate. None when the strategy does not define "
+            "an arrival schedule, or for reports predating this field"
+        ),
+    )
+    request_scheduled_latency: StatusDistributionSummary | None = Field(
+        default=None,
+        description=(
+            "Distribution of request latencies measured from each request's "
+            "targeted start rather than its dispatch, including scheduler "
+            "delay. None when the strategy does not define an arrival "
+            "schedule, or for reports predating this field"
+        ),
+    )
     request_streaming_iterations_count: StatusDistributionSummary = Field(
         description="Distribution of stream iterations for completed requests"
     )
@@ -883,6 +901,26 @@ class GenerativeMetrics(StandardBaseDict):
         incomplete = accumulator.incomplete.get_within_range(start_time, end_time)
         errored = accumulator.errored.get_within_range(start_time, end_time)
 
+        # Schedule-relative metrics describe lag against an arrival schedule.
+        # Closed-loop strategies derive each target from the system's own
+        # responses, so a delay measured against them is circular rather than a
+        # coordinated-omission correction, and is reported as None instead.
+        dispatch_delay: StatusDistributionSummary | None = None
+        scheduled_latency: StatusDistributionSummary | None = None
+        if accumulator.config.strategy.defines_arrival_schedule:
+            dispatch_delay = StatusDistributionSummary.from_values_function(
+                function=lambda req: req.request_dispatch_delay,
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            )
+            scheduled_latency = StatusDistributionSummary.from_values_function(
+                function=lambda req: req.request_scheduled_latency,
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            )
+
         return GenerativeMetrics(
             # Request stats
             request_totals=StatusBreakdown(
@@ -920,6 +958,8 @@ class GenerativeMetrics(StandardBaseDict):
                 incomplete=incomplete,
                 errored=errored,
             ),
+            request_dispatch_delay=dispatch_delay,
+            request_scheduled_latency=scheduled_latency,
             request_streaming_iterations_count=StatusDistributionSummary.from_values_function(
                 function=lambda req: req.info.timings.request_iterations or 0.0,
                 successful=successful,

--- a/src/guidellm/scheduler/strategies.py
+++ b/src/guidellm/scheduler/strategies.py
@@ -104,6 +104,20 @@ class SchedulingStrategy(PydanticClassRegistryMixin["SchedulingStrategy"], InfoM
         """
         return None
 
+    @property
+    def defines_arrival_schedule(self) -> bool:
+        """
+        Whether targeted start times follow an independent arrival schedule.
+
+        Strategies returning an ASAP-style target, such as the previous
+        request's completion time or the benchmark start time, do not define an
+        arrival schedule, so schedule-relative metrics are not meaningful for
+        them.
+
+        :return: True if targeted start times follow an arrival schedule
+        """
+        return False
+
     def init_processes_timings(
         self,
         worker_count: PositiveInt,
@@ -494,6 +508,13 @@ class AsyncConstantStrategy(SchedulingStrategy):
         return f"constant@{self.rate:.2f}"
 
     @property
+    def defines_arrival_schedule(self) -> bool:
+        """
+        :return: Always True; targets are derived from an arrival schedule
+        """
+        return True
+
+    @property
     def processes_limit(self) -> PositiveInt | None:
         """
         :return: Max concurrency if set, otherwise None for unlimited
@@ -592,6 +613,13 @@ class AsyncPoissonStrategy(SchedulingStrategy):
         :return: String identifier with rate value
         """
         return f"poisson@{self.rate:.2f}"
+
+    @property
+    def defines_arrival_schedule(self) -> bool:
+        """
+        :return: Always True; targets are derived from an arrival schedule
+        """
+        return True
 
     @property
     def processes_limit(self) -> PositiveInt | None:
@@ -704,6 +732,13 @@ class TraceReplayStrategy(SchedulingStrategy):
 
     def __str__(self) -> str:
         return f"trace@{self.time_scale:.2f}"
+
+    @property
+    def defines_arrival_schedule(self) -> bool:
+        """
+        :return: Always True; targets are derived from an arrival schedule
+        """
+        return True
 
     @property
     def processes_limit(self) -> PositiveInt | None:

--- a/src/guidellm/schemas/base/request_stats.py
+++ b/src/guidellm/schemas/base/request_stats.py
@@ -117,7 +117,7 @@ class GenerativeRequestStats(StandardBaseDict):
     @property
     def request_dispatch_delay(self) -> float | None:
         """
-        Delay between the scheduled arrival time and the actual dispatch.
+        Delay between the scheduled arrival time and the actual dispatch in seconds.
 
         Non-zero when the scheduler could not issue the request at the time its
         strategy targeted, for example while a concurrency limit is saturated.
@@ -140,7 +140,7 @@ class GenerativeRequestStats(StandardBaseDict):
     @property
     def request_scheduled_latency(self) -> float | None:
         """
-        Request latency measured from the scheduled arrival time.
+        Request latency measured from the scheduled arrival time in seconds.
 
         Unlike :attr:`request_latency`, which starts when the request was
         dispatched, this includes any time the request waited for the scheduler

--- a/src/guidellm/schemas/base/request_stats.py
+++ b/src/guidellm/schemas/base/request_stats.py
@@ -113,6 +113,51 @@ class GenerativeRequestStats(StandardBaseDict):
 
         return end - start
 
+    @computed_field  # type: ignore[misc]
+    @property
+    def request_dispatch_delay(self) -> float | None:
+        """
+        Delay between the scheduled arrival time and the actual dispatch.
+
+        Non-zero when the scheduler could not issue the request at the time its
+        strategy targeted, for example while a concurrency limit is saturated.
+        Only describes arrival-schedule delay for strategies that define an
+        arrival schedule (constant, poisson, and trace when the dataset supplies
+        timestamps); the synchronous, concurrent, and throughput strategies
+        target an ASAP start instead. See the metrics guide for full caveats.
+
+        :return: Duration from targeted start to request start in seconds, or
+            None if unavailable
+        """
+        targeted = self.info.timings.targeted_start
+        start = self.info.timings.request_start
+        if targeted is None or start is None:
+            return None
+
+        return start - targeted
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def request_scheduled_latency(self) -> float | None:
+        """
+        Request latency measured from the scheduled arrival time.
+
+        Unlike :attr:`request_latency`, which starts when the request was
+        dispatched, this includes any time the request waited for the scheduler
+        to reach it. The two are equal when the scheduler keeps up with the
+        configured rate and diverge once it falls behind. Carries the same
+        strategy caveat as :attr:`request_dispatch_delay`.
+
+        :return: Duration from targeted start to request completion in seconds,
+            or None if unavailable
+        """
+        targeted = self.info.timings.targeted_start
+        end = self.info.timings.request_end
+        if targeted is None or end is None:
+            return None
+
+        return end - targeted
+
     # General token stats
     @computed_field  # type: ignore[misc]
     @property

--- a/tests/e2e/test_coordinated_omission.py
+++ b/tests/e2e/test_coordinated_omission.py
@@ -1,0 +1,124 @@
+"""
+End-to-end checks that scheduler dispatch delay is reported.
+
+``request_latency`` is measured from the moment a request is dispatched, so any
+time it spent waiting for the scheduler is invisible to it. When the configured
+rate exceeds what the concurrency cap allows, that wait is where most of the
+real latency lives. These tests pin the reported dispatch delay in both
+directions: near zero while the scheduler keeps up, and dominant once it cannot.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.conftest import E2EServer, start_mock_server
+from tests.e2e.utils import (
+    GuidellmClient,
+    assert_no_python_exceptions,
+    load_benchmark_report,
+)
+
+# Service time is roughly ttft + itl * (output_tokens - 1), about 65ms here.
+SERVICE_TIME_SEC = 0.065
+CAPPED_CONCURRENCY = 2
+# Well above what CAPPED_CONCURRENCY can sustain, so the scheduler falls behind.
+OVERSUBSCRIBED_RATE = 100
+# Comfortably inside what the server handles without any concurrency cap.
+SUSTAINABLE_RATE = 10
+
+
+@pytest.fixture(scope="module")
+def server(e2e_server_kind: str) -> Iterator[E2EServer]:
+    """Healthy server with a stable, known service time.
+
+    ## WRITTEN BY AI ##
+    """
+    if e2e_server_kind == "llm-d":
+        pytest.skip("Dispatch delay assertions require a fixed-latency mock server")
+
+    handle = start_mock_server(
+        ttft_ms=50.0,
+        itl_ms=2.0,
+        output_tokens=8,
+        request_latency=SERVICE_TIME_SEC,
+    )
+    try:
+        yield handle
+    finally:
+        handle.stop()
+
+
+def _run(
+    server: E2EServer,
+    tmp_path: Path,
+    report_name: str,
+    rate: int,
+    max_concurrency: int | None,
+) -> dict:
+    """Run a benchmark and return the first benchmark entry of its report.
+
+    ## WRITTEN BY AI ##
+    """
+    client = GuidellmClient(
+        target=server.get_url(), output_dir=tmp_path, outputs=report_name
+    )
+    client.start_benchmark(
+        rate=rate,
+        max_concurrency=max_concurrency,
+        max_seconds=8,
+        data="kind=synthetic_text,prompt_tokens=32,output_tokens=8",
+    )
+    client.wait_for_completion(timeout=60)
+    assert_no_python_exceptions(client.stderr)
+
+    report = load_benchmark_report(tmp_path / report_name)
+    return report["benchmarks"][0]
+
+
+@pytest.mark.sanity
+@pytest.mark.timeout(120)
+def test_dispatch_delay_reported_when_scheduler_falls_behind(
+    server: E2EServer, tmp_path: Path
+):
+    """
+    Requested rate far above the concurrency cap surfaces a large delay.
+
+    ## WRITTEN BY AI ##
+    """
+    benchmark = _run(
+        server, tmp_path, "co_capped.json", OVERSUBSCRIBED_RATE, CAPPED_CONCURRENCY
+    )
+    metrics = benchmark["metrics"]
+
+    latency = metrics["request_latency"]["successful"]["median"]
+    delay = metrics["request_dispatch_delay"]["successful"]["median"]
+    scheduled = metrics["request_scheduled_latency"]["successful"]["median"]
+
+    # The server itself stays healthy, so dispatch is the only thing lagging.
+    assert latency == pytest.approx(SERVICE_TIME_SEC, abs=0.2)
+    assert delay > 2.0
+    # Almost all of the real latency is the wait, not the request itself.
+    assert scheduled > 3 * latency
+
+
+@pytest.mark.sanity
+@pytest.mark.timeout(120)
+def test_dispatch_delay_near_zero_when_scheduler_keeps_up(
+    server: E2EServer, tmp_path: Path
+):
+    """
+    A sustainable rate leaves scheduled latency equal to request latency.
+
+    ## WRITTEN BY AI ##
+    """
+    benchmark = _run(server, tmp_path, "co_sustainable.json", SUSTAINABLE_RATE, None)
+    metrics = benchmark["metrics"]
+
+    latency = metrics["request_latency"]["successful"]["median"]
+    delay = metrics["request_dispatch_delay"]["successful"]["median"]
+    scheduled = metrics["request_scheduled_latency"]["successful"]["median"]
+
+    assert delay < 0.5
+    assert scheduled == pytest.approx(latency, abs=0.5)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -43,10 +43,29 @@ class GuidellmClient:
         self.stdout: str | None = None
         self.stderr: str | None = None
 
+    @staticmethod
+    def _build_profile_config(
+        profile: str, rate: int, max_concurrency: int | None
+    ) -> str:
+        """
+        Build the ``--profile`` value, including an optional concurrency cap.
+
+        :param profile: Type of rate control (constant, etc.)
+        :param rate: Request rate
+        :param max_concurrency: Cap on concurrent requests, or None for no cap
+        :return: Comma-separated profile configuration string
+        """
+        config = f"kind={profile},rate={rate}"
+        if max_concurrency is not None:
+            config += f",max_concurrency={max_concurrency}"
+
+        return config
+
     def start_benchmark(
         self,
         profile: str = "constant",
         rate: int = 10,
+        max_concurrency: int | None = None,
         max_seconds: int | None = None,
         max_requests: int | None = None,
         max_error_rate: float | None = None,
@@ -62,6 +81,7 @@ class GuidellmClient:
 
         :param profile: Type of rate control (constant, etc.)
         :param rate: Request rate
+        :param max_concurrency: Cap on concurrent requests the scheduler dispatches
         :param max_seconds: Maximum duration in seconds
         :param max_requests: Maximum number of requests
         :param max_error_rate: Maximum error rate before stopping
@@ -93,11 +113,13 @@ class GuidellmClient:
 
         backend_config = backend or f"kind=openai_http,target={self.target}"
 
+        profile_config = self._build_profile_config(profile, rate, max_concurrency)
+
         cmd_parts = [
             *([f"{k}={v}" for k, v in offline_env.items()]),
             f"{guidellm_exe} run",
             f'--backend "{backend_config}"',
-            f'--profile "kind={profile},rate={rate}"',
+            f'--profile "{profile_config}"',
         ]
 
         if max_seconds is not None:

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -7,10 +7,17 @@ from __future__ import annotations
 
 import pytest
 
+from guidellm.benchmark.schemas.accumulator import GenerativeBenchmarkAccumulator
+from guidellm.benchmark.schemas.base import BenchmarkConfig
 from guidellm.benchmark.schemas.metrics import (
     GenerativeMetrics,
     GenerativeMetricsSummary,
     GenerativeToolCallMetricsSummary,
+)
+from guidellm.scheduler import (
+    AsyncConstantStrategy,
+    SchedulingStrategy,
+    ThroughputStrategy,
 )
 from guidellm.schemas import (
     GenerativeRequestStats,
@@ -213,3 +220,271 @@ def test_round_trip_metrics_compile():
 
     assert last_round_trip.successful.mean == pytest.approx(300.0, abs=0.1)
     assert avg_round_trip.successful.mean == pytest.approx(300.0, abs=0.1)
+
+
+def _make_scheduled_stats(
+    request_id: str, targeted_start: float, request_start: float, request_end: float
+) -> GenerativeRequestStats:
+    """Build a completed request with an explicit targeted start time.
+
+    ## WRITTEN BY AI ##
+    """
+    timings = RequestTimings(
+        targeted_start=targeted_start,
+        resolve_start=request_start,
+        resolve_end=request_end,
+        request_start=request_start,
+        request_end=request_end,
+    )
+    return GenerativeRequestStats(
+        request_id=request_id,
+        info=RequestInfo(request_id=request_id, status="completed", timings=timings),
+        input_metrics=UsageMetrics(text_tokens=8),
+        output_metrics=UsageMetrics(text_tokens=8),
+    )
+
+
+# Non-zero epoch base; a measurement window starting at 0.0 reads as unset.
+SCHEDULE_BASE_TIME = 1000.0
+
+
+def _make_accumulator(
+    successful: list[GenerativeRequestStats],
+    start_time: float,
+    end_time: float,
+    strategy: SchedulingStrategy | None = None,
+) -> GenerativeBenchmarkAccumulator:
+    """Build an accumulator holding completed requests over a measurement window.
+
+    Defaults to a constant-rate strategy, which defines an arrival schedule.
+
+    ## WRITTEN BY AI ##
+    """
+    accumulator = GenerativeBenchmarkAccumulator(
+        config=BenchmarkConfig(
+            run_id="schedule-metrics",
+            run_index=0,
+            strategy=strategy or AsyncConstantStrategy(rate=10.0),
+            constraints={},
+            profile={},
+            requests={},
+            backend={},
+            environment={},
+        )
+    )
+    accumulator.timings.measure_start = start_time
+    accumulator.timings.measure_end = end_time
+    accumulator.completed.requests_stats = list(successful)
+
+    return accumulator
+
+
+class TestScheduleRelativeMetrics:
+    """
+    Verify the schedule-relative distributions added alongside request_latency.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.smoke
+    def test_schedule_fields_are_optional_for_existing_reports(self):
+        """
+        The schedule-relative fields carry defaults so reports written before
+        they existed still validate.
+
+        ## WRITTEN BY AI ##
+        """
+        successful = [
+            _make_scheduled_stats(
+                "req",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + 1.0,
+                SCHEDULE_BASE_TIME + 1.5,
+            )
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(successful, SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 10.0)
+        )
+
+        # Strip the new keys to mimic a report written before they existed.
+        payload = metrics.model_dump()
+        for name in ("request_dispatch_delay", "request_scheduled_latency"):
+            del payload[name]
+
+        restored = GenerativeMetrics.model_validate(payload)
+
+        assert restored.request_dispatch_delay is None
+        assert restored.request_scheduled_latency is None
+        assert restored.request_latency.successful.mean == pytest.approx(0.5)
+
+    @pytest.mark.sanity
+    def test_compile_distributions_track_scheduler_backlog(self):
+        """
+        Compiled dispatch delay reflects how far behind its targeted start each
+        request was issued, while request latency stays flat.
+
+        ## WRITTEN BY AI ##
+        """
+        # Constant 0.5s service time, dispatched 0s / 1s / 2s behind schedule.
+        successful = [
+            _make_scheduled_stats(
+                f"req-{index}",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + index,
+                SCHEDULE_BASE_TIME + index + 0.5,
+            )
+            for index in range(3)
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(successful, SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 10.0)
+        )
+
+        assert metrics.request_latency.successful.mean == pytest.approx(0.5)
+        assert metrics.request_dispatch_delay.successful.mean == pytest.approx(1.0)
+        assert metrics.request_scheduled_latency.successful.mean == pytest.approx(1.5)
+        assert metrics.request_scheduled_latency.successful.max == pytest.approx(2.5)
+
+    @pytest.mark.sanity
+    def test_compile_reports_percentiles_for_schedule_metrics(self):
+        """
+        Compiled schedule-relative metrics carry percentiles, so a tail hidden
+        from request_latency is visible in the report.
+
+        ## WRITTEN BY AI ##
+        """
+        # Steady 0.1s service time with dispatch falling a second further behind.
+        successful = [
+            _make_scheduled_stats(
+                f"req-{index}",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + index,
+                SCHEDULE_BASE_TIME + index + 0.1,
+            )
+            for index in range(100)
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(
+                successful, SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 200.0
+            )
+        )
+
+        assert metrics.request_scheduled_latency is not None
+        latency = metrics.request_latency.successful
+        scheduled = metrics.request_scheduled_latency.successful
+
+        assert latency.percentiles.p99 == pytest.approx(0.1)
+        assert scheduled.percentiles.p99 > 90.0
+
+    @pytest.mark.regression
+    def test_compile_scheduled_latency_decomposes_across_requests(self):
+        """
+        Every compiled request satisfies scheduled latency equal to dispatch
+        delay plus request latency.
+
+        ## WRITTEN BY AI ##
+        """
+        successful = [
+            _make_scheduled_stats(
+                "even",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + 2.0,
+                SCHEDULE_BASE_TIME + 2.75,
+            ),
+            _make_scheduled_stats(
+                "odd",
+                SCHEDULE_BASE_TIME + 1.0,
+                SCHEDULE_BASE_TIME + 4.5,
+                SCHEDULE_BASE_TIME + 5.0,
+            ),
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(successful, SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 10.0)
+        )
+
+        assert metrics.request_dispatch_delay is not None
+        assert metrics.request_scheduled_latency is not None
+        assert metrics.request_scheduled_latency.successful.mean == pytest.approx(
+            metrics.request_dispatch_delay.successful.mean
+            + metrics.request_latency.successful.mean
+        )
+
+    @pytest.mark.sanity
+    def test_compile_omits_metrics_for_asap_strategies(self):
+        """
+        Strategies without an arrival schedule report None.
+
+        Under throughput every target is the benchmark start time, so populated
+        values would report elapsed run time rather than a delay or a latency.
+
+        ## WRITTEN BY AI ##
+        """
+        successful = [
+            _make_scheduled_stats(
+                f"req-{index}",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + index,
+                SCHEDULE_BASE_TIME + index + 0.5,
+            )
+            for index in range(3)
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(
+                successful,
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + 10.0,
+                strategy=ThroughputStrategy(),
+            )
+        )
+
+        # None rather than a zero-filled distribution, which would read as
+        # "no delay measured" instead of "not applicable".
+        assert metrics.request_dispatch_delay is None
+        assert metrics.request_scheduled_latency is None
+        # Existing metrics are unaffected by the gating.
+        assert metrics.request_latency.successful.mean == pytest.approx(0.5)
+
+    @pytest.mark.regression
+    def test_compile_skips_requests_without_a_dispatch_timestamp(self):
+        """
+        Requests that never reached dispatch are excluded, not counted as zero.
+
+        A request cancelled while the scheduler was backed up has no
+        request_start, so its delay is unknown. Recording it as 0.0 would drag
+        the distribution toward zero for exactly the requests these metrics
+        exist to describe.
+
+        ## WRITTEN BY AI ##
+        """
+        dispatched = _make_scheduled_stats(
+            "dispatched",
+            SCHEDULE_BASE_TIME,
+            SCHEDULE_BASE_TIME + 4.0,
+            SCHEDULE_BASE_TIME + 4.5,
+        )
+        never_dispatched = GenerativeRequestStats(
+            request_id="never-dispatched",
+            info=RequestInfo(
+                request_id="never-dispatched",
+                status="completed",
+                timings=RequestTimings(
+                    targeted_start=SCHEDULE_BASE_TIME,
+                    resolve_start=SCHEDULE_BASE_TIME + 4.0,
+                    resolve_end=SCHEDULE_BASE_TIME + 4.5,
+                ),
+            ),
+            input_metrics=UsageMetrics(text_tokens=8),
+            output_metrics=UsageMetrics(text_tokens=8),
+        )
+        assert never_dispatched.request_dispatch_delay is None
+
+        metrics = GenerativeMetrics.compile(
+            _make_accumulator(
+                [dispatched, never_dispatched],
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + 10.0,
+            )
+        )
+
+        assert metrics.request_dispatch_delay is not None
+        assert metrics.request_dispatch_delay.successful.count == 1
+        assert metrics.request_dispatch_delay.successful.mean == pytest.approx(4.0)

--- a/tests/unit/benchmark/test_console_output.py
+++ b/tests/unit/benchmark/test_console_output.py
@@ -1,0 +1,89 @@
+"""Tests for the console benchmark output tables."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from guidellm.benchmark.outputs.console import GenerativeBenchmarkerConsole
+from guidellm.schemas import StatusDistributionSummary
+
+# Metrics read by GenerativeBenchmarkerConsole.print_request_latency_table.
+LATENCY_TABLE_METRICS = (
+    "request_latency",
+    "time_to_first_token_ms",
+    "time_to_first_output_token_ms",
+    "inter_token_latency_ms",
+    "time_per_output_token_ms",
+)
+
+
+def _make_benchmark() -> SimpleNamespace:
+    """Build a benchmark stub exposing every metric the latency table reads.
+
+    ## WRITTEN BY AI ##
+    """
+    distribution = StatusDistributionSummary.from_values([1.0, 2.0, 3.0], [], [])
+    metrics = SimpleNamespace(
+        **dict.fromkeys(LATENCY_TABLE_METRICS, distribution),
+        request_dispatch_delay=distribution,
+        request_scheduled_latency=distribution,
+    )
+
+    return SimpleNamespace(
+        config=SimpleNamespace(strategy=SimpleNamespace(type_="constant")),
+        metrics=metrics,
+    )
+
+
+def _render_latency_table_headers() -> str:
+    """Render the latency table and return its headers flattened to text.
+
+    ## WRITTEN BY AI ##
+    """
+    captured: dict[str, object] = {}
+    output = GenerativeBenchmarkerConsole()
+    output.console.print = lambda *args, **kwargs: None
+    output.console.print_table = lambda headers, values, title=None: captured.update(
+        headers=headers
+    )
+    output.print_request_latency_table(SimpleNamespace(benchmarks=[_make_benchmark()]))
+
+    return " ".join(str(header) for header in captured["headers"])  # type: ignore[union-attr]
+
+
+class TestRequestLatencyTable:
+    """
+    Verify which metrics the final console latency table exposes.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.regression
+    def test_omits_schedule_relative_metrics(self):
+        """
+        Dispatch delay and scheduled latency are absent from the console table.
+
+        They are derived from targeted_start, which is an ASAP-style value under
+        the synchronous, concurrent, and throughput profiles, so they are not
+        meaningful in a table shared across every profile.
+
+        ## WRITTEN BY AI ##
+        """
+        headers = _render_latency_table_headers()
+
+        assert "Dispatch Delay" not in headers
+        assert "Scheduled Latency" not in headers
+
+    @pytest.mark.regression
+    def test_retains_existing_latency_columns(self):
+        """
+        The pre-existing latency columns are still rendered unchanged.
+
+        ## WRITTEN BY AI ##
+        """
+        headers = _render_latency_table_headers()
+
+        for group in ("Request Latency", "TTFT", "TTFOT", "ITL", "TPOT"):
+            assert group in headers

--- a/tests/unit/benchmark/test_csv_output.py
+++ b/tests/unit/benchmark/test_csv_output.py
@@ -270,3 +270,108 @@ async def test_finalize_aligns_columns_in_written_csv(tmp_path: Path):
     data_rows = rows[3:]
     assert data_rows[0] == ["a1", ""]
     assert data_rows[1] == ["a2", "b2"]
+
+
+# Metrics read by GenerativeBenchmarkerCSV._add_request_latency_metrics.
+_LATENCY_CSV_METRICS = (
+    "request_latency",
+    "request_dispatch_delay",
+    "request_scheduled_latency",
+    "request_streaming_iterations_count",
+    "time_to_first_token_ms",
+    "time_to_first_output_token_ms",
+    "time_per_output_token_ms",
+    "inter_token_latency_ms",
+    "time_to_last_round_trip_ms",
+    "avg_round_trip_time_ms",
+)
+
+
+def _latency_metric_groups(
+    tmp_path: Path, schedule_metrics_missing: bool = False
+) -> list[str]:
+    """Emit the latency CSV section and return its column group names in order.
+
+    ## WRITTEN BY AI ##
+    """
+    distribution = StatusDistributionSummary.from_values([1.0, 2.0, 3.0], [], [])
+    metrics = dict.fromkeys(_LATENCY_CSV_METRICS, distribution)
+    if schedule_metrics_missing:
+        for name in ("request_dispatch_delay", "request_scheduled_latency"):
+            metrics[name] = None
+    benchmark = SimpleNamespace(metrics=SimpleNamespace(**metrics))
+
+    output = GenerativeBenchmarkerCSV(output_path=tmp_path)
+    headers: list[list[str]] = []
+    values: list[str | int | float] = []
+    output._add_request_latency_metrics(benchmark, headers, values)
+
+    groups: list[str] = []
+    for header in headers:
+        if header[0] not in groups:
+            groups.append(header[0])
+
+    return groups
+
+
+class TestRequestLatencyCSVMetrics:
+    """
+    Verify the latency section of the CSV export.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.sanity
+    def test_exports_schedule_relative_metrics(self, tmp_path: Path):
+        """
+        Dispatch delay and scheduled latency reach the CSV even though they are
+        omitted from the console table.
+
+        ## WRITTEN BY AI ##
+        """
+        groups = _latency_metric_groups(tmp_path)
+
+        assert "Dispatch Delay" in groups
+        assert "Scheduled Latency" in groups
+
+    @pytest.mark.regression
+    def test_preserves_existing_column_order(self, tmp_path: Path):
+        """
+        Pre-existing latency columns keep their relative order, so the new
+        groups are additions rather than a reshuffle.
+
+        ## WRITTEN BY AI ##
+        """
+        groups = _latency_metric_groups(tmp_path)
+        existing = [
+            group
+            for group in groups
+            if group not in {"Dispatch Delay", "Scheduled Latency"}
+        ]
+
+        assert existing == [
+            "Request Latency",
+            "Streaming Iterations",
+            "Time to First Token",
+            "Time to First Output Token",
+            "Time per Output Token",
+            "Inter Token Latency",
+            "Time To Last Round Trip",
+            "Avg Round Trip Time",
+        ]
+
+    @pytest.mark.regression
+    def test_omits_schedule_metrics_when_not_applicable(self, tmp_path: Path):
+        """
+        Schedule-relative metrics set to None produce no CSV columns.
+
+        GenerativeMetrics.compile leaves these None for strategies without an
+        arrival schedule, so a throughput row carries no misleading values.
+
+        ## WRITTEN BY AI ##
+        """
+        groups = _latency_metric_groups(tmp_path, schedule_metrics_missing=True)
+
+        assert "Dispatch Delay" not in groups
+        assert "Scheduled Latency" not in groups
+        assert "Request Latency" in groups

--- a/tests/unit/scheduler/test_strategies.py
+++ b/tests/unit/scheduler/test_strategies.py
@@ -17,7 +17,7 @@ from guidellm.scheduler import (
     SynchronousStrategy,
     ThroughputStrategy,
 )
-from guidellm.scheduler.strategies import StrategyType
+from guidellm.scheduler.strategies import StrategyType, TraceReplayStrategy
 from guidellm.schemas import RequestInfo
 
 
@@ -744,3 +744,36 @@ class TestAsyncPoissonStrategy:
 
         for key, value in constructor_args.items():
             assert getattr(base_json_reconstructed, key) == value
+
+
+class TestDefinesArrivalSchedule:
+    """
+    Verify which strategies report an independent arrival schedule.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        ("strategy", "expected"),
+        [
+            (SynchronousStrategy(), False),
+            (ConcurrentStrategy(streams=2), False),
+            (ThroughputStrategy(), False),
+            (AsyncConstantStrategy(rate=10.0), True),
+            (AsyncPoissonStrategy(rate=10.0), True),
+            (TraceReplayStrategy(), True),
+        ],
+    )
+    def test_defines_arrival_schedule(
+        self, strategy: SchedulingStrategy, expected: bool
+    ):
+        """
+        Only rate- and trace-driven strategies define an arrival schedule.
+
+        The others target an ASAP start, so schedule-relative metrics do not
+        apply to them.
+
+        ## WRITTEN BY AI ##
+        """
+        assert strategy.defines_arrival_schedule is expected

--- a/tests/unit/schemas/test_request_stats.py
+++ b/tests/unit/schemas/test_request_stats.py
@@ -274,6 +274,8 @@ class TestGenerativeRequestStats:
             "request_start_time",
             "request_end_time",
             "request_latency",
+            "request_dispatch_delay",
+            "request_scheduled_latency",
             "prompt_tokens",
             "output_tokens",
             "total_tokens",
@@ -437,6 +439,76 @@ class TestGenerativeRequestStats:
         assert instance.time_to_first_token_ms is None
         assert instance.time_per_output_token_ms is None
         assert instance.inter_token_latency_ms is None
+
+    @pytest.mark.sanity
+    def test_dispatch_delay_and_scheduled_latency(self):
+        """
+        Schedule-relative metrics measure from the targeted arrival time.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="targeted", status="completed")
+        info.timings.targeted_start = 100.0
+        info.timings.request_start = 103.5
+        info.timings.request_end = 104.0
+        info.timings.resolve_end = 104.0
+        instance = GenerativeRequestStats(
+            request_id="targeted",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=4),
+            output_metrics=UsageMetrics(text_tokens=6),
+        )
+
+        assert instance.request_latency == pytest.approx(0.5)
+        assert instance.request_dispatch_delay == pytest.approx(3.5)
+        assert instance.request_scheduled_latency == pytest.approx(4.0)
+
+    @pytest.mark.sanity
+    def test_scheduled_latency_decomposes_into_delay_and_latency(self):
+        """
+        Scheduled latency equals dispatch delay plus request latency.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="decompose", status="completed")
+        info.timings.targeted_start = 5.0
+        info.timings.request_start = 11.25
+        info.timings.request_end = 13.75
+        info.timings.resolve_end = 13.75
+        instance = GenerativeRequestStats(
+            request_id="decompose",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=4),
+            output_metrics=UsageMetrics(text_tokens=6),
+        )
+
+        assert instance.request_dispatch_delay is not None
+        assert instance.request_latency is not None
+        assert instance.request_scheduled_latency == pytest.approx(
+            instance.request_dispatch_delay + instance.request_latency
+        )
+
+    @pytest.mark.sanity
+    def test_schedule_metrics_none_without_targeted_start(self):
+        """
+        Schedule-relative metrics are None when no targeted start was recorded.
+
+        ## WRITTEN BY AI ##
+        """
+        info = RequestInfo(request_id="untargeted", status="completed")
+        info.timings.request_start = 1.0
+        info.timings.request_end = 2.0
+        info.timings.resolve_end = 2.0
+        instance = GenerativeRequestStats(
+            request_id="untargeted",
+            info=info,
+            input_metrics=UsageMetrics(text_tokens=4),
+            output_metrics=UsageMetrics(text_tokens=6),
+        )
+
+        assert instance.request_dispatch_delay is None
+        assert instance.request_scheduled_latency is None
+        assert instance.request_latency == pytest.approx(1.0)
 
     @pytest.mark.smoke
     def test_marshalling(self, valid_instances):


### PR DESCRIPTION
## Summary

`request_latency` is measured from the moment a request is dispatched, so any time a request spent waiting on a saturated concurrency limit is excluded from every reported latency percentile. This is the coordinated omission failure mode: reported tail latency improves precisely when the load generator falls behind.

Most of what is needed to detect this is already captured. The scheduler records the intended arrival time in `RequestTimings.targeted_start`, and `SchedulerMetrics.request_targeted_start_delay_avg` already reports a scalar mean of the delay in the CSV. What is missing is a distribution behind that mean, and a metric that folds the delay back into an end-to-end latency.

This change is purely additive. `request_latency`, `time_to_first_token_ms`, and every other existing metric keep their current definitions and values, so historical comparisons and saved reports remain valid. Two new metrics are added alongside them:

```
request_dispatch_delay    = request_start - targeted_start
request_scheduled_latency = request_end   - targeted_start
```

When all three timestamps are present, `request_scheduled_latency == request_dispatch_delay + request_latency`.

Following the feedback on #1048, these are not added to the console latency table, and they are reported as `null` for the strategies where `targeted_start` is an ASAP-style value rather than an arrival schedule. Both are explained under Notes for review.

## Details

- [x] Add `request_dispatch_delay` and `request_scheduled_latency` computed fields to `GenerativeRequestStats`, returning `None` when the timestamps they require are absent
- [x] Add matching `StatusDistributionSummary | None` fields to `GenerativeMetrics`, aggregated in `GenerativeMetrics.compile()`, defaulting to `None` so reports written before these fields existed still deserialize
- [x] Add `SchedulingStrategy.defines_arrival_schedule`, `True` for `constant`, `poisson`, and `trace`, and `False` for the ASAP-style strategies. When `False`, both metrics compile to `None`
- [x] Export both metrics with full distributions in the CSV output, emitting no columns when they are `None`
- [x] Document both metrics in `docs/guides/metrics.md`, including which profiles they apply to and why they are absent from console output
- [x] Add an optional `max_concurrency` parameter to the E2E `GuidellmClient` helper so a test can bind the concurrency cap

## Test Plan

- Unit semantics on fixed timestamps, including the `scheduled == dispatch_delay + latency` invariant, and `None` when `targeted_start` is absent
- Aggregation through real `GenerativeMetrics.compile()`, including a percentile case where `request_latency` p99 stays at roughly 0.1s while `request_scheduled_latency` p99 exceeds 90s, making the coordinated-omission effect visible
- Requests that never reached dispatch are excluded from the distributions rather than recorded as zero delay
- Strategy gating: `defines_arrival_schedule` asserted per strategy, and `compile()` returning `None` for both metrics under `throughput`
- Backward compatibility: a compiled `GenerativeMetrics` is dumped, both new keys are stripped to mimic a report written before they existed, and the payload is re-validated
- CSV: both metrics are exported when applicable, no columns are emitted when they are `None`, and pre-existing latency columns keep their relative order
- Console: regression test asserting neither metric appears in the Request Latency table and that the existing columns are unchanged
- E2E, two regimes against the shipped mock server: dispatch delay becomes large when the concurrency cap binds, and stays near zero when the scheduler keeps up

Manual reproduction against the mock server on a `constant` profile, at a rate the concurrency cap cannot sustain. The server stays healthy throughout at roughly 190ms service time:

| source | p50 | p95 | p99 |
| --- | --- | --- | --- |
| reported `request_latency` | 0.189 | 0.195 | 0.198 |
| `request_end - targeted_start` | 3.718 | 6.865 | 7.148 |

## Notes for review

**This goes one step beyond the console-only change requested in #1048, and is easy to scale back.** The ask was to omit these from console output. I also gated them out of the compiled report, because under `throughput` every request targets the benchmark start time, so the values track elapsed run time rather than any delay. Since `sweep` is the default profile and runs `throughput`, a default CSV would otherwise carry a `Scheduled Latency` column roughly equal to half the run duration, and a CSV consumer never sees the documentation caveat. If you would rather keep the raw values in the report and only suppress the console, that is a one-property change.

**Why all three strategies, and why `null` rather than zero.** `defines_arrival_schedule` is `False` for exactly the three profiles named in the issue thread. `synchronous` and `concurrent` target the previous request's completion, so a delay measured against it is circular: it describes harness turnaround rather than lag against an arrival schedule. `throughput` targets the benchmark start, so the value grows with elapsed run time. They are null rather than a zero-filled distribution because a zero serializes as `mean = 0.0` and reads as "no delay measured", which is a stronger and more misleading claim than "not applicable".

**Deliberate asymmetry with `request_latency`.** `request_latency` maps a missing timing to `0.0` via `or 0.0` in `compile()`. The two new metrics instead pass the raw value, so a request with no `request_start` is dropped by `from_values_function` rather than recorded as zero. That is deliberate. A request cancelled while the scheduler was backed up is exactly the population these metrics describe, and recording it as zero delay would bias the tail toward the answer this PR exists to correct. I left `request_latency` alone rather than change an existing metric's values.

**Relationship to the existing scheduler metric.** `Dispatch Delay` is the per-status distribution of the same quantity as `Request Targeted Start Delay Avg`. The scheduler value is a running mean over the whole run, while the new one is scoped to the measurement window, so the two will not match exactly.

**Known limitation.** Applicability is modelled per strategy, but it is really a per-request property of where `targeted_start` came from. Two consequences, both documented in the metrics guide: a `trace` request carrying no relative timestamp falls back to the benchmark start and is still included, and for multi-turn datasets the think time between turns lands inside Dispatch Delay. Moving the signal onto `RequestTimings` per request would fix both and remove the branch in `compile()`. I did not do that here because it touches the worker dispatch path and the per-request schema. I can implement it in this PR if you prefer that shape.

**CSV column placement in mixed-strategy runs.** `_align_columns` unions headers in first-seen order, so in a `sweep`, where the first benchmark is `synchronous` and contributes no columns for these metrics, the two new groups land at the right-hand end of the CSV rather than beside `Request Latency`. That is existing behaviour of the aligner, not something introduced here.

## Related Issues

- Resolves #1048

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit b88ce8c7536547046ae9b2828e04bf3a8e6fe832
Author: QHarshil <harshil_c@hotmail.com>
Date:   Mon Aug 24 16:14:20 2026 -0700

    feat: add scheduler dispatch delay and schedule-relative latency metrics
    
    request_latency is measured from the moment a request is dispatched, so
    any time it spent waiting on a saturated concurrency limit is excluded
    from every reported percentile. The scheduler already records the
    intended arrival time in RequestTimings.targeted_start, and
    SchedulerMetrics reports a scalar mean of that delay, but there is no
    distribution behind it and nothing folds it back into an end-to-end
    latency.
    
    Add two metrics alongside the existing ones:
    
      request_dispatch_delay    = request_start - targeted_start
      request_scheduled_latency = request_end - targeted_start
    
    Dispatch delay is the per-status distribution of the same quantity as
    the existing Request Targeted Start Delay Avg, scoped to the measurement
    window rather than the whole run, so the two will not match exactly.
    Scheduled latency is new.
    
    request_latency and every other existing metric keep their current
    definitions and values. The new GenerativeMetrics fields carry defaults
    so reports written before they existed still load.
    
    Both only apply to strategies that define an arrival schedule. A new
    SchedulingStrategy.defines_arrival_schedule property is True for
    constant, poisson, and trace, and False for synchronous, concurrent, and
    throughput. Synchronous and concurrent target the previous request's
    completion, so a delay measured against it is circular rather than lag
    against an arrival schedule; throughput targets the benchmark start, so
    the value would grow with elapsed run time. When the property is False
    both metrics are reported as None rather than zero, since zero would
    read as "no delay measured" instead of "not applicable", and the CSV
    emits no columns for them. This matters for the default sweep profile,
    which runs synchronous and throughput alongside its rate-based
    strategies.
    
    Per-request values are left None when a request never reached dispatch,
    so requests cancelled during a backlog are excluded from the
    distributions rather than being counted as zero delay.
    
    Where they do apply they are exposed through the serialized report and
    the CSV output. They are left out of the console latency table in all
    cases, since that table is shared across every profile in a run. The
    metrics guide documents the applicability rules.
    
    Against the shipped mock server on a constant-rate profile at a rate the
    concurrency cap cannot sustain, reported p99 request latency was 0.198s
    while p99 measured from targeted_start was 7.148s.
    
    Closes #1048
    
    Assisted-by: Claude Code claude-opus-5
    Signed-off-by: QHarshil <harshil_c@hotmail.com>

commit 4f0dd5ae2516e8d37ef49276436dcab367ae9fdf
Author: QHarshil <harshil_c@hotmail.com>
Date:   Thu Aug 27 12:02:02 2026 -0700

    docs: move scheduling metric applicability notes
    
    Move the Dispatch Delay and Scheduled Latency applicability section out
    of the flat list of metric definitions and to the end of the metrics
    guide, leaving a pointer to it from the definitions.
    
    Assisted-by: Claude Code claude-opus-5
    Signed-off-by: QHarshil <harshil_c@hotmail.com>

commit c0a0273893a6fc8292fc30bbfc97f0cb27c988ae
Author: QHarshil <harshil_c@hotmail.com>
Date:   Thu Aug 27 12:12:21 2026 -0700

    docs(metrics): simplify schedule-relative metric descriptions
    
    Drop the note about reports predating these fields from the
    request_dispatch_delay and request_scheduled_latency descriptions. The
    default of None still allows older reports to deserialize; only the
    description text changes.
    
    Assisted-by: Claude Code claude-opus-5
    Signed-off-by: QHarshil <harshil_c@hotmail.com>

commit 38a93bbf85b7bcedb5bc9630383c9772a8f5aedd
Author: QHarshil <harshil_c@hotmail.com>
Date:   Thu Aug 27 13:59:49 2026 -0700

    docs(metrics): note units in schedule-relative metric docstrings
    
    State seconds in the summary line of request_dispatch_delay and
    request_scheduled_latency so the unit is visible without reading the
    return description.
    
    Signed-off-by: QHarshil <harshil_c@hotmail.com>

---------

Assisted-by: Claude Code claude-opus-5
Signed-off-by: QHarshil <harshil_c@hotmail.com>
