### PR TITLE
fix: make terminal request bookkeeping idempotent under max_duration cancellation

### DIFF
--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -11,6 +11,7 @@ status updates throughout request processing.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 import traceback
 from collections.abc import AsyncIterator
@@ -238,6 +239,10 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 poll_interval=self.messaging.poll_interval,
             )
             processing_task.cancel()
+            # Let in-flight nodes finish reporting their own terminal update
+            # before the sweep below, so a node is never reported twice.
+            with contextlib.suppress(asyncio.CancelledError):
+                await processing_task
 
             # 4. Cancel pending requests until proc canceled (manual, shutdown, error)
             await self._cancel_requests_loop()

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -730,38 +730,27 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             self._state.queued_requests = len(self._queued_request_ids)
             self._state.created_requests += 1
         elif info.status == "pending":
+            if info.request_id not in self._queued_request_ids:
+                # Already finalized by a racing terminal update; ignore.
+                return
             self._queued_request_ids.remove(info.request_id)
             self._state.queued_requests = len(self._queued_request_ids)
             self._pending_request_ids.add(info.request_id)
             self._state.pending_requests = len(self._pending_request_ids)
         elif info.status == "in_progress":
+            if info.request_id not in self._pending_request_ids:
+                # Already finalized by a racing terminal update; ignore.
+                return
             self._pending_request_ids.remove(info.request_id)
             self._state.pending_requests = len(self._pending_request_ids)
             self._processing_request_ids.add(info.request_id)
             self._state.processing_requests = len(self._processing_request_ids)
         elif info.status == "first_token":
             pass
-        elif info.status == "completed":
-            info.timings.finalized = finalized
-            self._processing_request_ids.remove(info.request_id)
-            self._state.processing_requests = len(self._processing_request_ids)
-            self._state.processed_requests += 1
-            self._state.successful_requests += 1
-        elif info.status in ("errored", "cancelled"):
-            info.timings.finalized = finalized
-            if info.request_id in self._queued_request_ids:
-                self._queued_request_ids.remove(info.request_id)
-                self._state.queued_requests = len(self._queued_request_ids)
-            elif info.request_id in self._pending_request_ids:
-                self._pending_request_ids.remove(info.request_id)
-                self._state.pending_requests = len(self._pending_request_ids)
-            elif info.request_id in self._processing_request_ids:
-                self._processing_request_ids.remove(info.request_id)
-                self._state.processing_requests = len(self._processing_request_ids)
-
-            self._state.processed_requests += 1
-            self._state.errored_requests += 1 if info.status == "errored" else 0
-            self._state.cancelled_requests += 1 if info.status == "cancelled" else 0
+        elif info.status in ("completed", "errored", "cancelled"):
+            if not self._finalize_terminal_request(info, finalized):
+                # Already finalized by a racing terminal update; ignore.
+                return
         else:
             raise ValueError(f"Unknown request_info status {info.status} for {info}")
 
@@ -775,6 +764,46 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             self._state.end_requests_time or float("-inf"),
             finalized,
         )
