### PR TITLE
fix: reject empty trace conversations

### DIFF
--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -339,6 +339,8 @@ def _validate_dataset(config: TraceDataArgs, trace_format: TraceFormatBase) -> N
         }
     )
     for conv in trace_format:  # type: ignore[attr-defined]
+        if len(conv) == 0:
+            raise DataNotSupportedError("Trace conversation is empty")
         if config.conversation_id_column in features:
             features.pop(config.conversation_id_column)
         _raise_if_nonetype_found(conv)

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -339,6 +339,23 @@ class TestWEKATraceFormat:
         with pytest.raises(DataNotSupportedError, match=match):
             self.deserialize(deserializer, trace)
 
+    @pytest.mark.regression
+    def test_rejects_empty_conversation_after_first_row(
+        self, tmp_path: Path, deserializer
+    ):
+        """Reject an empty nested conversation during deserialization.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            '{"id": "conv0", "requests": [{"t": 0, "in": 10, '
+            '"out": 5, "hash_ids": []}]}\n'
+            '{"id": "conv1", "requests": []}\n',
+        )
+        with pytest.raises(DataNotSupportedError, match="conversation is empty"):
+            self.deserialize(deserializer, trace)
+
     @pytest.mark.sanity
     def test_incompatible_encoding_raises(
         self, tmp_path: Path, deserializer, default_block_size


### PR DESCRIPTION
## Summary

- reject empty trace conversations during trace dataset validation
- fail early with an actionable `DataNotSupportedError` instead of an `IndexError` during iteration
- add a regression test for a later empty conversation in a WEKA trace

## Testing

- `tox -e tests -- tests/unit/data/deserializers/test_trace_weka.py -q` (16 passed)

---

- [x] I certify that my contribution is made under the terms of the Developer Certificate of Origin.

<!-- begin:squash-data -->

---

# git log

commit 0eec7735018996c0369e540ac243f3fb52043754
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Wed Aug 26 13:57:13 2026 +0800

    fix: reject empty trace conversations
    
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

---------

Signed-off-by: tangming1996 <ming.tang@daocloud.io>