+
+    def _finalize_terminal_request(self, info: RequestInfo, finalized: float) -> bool:
+        """
+        Apply a completed/errored/cancelled update to the tracking sets.
+
+        :return: False if the request was already finalized by a prior
+            terminal update (nothing is changed in that case), True otherwise.
+        """
+        if info.status == "completed":
+            if info.request_id not in self._processing_request_ids:
+                return False
+            info.timings.finalized = finalized
+            self._processing_request_ids.remove(info.request_id)
+            self._state.processing_requests = len(self._processing_request_ids)
+            self._state.processed_requests += 1
+            self._state.successful_requests += 1
+            return True
+
+        if (
+            info.request_id not in self._queued_request_ids
+            and info.request_id not in self._pending_request_ids
+            and info.request_id not in self._processing_request_ids
+        ):
+            return False
+
+        info.timings.finalized = finalized
+        if info.request_id in self._queued_request_ids:
+            self._queued_request_ids.remove(info.request_id)
+            self._state.queued_requests = len(self._queued_request_ids)
+        elif info.request_id in self._pending_request_ids:
+            self._pending_request_ids.remove(info.request_id)
+            self._state.pending_requests = len(self._pending_request_ids)
+        elif info.request_id in self._processing_request_ids:
+            self._processing_request_ids.remove(info.request_id)
+            self._state.processing_requests = len(self._processing_request_ids)
+
+        self._state.processed_requests += 1
+        self._state.errored_requests += 1 if info.status == "errored" else 0
+        self._state.cancelled_requests += 1 if info.status == "cancelled" else 0
+        return True
 
     def _update_with_constraints(self, info: RequestInfo):
         actions: dict[str, SchedulerUpdateAction] = {

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -655,6 +655,71 @@ class TestWorkerProcess:
                 f"Process exited with error code: {process.exitcode}"
             )
 
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    @async_timeout(5)
+    async def test_process_requests_awaits_cancellation_before_cancel_loop(
+        self,
+        valid_instances: tuple[WorkerProcess, InterProcessMessagingQueue, dict],
+    ):
+        """``_process_requests`` must fully drain ``_process_requests_loop``'s
+        own cancellation (which reports each in-flight node's terminal status
+        itself) before ``_cancel_requests_loop`` sweeps ``turns_queue``: a
+        node cancelled by the sweep while its own task is still finishing is
+        exactly the race that double-reports a request's terminal status
+        (worker_group.py's ``_update_state_request_counts``).
+        ## WRITTEN BY AI ##
+        """
+        instance, _main_messaging, _constructor_args = valid_instances
+        events: list[str] = []
+
+        async def fake_processing_startup():
+            events.append("startup")
+
+        async def fake_process_requests_loop():
+            try:
+                await asyncio.sleep(1000)
+            except asyncio.CancelledError:
+                events.append("loop_cancel_start")
+                # Simulate an in-flight node task still finishing its own
+                # cancellation handling (reporting its terminal status).
+                await asyncio.sleep(0.05)
+                events.append("loop_cancel_done")
+                raise
+
+        async def fake_cancel_requests_loop():
+            events.append("cancel_requests_loop")
+
+        async def fake_processing_shutdown():
+            events.append("shutdown")
+
+        instance._processing_startup = fake_processing_startup
+        instance._process_requests_loop = fake_process_requests_loop
+        instance._cancel_requests_loop = fake_cancel_requests_loop
+        instance._processing_shutdown = fake_processing_shutdown
+
+        process_requests_task = asyncio.create_task(instance._process_requests())
+        # Give the inner processing loop task a chance to actually start and
+        # suspend on its (mocked) long-running work before triggering the
+        # constraint, so cancellation exercises its except-CancelledError
+        # handling rather than short-circuiting a task that never ran.
+        await asyncio.sleep(0.01)
+        instance.constraint_reached_event.set()
+        await process_requests_task
+
+        # On `main` this reads ["startup", "cancel_requests_loop", "shutdown"]
+        # without "loop_cancel_start"/"loop_cancel_done" ever appearing before
+        # it: the cancel loop sweeps turns_queue before the in-flight task's
+        # own cancellation handling (and its own terminal-status report) has
+        # even started.
+        assert events == [
+            "startup",
+            "loop_cancel_start",
+            "loop_cancel_done",
+            "cancel_requests_loop",
+            "shutdown",
+        ]
+
 
 class MockMessaging:
     """Mock messaging queue for testing worker DAG functionality.

--- a/tests/unit/scheduler/test_worker_group.py
+++ b/tests/unit/scheduler/test_worker_group.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import multiprocessing
+import threading
 import time
 from multiprocessing.context import BaseContext
 from multiprocessing.managers import BaseManager
@@ -506,3 +508,160 @@ class TestWorkerProcessGroup:
         assert instance.error_event is None
         assert instance.mp_manager is None
         assert instance.mp_context is None
+
+
+class TestWorkerGroupStateDuplicateTerminalUpdate:
+    """
+    Regression coverage for a request receiving two terminal status updates:
+    once from the worker's cancel loop (which aborts every node not yet in
+    the DAG's completed set, including one an in-flight task still owns) and
+    once from that task's own completion/cancellation handling. ## WRITTEN BY AI ##
+    """
+
+    def _build_state(self) -> WorkerGroupState:
+        return WorkerGroupState(
+            start_time=time.time(),
+            processes=[],
+            strategy=SynchronousStrategy(),
+            constraints={},
+            stop_send_requests_event=threading.Event(),
+            send_requests_stopped_event=threading.Event(),
+            requests_generated_event=multiprocessing.Event(),
+            constraint_reached_event=multiprocessing.Event(),
+            shutdown_event=multiprocessing.Event(),
+            error_event=multiprocessing.Event(),
+            messaging=None,
+        )
+
+    def _advance(
+        self, state: WorkerGroupState, request_id: str, status: str
+    ) -> RequestInfo:
+        info = RequestInfo(request_id=request_id, status=status)
+        state.received_callback((None, f"request-{request_id}", info))
+        return info
+
+    @pytest.mark.regression
+    def test_cancel_loop_then_in_flight_completion_does_not_raise_or_double_count(
+        self,
+    ):
+        """A 'cancelled' update (cancel loop) followed by a stray 'completed'
+        for the same request (the task that was already reported cancelled
+        finishing anyway) must not raise and must not double-count.
+        ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending", "in_progress"):
+            self._advance(state, "req-1", status)
+
+        self._advance(state, "req-1", "cancelled")
+        # Must not raise KeyError: on `main` this crashes inside
+        # `_update_state_request_counts` because "completed" unconditionally
+        # removes from `_processing_request_ids`, which "cancelled" already did.
+        self._advance(state, "req-1", "completed")
+
+        assert state._state.processed_requests == 1
+        assert state._state.cancelled_requests == 1
+        assert state._state.successful_requests == 0
+        assert state._state.processing_requests == 0
+
+    @pytest.mark.regression
+    def test_in_flight_completion_then_stray_cancel_does_not_double_count(self):
+        """The other interleaving: the in-flight task's own 'completed'
+        update lands first, and a stray 'cancelled' for the same request
+        (e.g. from a cancel loop that started before completion but was
+        delayed) arrives after. On `main` this does not raise (the
+        "cancelled" branch's remove is already guarded) but silently
+        double-counts `processed_requests`. ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending", "in_progress"):
+            self._advance(state, "req-2", status)
+
+        self._advance(state, "req-2", "completed")
+        self._advance(state, "req-2", "cancelled")
+
+        assert state._state.processed_requests == 1
+        assert state._state.successful_requests == 1
+        assert state._state.cancelled_requests == 0
+
+    @pytest.mark.regression
+    def test_normal_single_terminal_update_still_counts(self):
+        """Control: the ordinary, non-racing lifecycle still counts exactly
+        once, so the new guards do not mask a real update. ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending", "in_progress", "completed"):
+            self._advance(state, "req-3", status)
+
+        assert state._state.processed_requests == 1
+        assert state._state.successful_requests == 1
+        assert state._state.queued_requests == 0
+        assert state._state.pending_requests == 0
+        assert state._state.processing_requests == 0
+
+    @pytest.mark.regression
+    def test_stray_pending_after_finalization_is_ignored(self):
+        """A stray 'pending' update for a request already finalized (e.g. an
+        out-of-order / duplicate delivery) must not raise and must not
+        resurrect the request into `_pending_request_ids`. ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending", "in_progress", "cancelled"):
+            self._advance(state, "req-4", status)
+
+        self._advance(state, "req-4", "pending")
+
+        assert state._state.processed_requests == 1
+        assert state._state.cancelled_requests == 1
+        assert state._state.pending_requests == 0
+        assert "req-4" not in state._pending_request_ids
+
+    @pytest.mark.regression
+    def test_stray_in_progress_after_finalization_is_ignored(self):
+        """Same as above for a stray 'in_progress' update after the request
+        already reached a terminal state. ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending", "in_progress", "completed"):
+            self._advance(state, "req-5", status)
+
+        self._advance(state, "req-5", "in_progress")
+
+        assert state._state.processed_requests == 1
+        assert state._state.successful_requests == 1
+        assert state._state.processing_requests == 0
+        assert "req-5" not in state._processing_request_ids
+
+    @pytest.mark.regression
+    def test_cancelled_while_still_queued_is_finalized_from_queued_set(self):
+        """A request cancelled before it was ever dispatched (still in
+        `_queued_request_ids`, no 'pending'/'in_progress' update yet) must be
+        finalized from the queued set, not just the pending/processing ones.
+        ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        self._advance(state, "req-6", "queued")
+
+        self._advance(state, "req-6", "cancelled")
+
+        assert state._state.processed_requests == 1
+        assert state._state.cancelled_requests == 1
+        assert state._state.queued_requests == 0
+        assert "req-6" not in state._queued_request_ids
+
+    @pytest.mark.regression
+    def test_errored_while_pending_is_finalized_from_pending_set(self):
+        """A request that errors after being dispatched but before entering
+        `_processing_request_ids` (still in `_pending_request_ids`) must be
+        finalized from the pending set. ## WRITTEN BY AI ##
+        """
+        state = self._build_state()
+        for status in ("queued", "pending"):
+            self._advance(state, "req-7", status)
+
+        self._advance(state, "req-7", "errored")
+
+        assert state._state.processed_requests == 1
+        assert state._state.errored_requests == 1
+        assert state._state.pending_requests == 0
+        assert "req-7" not in state._pending_request_ids


### PR DESCRIPTION
## Summary

A `max_duration` run at high concurrency can abort with a `KeyError` or hang forever, because a request can get two terminal status updates for the same lifecycle.

## Details

- [x] `WorkerProcess._process_requests` (`worker.py`) calls `processing_task.cancel()` then immediately runs `_cancel_requests_loop`, without waiting for the cancellation to actually land. `cancel()` only schedules the exception; the cancel loop can walk `turns_queue` and report a node as `cancelled` while that node's own task is still finishing and about to report itself `completed`.
- [x] `WorkerGroupState._update_state_request_counts` (`worker_group.py`) treated `completed`, `pending`, and `in_progress` as always-valid transitions with unguarded set removals. A second terminal report for an already-finalized request either raised `KeyError` on the unguarded `_processing_request_ids.remove(...)`, or, when the removal happened to hit a different (already-empty) branch, silently incremented `processed_requests` a second time, so the scheduler's shutdown equality check never held and `Scheduler.run()` never returned.

Fix, matching the maintainer's own comment on the issue (options 1 + 3):

- `_process_requests` now awaits the cancelled `processing_task` (suppressing `CancelledError`) before running `_cancel_requests_loop`, so in-flight nodes report their own terminal status first.
- `_update_state_request_counts` is now idempotent: a `pending`/`in_progress` update for a request no longer in the set it expects, or a `completed`/`errored`/`cancelled` update for a request already finalized, is treated as a stray duplicate and ignored instead of raising or double-counting. The completed/errored/cancelled path is extracted into `_finalize_terminal_request`, which returns whether it actually applied the update.

## Test Plan

- New regression tests in `tests/unit/scheduler/test_worker.py` and `tests/unit/scheduler/test_worker_group.py`: fail on `main` (`KeyError`, wrong event ordering, or a double-counted `processed_requests`), pass on this branch. Full `tests/unit/scheduler` suite green on Python 3.10 and 3.12 (549 passed, 16 pre-existing unrelated xfails).
- Reproduced the issue's own `race.py` script directly: 6/6 runs hung on unmodified `main` at `max_concurrency=500, max_duration=8`; 10/10 clean exits on this branch.
- `ruff format --check`, `ruff check`, and `mypy --check-untyped-defs` pass on the changed files. Coverage confirms every changed line is exercised by the new tests.
- Not checked: `tests/integration` and `tests/e2e`, which need a live backend/model server and don't import the changed code paths.

## Related Issues

- Resolves #1049

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit bf59fcd1942c8d3db573cae90bea3ebfc6c629fc
Author: Amir Fathi <amirfathi.me@gmail.com>
Date:   Wed Aug 26 09:02:51 2026 +0000

    fix: make terminal request bookkeeping idempotent under max_duration cancellation
    
    WorkerProcess._process_requests cancelled processing_task and immediately
    ran _cancel_requests_loop without awaiting the cancellation, so a node the
    cancel loop reported as "cancelled" could still be finishing its own
    "completed" report. WorkerGroupState._update_state_request_counts treated
    completed/errored/cancelled as first-report-wins, so the second report hit
    an unguarded set removal (KeyError abort) or, when it missed the removal,
    double-incremented processed_requests so the shutdown equality check never
    held (hang).
    
    Await the cancelled task before the cancel loop runs, so it is the one
    reporting nodes it still owns, and make _update_state_request_counts
    idempotent: a pending/in_progress/terminal update for a request no longer
    in the set it expects is a stray duplicate and is ignored rather than
    raising or double-counting.
    
    Fixes #1049
    
    Generated-by: Claude Code claude-sonnet-5
    Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>

---------

Generated-by: Claude Code claude-sonnet-5
Signed-off-by: Amir Fathi <amirfathi.me@gmail.com>
