### PR TITLE
Add multimodal support to the mock server

### DIFF
--- a/src/guidellm/cli/mock_server.py
+++ b/src/guidellm/cli/mock_server.py
@@ -94,6 +94,24 @@ __all__ = ["mock_server"]
     help="Output tokens standard deviation (normal distribution).",
 )
 @click.option(
+    "--image-tokens",
+    default=576,
+    type=int,
+    help="Prompt tokens charged per image content part in multimodal requests.",
+)
+@click.option(
+    "--video-tokens",
+    default=1024,
+    type=int,
+    help="Prompt tokens charged per video content part in multimodal requests.",
+)
+@click.option(
+    "--audio-tokens-per-second",
+    default=25.0,
+    type=float,
+    help="Prompt tokens charged per estimated second of audio input.",
+)
+@click.option(
     "--fail-after-requests",
     default=None,
     type=int,
@@ -125,6 +143,9 @@ def mock_server(
     itl_ms_std: float,
     output_tokens: int,
     output_tokens_std: float,
+    image_tokens: int,
+    video_tokens: int,
+    audio_tokens_per_second: float,
     fail_after_requests: int | None,
     max_concurrent_requests: int | None,
 ):
@@ -142,6 +163,9 @@ def mock_server(
         itl_ms_std=itl_ms_std,
         output_tokens=output_tokens,
         output_tokens_std=output_tokens_std,
+        image_tokens=image_tokens,
+        video_tokens=video_tokens,
+        audio_tokens_per_second=audio_tokens_per_second,
         fail_after_requests=fail_after_requests,
         max_concurrent_requests=max_concurrent_requests,
     )

--- a/src/guidellm/mock_server/handlers/chat_completions.py
+++ b/src/guidellm/mock_server/handlers/chat_completions.py
@@ -32,6 +32,11 @@ from guidellm.mock_server.models import (
     ErrorResponse,
     Usage,
 )
+from guidellm.mock_server.multimodal import (
+    InvalidContentPartError,
+    MultimodalPromptStats,
+    accumulate_multimodal_content,
+)
 from guidellm.mock_server.utils import (
     MockTokenizer,
     create_fake_text,
@@ -113,11 +118,28 @@ class ChatCompletionsHandler:
                 status=400,
             )
 
+        # Validate multimodal content parts and accumulate their token charges
+        try:
+            multimodal_stats = accumulate_multimodal_content(
+                req_data.messages, self.config
+            )
+        except InvalidContentPartError as exc:
+            return response.json(
+                ErrorResponse(
+                    error=ErrorDetail(
+                        message=f"Invalid request: {exc}",
+                        type="invalid_request_error",
+                        code="invalid_request",
+                    )
+                ).model_dump(),
+                status=400,
+            )
+
         # Handle streaming vs non-streaming
         if req_data.stream:
-            return await self._handle_stream(req_data)
+            return await self._handle_stream(req_data, multimodal_stats)
         else:
-            return await self._handle_non_stream(req_data)
+            return await self._handle_non_stream(req_data, multimodal_stats)
 
     def _should_return_tool_calls(self, req: ChatCompletionsRequest) -> bool:
         """Check if this request expects a tool call response.
@@ -146,7 +168,9 @@ class ChatCompletionsHandler:
             }
         ]
 
-    async def _handle_non_stream(self, req: ChatCompletionsRequest) -> HTTPResponse:
+    async def _handle_non_stream(
+        self, req: ChatCompletionsRequest, multimodal_stats: MultimodalPromptStats
+    ) -> HTTPResponse:
         """
         Generate complete non-streaming chat completion response.
 
@@ -156,6 +180,7 @@ class ChatCompletionsHandler:
         returns tool_calls instead of text content.
 
         :param req: Validated chat completion request parameters
+        :param multimodal_stats: Accumulated multimodal prompt token charges
         :return: Complete HTTP response with generated completion data
         """
         # TTFT delay
@@ -165,7 +190,8 @@ class ChatCompletionsHandler:
 
         # Token counts
         prompt_text = self.tokenizer.apply_chat_template(req.messages)
-        prompt_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
+        text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
+        prompt_tokens = text_tokens + multimodal_stats.total_tokens
         max_tokens = req.max_completion_tokens or req.max_tokens or math.inf
         completion_tokens_count = min(
             sample_number(self.config.output_tokens, self.config.output_tokens_std),
@@ -209,13 +235,18 @@ class ChatCompletionsHandler:
             usage=Usage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=int(completion_tokens_count),
+                prompt_tokens_details=multimodal_stats.prompt_tokens_details(
+                    text_tokens
+                ),
             ),
             system_fingerprint=f"fp_{uuid.uuid4().hex[:10]}",
         )
 
         return response.json(chat_response.model_dump())
 
-    async def _handle_stream(self, req: ChatCompletionsRequest) -> HTTPResponse:
+    async def _handle_stream(
+        self, req: ChatCompletionsRequest, multimodal_stats: MultimodalPromptStats
+    ) -> HTTPResponse:
         """
         Generate streaming chat completion response with real-time token delivery.
 
@@ -225,6 +256,7 @@ class ChatCompletionsHandler:
         "required", streams tool call deltas instead of content.
 
         :param req: Validated chat completion request with streaming enabled
+        :param multimodal_stats: Accumulated multimodal prompt token charges
         :return: Streaming HTTP response delivering tokens with proper timing
         """
         is_tool_call = self._should_return_tool_calls(req)
@@ -239,7 +271,9 @@ class ChatCompletionsHandler:
 
             # Token counts
             prompt_text = self.tokenizer.apply_chat_template(req.messages)
-            prompt_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
+            text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
+            prompt_tokens = text_tokens + multimodal_stats.total_tokens
+            prompt_tokens_details = multimodal_stats.prompt_tokens_details(text_tokens)
             max_tokens = req.max_completion_tokens or req.max_tokens or math.inf
             completion_tokens_count = int(
                 min(
@@ -257,6 +291,7 @@ class ChatCompletionsHandler:
                     completion_id,
                     prompt_tokens,
                     completion_tokens_count,
+                    prompt_tokens_details,
                 )
             else:
                 await self._stream_content(
@@ -265,6 +300,7 @@ class ChatCompletionsHandler:
                     completion_id,
                     prompt_tokens,
                     completion_tokens_count,
+                    prompt_tokens_details,
                 )
 
             # End stream
@@ -287,6 +323,7 @@ class ChatCompletionsHandler:
         completion_id,
         prompt_tokens,
         completion_tokens_count,
+        prompt_tokens_details=None,
     ):
         """Stream text content tokens with ITL delays."""
         tokens = create_fake_tokens_str(completion_tokens_count, self.tokenizer)
@@ -330,17 +367,20 @@ class ChatCompletionsHandler:
 
         # Send usage if requested
         if req.stream_options and req.stream_options.include_usage:
+            usage_data: dict[str, Any] = {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens_count,
+                "total_tokens": prompt_tokens + completion_tokens_count,
+            }
+            if prompt_tokens_details is not None:
+                usage_data["prompt_tokens_details"] = prompt_tokens_details
             usage_chunk = {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": int(time.time()),
                 "model": req.model,
                 "choices": [],
-                "usage": {
-                    "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens_count,
-                    "total_tokens": prompt_tokens + completion_tokens_count,
-                },
+                "usage": usage_data,
             }
             await stream_response.write(f"data: {json.dumps(usage_chunk)}\n\n")
 
@@ -351,6 +391,7 @@ class ChatCompletionsHandler:
         completion_id,
         prompt_tokens,
         completion_tokens_count,
+        prompt_tokens_details=None,
     ):
         """Stream tool call deltas matching the OpenAI streaming tool call format.
 
@@ -441,16 +482,19 @@ class ChatCompletionsHandler:
 
         # Send usage if requested
         if req.stream_options and req.stream_options.include_usage:
+            usage_data: dict[str, Any] = {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens_count,
+                "total_tokens": prompt_tokens + completion_tokens_count,
+            }
+            if prompt_tokens_details is not None:
+                usage_data["prompt_tokens_details"] = prompt_tokens_details
             usage_chunk = {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": int(time.time()),
                 "model": req.model,
                 "choices": [],
-                "usage": {
-                    "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens_count,
-                    "total_tokens": prompt_tokens + completion_tokens_count,
-                },
+                "usage": usage_data,
             }
             await stream_response.write(f"data: {json.dumps(usage_chunk)}\n\n")

--- a/src/guidellm/mock_server/models.py
+++ b/src/guidellm/mock_server/models.py
@@ -50,6 +50,13 @@ class Usage(BaseModel):
         description="Number of tokens in the generated completion"
     )
     total_tokens: int = Field(description="Total tokens used (prompt + completion)")
+    prompt_tokens_details: dict[str, int | float] | None = Field(
+        default=None,
+        description=(
+            "Optional per-modality breakdown of prompt tokens (text, image, "
+            "video, audio) following vLLM usage conventions"
+        ),
+    )
 
     def __init__(self, prompt_tokens: int = 0, completion_tokens: int = 0, **kwargs):
         """Initialize usage statistics.

--- a/src/guidellm/mock_server/multimodal.py
+++ b/src/guidellm/mock_server/multimodal.py
@@ -1,0 +1,225 @@
+"""
+Multimodal content accounting utilities for the mock server.
+
+Provides validation and prompt token accounting for the multimodal chat
+completion content parts that GuideLLM's OpenAI-compatible backend produces:
+``image_url``, ``video_url``, and ``input_audio``. Token charges use simple,
+configurable heuristics so benchmarks receive plausible per-modality usage
+statistics without running real encoders. Audio duration is estimated from the
+payload size using the byte rates of GuideLLM's synthetic audio encoding
+defaults (PCM16 mono at 16 kHz for WAV, 64 kbit/s for lossy formats).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import math
+
+from pydantic import BaseModel, Field
+
+from guidellm.mock_server.models import ChatMessage
+from guidellm.schemas.mock_server import MockServerConfig
+
+__all__ = [
+    "LOSSY_BYTES_PER_SECOND",
+    "WAV_BYTES_PER_SECOND",
+    "InvalidContentPartError",
+    "MultimodalPromptStats",
+    "accumulate_multimodal_content",
+    "estimate_audio_seconds",
+]
+
+WAV_BYTES_PER_SECOND = 32000
+"""Bytes per second for WAV payloads, assuming PCM16 mono at 16 kHz."""
+
+LOSSY_BYTES_PER_SECOND = 8000
+"""Bytes per second for lossy audio payloads, assuming 64 kbit/s encoding."""
+
+
+class InvalidContentPartError(ValueError):
+    """Raised when a multimodal content part fails shape validation."""
+
+
+class MultimodalPromptStats(BaseModel):
+    """
+    Per-modality prompt token accounting for a multimodal chat request.
+
+    Fields are ``None`` when the request contains no parts of that modality so
+    that text-only requests keep their existing usage payloads and benchmark
+    metrics do not record spurious zero values for absent modalities.
+    """
+
+    image_tokens: int | None = Field(
+        default=None, description="Prompt tokens charged for image content parts"
+    )
+    video_tokens: int | None = Field(
+        default=None, description="Prompt tokens charged for video content parts"
+    )
+    audio_tokens: int | None = Field(
+        default=None, description="Prompt tokens charged for audio content parts"
+    )
+    audio_seconds: float | None = Field(
+        default=None, description="Estimated total seconds of audio input"
+    )
+
+    @property
+    def total_tokens(self) -> int:
+        """
+        :return: Total multimodal prompt tokens across all modalities
+        """
+        return (
+            (self.image_tokens or 0)
+            + (self.video_tokens or 0)
+            + (self.audio_tokens or 0)
+        )
+
+    def prompt_tokens_details(self, text_tokens: int) -> dict[str, int | float] | None:
+        """
+        Build a vLLM-style ``prompt_tokens_details`` usage breakdown.
+
+        :param text_tokens: Number of text-only prompt tokens for the request
+        :return: Details dict with per-modality token counts, or None when the
+            request contained no multimodal content
+        """
+        if (
+            self.image_tokens is None
+            and self.video_tokens is None
+            and self.audio_tokens is None
+        ):
+            return None
+
+        details: dict[str, int | float] = {"prompt_tokens": text_tokens}
+        if self.image_tokens is not None:
+            details["image_tokens"] = self.image_tokens
+        if self.video_tokens is not None:
+            details["video_tokens"] = self.video_tokens
+        if self.audio_tokens is not None:
+            details["audio_tokens"] = self.audio_tokens
+        if self.audio_seconds is not None:
+            details["seconds"] = self.audio_seconds
+        return details
+
+
+def estimate_audio_seconds(num_bytes: int, format_hint: str | None) -> float:
+    """
+    Estimate audio duration in seconds from payload size and format.
+
+    Mirrors the encoding defaults of GuideLLM's synthetic audio pipeline: WAV
+    (and raw PCM) payloads are assumed to be PCM16 mono at 16 kHz, while all
+    other formats are assumed to be encoded at 64 kbit/s.
+
+    :param num_bytes: Size of the decoded audio payload in bytes
+    :param format_hint: Format name, file name, or MIME type of the audio
+    :return: Estimated duration of the audio in seconds
+    """
+    hint = (format_hint or "").lower()
+    bytes_per_second = (
+        WAV_BYTES_PER_SECOND
+        if "wav" in hint or "pcm" in hint
+        else LOSSY_BYTES_PER_SECOND
+    )
+    return num_bytes / bytes_per_second
+
+
+def _validate_text_part(part: dict) -> None:
+    """Validate a ``text`` content part."""
+    if not isinstance(part.get("text"), str):
+        raise InvalidContentPartError(
+            "Content part 'text' requires a string 'text' field"
+        )
+
+
+def _validate_url_part(part: dict, part_type: str) -> None:
+    """Validate an ``image_url`` or ``video_url`` content part."""
+    url_obj = part.get(part_type)
+    if not isinstance(url_obj, dict) or not isinstance(url_obj.get("url"), str):
+        raise InvalidContentPartError(
+            f"Content part '{part_type}' requires an object '{part_type}' "
+            "with a string 'url' field"
+        )
+    if not url_obj["url"]:
+        raise InvalidContentPartError(
+            f"Content part '{part_type}' requires a non-empty 'url'"
+        )
+
+
+def _decode_audio_part(part: dict) -> tuple[bytes, str | None]:
+    """Validate an ``input_audio`` content part and decode its payload."""
+    audio_obj = part.get("input_audio")
+    if not isinstance(audio_obj, dict) or not isinstance(audio_obj.get("data"), str):
+        raise InvalidContentPartError(
+            "Content part 'input_audio' requires an object 'input_audio' "
+            "with a base64 string 'data' field"
+        )
+    if not audio_obj["data"]:
+        raise InvalidContentPartError(
+            "Content part 'input_audio' requires non-empty base64 'data'"
+        )
+    audio_format = audio_obj.get("format")
+    if audio_format is not None and not isinstance(audio_format, str):
+        raise InvalidContentPartError(
+            "Content part 'input_audio' has a non-string 'format' field"
+        )
+    try:
+        audio_bytes = base64.b64decode(audio_obj["data"], validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise InvalidContentPartError(
+            f"Content part 'input_audio' has invalid base64 data: {exc}"
+        ) from exc
+    return audio_bytes, audio_format
+
+
+def accumulate_multimodal_content(
+    messages: list[ChatMessage], config: MockServerConfig
+) -> MultimodalPromptStats:
+    """
+    Validate multimodal content parts and accumulate prompt token charges.
+
+    Walks every message's content list, validates the shape of each content
+    part, and charges tokens per part using the configured heuristics: a flat
+    per-image and per-video token count, and a per-second rate applied to the
+    estimated duration of ``input_audio`` payloads.
+
+    :param messages: Chat messages from a validated chat completions request
+    :param config: Mock server configuration with multimodal token settings
+    :return: Accumulated per-modality prompt token statistics
+    :raises InvalidContentPartError: When a content part fails shape validation
+    """
+    images = 0
+    videos = 0
+    audio_parts = 0
+    audio_seconds = 0.0
+
+    for message in messages:
+        if not isinstance(message.content, list):
+            continue
+        for part in message.content:
+            part_type = part.get("type")
+            if part_type == "text":
+                _validate_text_part(part)
+            elif part_type in ("image_url", "video_url"):
+                _validate_url_part(part, part_type)
+                if part_type == "image_url":
+                    images += 1
+                else:
+                    videos += 1
+            elif part_type == "input_audio":
+                audio_bytes, audio_format = _decode_audio_part(part)
+                audio_parts += 1
+                audio_seconds += estimate_audio_seconds(len(audio_bytes), audio_format)
+            else:
+                raise InvalidContentPartError(
+                    f"Unsupported content part type: {part_type!r}"
+                )
+
+    return MultimodalPromptStats(
+        image_tokens=images * config.image_tokens if images else None,
+        video_tokens=videos * config.video_tokens if videos else None,
+        audio_tokens=(
+            math.ceil(audio_seconds * config.audio_tokens_per_second)
+            if audio_parts
+            else None
+        ),
+        audio_seconds=round(audio_seconds, 3) if audio_parts else None,
+    )

--- a/src/guidellm/mock_server/server.py
+++ b/src/guidellm/mock_server/server.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
@@ -29,6 +30,7 @@ from guidellm.mock_server.handlers import (
     ResponsesHandler,
     TokenizerHandler,
 )
+from guidellm.mock_server.multimodal import estimate_audio_seconds
 from guidellm.schemas.mock_server import MockServerConfig
 
 __all__ = ["MockServer"]
@@ -145,6 +147,28 @@ class MockServer:
         async with semaphore:
             return await handler(request)
 
+    def _audio_usage(self, file: File, text: str) -> dict[str, int | float]:
+        """
+        Build usage statistics for an audio endpoint response.
+
+        Charges prompt tokens for the uploaded audio using the configured
+        per-second rate applied to the duration estimated from the payload
+        size, and counts completion tokens from the generated text.
+
+        :param file: Uploaded audio file from the multipart form
+        :param text: Text returned in the response body
+        :return: Usage dict with prompt, completion, and total token counts
+        """
+        audio_seconds = estimate_audio_seconds(len(file.body), file.type or file.name)
+        prompt_tokens = math.ceil(audio_seconds * self.config.audio_tokens_per_second)
+        completion_tokens = len(self.tokenizer_handler.tokenizer.tokenize(text))
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "seconds": round(audio_seconds, 3),
+        }
+
     def _setup_middleware(self):
         """Setup middleware for CORS, logging, etc."""
 
@@ -236,13 +260,15 @@ class MockServer:
 
             file = cast("File", file)
             model = request.form.get("model", "mock-model")
+            text = f"Mock transcription for {file.name}"
 
             return response.json(
                 {
-                    "text": f"Mock transcription for {file.name}",
+                    "text": text,
                     "file_size": len(file.body),
                     "model_used": model,
                     "transcription": f"Transcribed({file.name}) using {model}",
+                    "usage": self._audio_usage(file, text),
                 }
             )
 
@@ -274,9 +300,10 @@ class MockServer:
                 {
                     "text": decoded_text,
                     "file_size": len(file.body),
-                    "filename": {file.name},
+                    "filename": file.name,
                     "model_used": request.form.get("model", "mock-model"),
                     "mimetype": file.type,
+                    "usage": self._audio_usage(file, decoded_text),
                 }
             )
 

--- a/src/guidellm/schemas/mock_server/config.py
+++ b/src/guidellm/schemas/mock_server/config.py
@@ -78,6 +78,33 @@ class MockServerConfig(BaseSettings):
         default=0.0,
         description="Standard deviation for output token count variation",
     )
+    image_tokens: int = Field(
+        default=576,
+        ge=0,
+        description=(
+            "Prompt tokens charged per image content part in multimodal chat "
+            "requests. Flat heuristic; the default matches a 336px ViT-L/14 "
+            "vision encoder."
+        ),
+    )
+    video_tokens: int = Field(
+        default=1024,
+        ge=0,
+        description=(
+            "Prompt tokens charged per video content part in multimodal chat "
+            "requests. Flat heuristic."
+        ),
+    )
+    audio_tokens_per_second: float = Field(
+        default=25.0,
+        ge=0,
+        description=(
+            "Prompt tokens charged per estimated second of audio input for "
+            "multimodal chat requests and audio endpoints. Duration is "
+            "estimated from payload size assuming PCM16 mono 16 kHz for WAV "
+            "and 64 kbit/s for lossy formats."
+        ),
+    )
     fail_after_requests: int | None = Field(
         default=None,
         ge=0,

--- a/tests/unit/mock_server/test_multimodal.py
+++ b/tests/unit/mock_server/test_multimodal.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from guidellm.mock_server.models import ChatMessage
+from guidellm.mock_server.multimodal import (
+    LOSSY_BYTES_PER_SECOND,
+    WAV_BYTES_PER_SECOND,
+    InvalidContentPartError,
+    MultimodalPromptStats,
+    accumulate_multimodal_content,
+    estimate_audio_seconds,
+)
+from guidellm.schemas.mock_server.config import MockServerConfig
+
+
+def _config(**kwargs) -> MockServerConfig:
+    defaults = {
+        "image_tokens": 576,
+        "video_tokens": 1024,
+        "audio_tokens_per_second": 25.0,
+    }
+    defaults.update(kwargs)
+    return MockServerConfig(**defaults)
+
+
+def _b64_audio(num_bytes: int) -> str:
+    return base64.b64encode(b"\x00" * num_bytes).decode("utf-8")
+
+
+class TestEstimateAudioSeconds:
+    """Test suite for estimate_audio_seconds."""
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        ("num_bytes", "format_hint", "expected"),
+        [
+            (WAV_BYTES_PER_SECOND, "wav", 1.0),
+            (WAV_BYTES_PER_SECOND, "audio/wav", 1.0),
+            (WAV_BYTES_PER_SECOND, "sample.WAV", 1.0),
+            (WAV_BYTES_PER_SECOND, "pcm", 1.0),
+            (LOSSY_BYTES_PER_SECOND, "mp3", 1.0),
+            (LOSSY_BYTES_PER_SECOND, "audio/flac", 1.0),
+            (LOSSY_BYTES_PER_SECOND, None, 1.0),
+            (0, "wav", 0.0),
+        ],
+    )
+    def test_invocation(self, num_bytes, format_hint, expected):
+        """Test duration estimates across formats and byte counts.
+
+        ## WRITTEN BY AI ##
+        """
+        assert estimate_audio_seconds(num_bytes, format_hint) == expected
+
+
+class TestMultimodalPromptStats:
+    """Test suite for MultimodalPromptStats."""
+
+    @pytest.mark.smoke
+    def test_total_tokens(self):
+        """Test total_tokens sums the present modalities and treats None as 0.
+
+        ## WRITTEN BY AI ##
+        """
+        assert MultimodalPromptStats().total_tokens == 0
+        stats = MultimodalPromptStats(
+            image_tokens=576, video_tokens=1024, audio_tokens=25, audio_seconds=1.0
+        )
+        assert stats.total_tokens == 576 + 1024 + 25
+        assert MultimodalPromptStats(image_tokens=10).total_tokens == 10
+
+    @pytest.mark.smoke
+    def test_prompt_tokens_details_empty(self):
+        """Test details are None for text-only requests.
+
+        ## WRITTEN BY AI ##
+        """
+        assert MultimodalPromptStats().prompt_tokens_details(42) is None
+
+    @pytest.mark.smoke
+    def test_prompt_tokens_details_full(self):
+        """Test details include text tokens and only the present modalities.
+
+        ## WRITTEN BY AI ##
+        """
+        stats = MultimodalPromptStats(
+            image_tokens=576, video_tokens=1024, audio_tokens=25, audio_seconds=1.0
+        )
+        assert stats.prompt_tokens_details(42) == {
+            "prompt_tokens": 42,
+            "image_tokens": 576,
+            "video_tokens": 1024,
+            "audio_tokens": 25,
+            "seconds": 1.0,
+        }
+        assert MultimodalPromptStats(image_tokens=576).prompt_tokens_details(7) == {
+            "prompt_tokens": 7,
+            "image_tokens": 576,
+        }
+
+
+class TestAccumulateMultimodalContent:
+    """Test suite for accumulate_multimodal_content."""
+
+    @pytest.mark.smoke
+    def test_text_only(self):
+        """Test string and text-part content produce no multimodal charges.
+
+        ## WRITTEN BY AI ##
+        """
+        messages = [
+            ChatMessage(role="system", content="You are helpful."),
+            ChatMessage(role="user", content=[{"type": "text", "text": "Hi"}]),
+            ChatMessage(role="assistant", content=None),
+        ]
+        stats = accumulate_multimodal_content(messages, _config())
+        assert stats.image_tokens is None
+        assert stats.video_tokens is None
+        assert stats.audio_tokens is None
+        assert stats.audio_seconds is None
+        assert stats.total_tokens == 0
+
+    @pytest.mark.smoke
+    def test_mixed_modalities(self):
+        """Test image, video, and audio parts accumulate across messages.
+
+        ## WRITTEN BY AI ##
+        """
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Describe these"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                    },
+                    {"type": "image_url", "image_url": {"url": "http://x/img.png"}},
+                    {"type": "video_url", "video_url": {"url": "http://x/clip.mp4"}},
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": _b64_audio(WAV_BYTES_PER_SECOND * 2),
+                            "format": "wav",
+                        },
+                    },
+                ],
+            ),
+            ChatMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": _b64_audio(LOSSY_BYTES_PER_SECOND),
+                            "format": "mp3",
+                        },
+                    },
+                ],
+            ),
+        ]
+        stats = accumulate_multimodal_content(messages, _config())
+        assert stats.image_tokens == 2 * 576
+        assert stats.video_tokens == 1024
+        assert stats.audio_seconds == 3.0
+        assert stats.audio_tokens == 75
+        assert stats.total_tokens == 2 * 576 + 1024 + 75
+
+    @pytest.mark.sanity
+    def test_configurable_charges(self):
+        """Test token charges follow the configured heuristic values.
+
+        ## WRITTEN BY AI ##
+        """
+        config = _config(image_tokens=10, video_tokens=20, audio_tokens_per_second=2.0)
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[
+                    {"type": "image_url", "image_url": {"url": "http://x/a.png"}},
+                    {"type": "video_url", "video_url": {"url": "http://x/a.mp4"}},
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": _b64_audio(WAV_BYTES_PER_SECOND // 2),
+                            "format": "wav",
+                        },
+                    },
+                ],
+            ),
+        ]
+        stats = accumulate_multimodal_content(messages, config)
+        assert stats.image_tokens == 10
+        assert stats.video_tokens == 20
+        assert stats.audio_seconds == 0.5
+        assert stats.audio_tokens == 1  # ceil(0.5 * 2.0)
+
+    @pytest.mark.sanity
+    def test_audio_format_default_lossy(self):
+        """Test audio without a format field uses the lossy byte rate.
+
+        ## WRITTEN BY AI ##
+        """
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "input_audio",
+                        "input_audio": {"data": _b64_audio(LOSSY_BYTES_PER_SECOND)},
+                    },
+                ],
+            ),
+        ]
+        stats = accumulate_multimodal_content(messages, _config())
+        assert stats.audio_seconds == 1.0
+        assert stats.audio_tokens == 25
+
+    @pytest.mark.sanity
+    @pytest.mark.parametrize(
+        ("part", "match"),
+        [
+            ({"type": "ref_image"}, "Unsupported content part type"),
+            ({"text": "no type"}, "Unsupported content part type"),
+            ({"type": "text"}, "string 'text' field"),
+            ({"type": "text", "text": 5}, "string 'text' field"),
+            ({"type": "image_url"}, "string 'url' field"),
+            ({"type": "image_url", "image_url": "http://x/a.png"}, "string 'url'"),
+            ({"type": "image_url", "image_url": {"url": ""}}, "non-empty 'url'"),
+            ({"type": "video_url", "video_url": {}}, "string 'url' field"),
+            ({"type": "input_audio"}, "base64 string 'data' field"),
+            ({"type": "input_audio", "input_audio": {"data": ""}}, "non-empty"),
+            (
+                {"type": "input_audio", "input_audio": {"data": "@@not-base64@@"}},
+                "invalid base64",
+            ),
+            (
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": "AAAA", "format": 3},
+                },
+                "non-string 'format'",
+            ),
+        ],
+    )
+    def test_invalid_parts(self, part, match):
+        """Test malformed content parts raise InvalidContentPartError.
+
+        ## WRITTEN BY AI ##
+        """
+        messages = [ChatMessage(role="user", content=[part])]
+        with pytest.raises(InvalidContentPartError, match=match):
+            accumulate_multimodal_content(messages, _config())

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+import math
 import multiprocessing
 
 import httpx
@@ -691,6 +693,249 @@ class TestMockServerEndpoints:
             assert completed[0]["response"]["usage"] is not None
             assert "input_tokens" in completed[0]["response"]["usage"]
             assert "output_tokens" in completed[0]["response"]["usage"]
+
+    @pytest.mark.smoke
+    @pytest.mark.asyncio
+    async def test_chat_completions_multimodal_usage(self, mock_server_instance):
+        """Test multimodal chat content is accepted and accounted in usage.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, config = mock_server_instance
+
+        wav_seconds = 1.0
+        audio_b64 = base64.b64encode(b"\x00" * 32000).decode("utf-8")
+        payload = {
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe these inputs."},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "http://example.com/image.png"},
+                        },
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "http://example.com/clip.mp4"},
+                        },
+                        {
+                            "type": "input_audio",
+                            "input_audio": {"data": audio_b64, "format": "wav"},
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 5,
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/chat/completions", json=payload, timeout=10.0
+            )
+            assert response.status_code == 200
+
+            usage = response.json()["usage"]
+            details = usage["prompt_tokens_details"]
+            assert details["image_tokens"] == 2 * config.image_tokens
+            assert details["video_tokens"] == config.video_tokens
+            assert details["audio_tokens"] == math.ceil(
+                wav_seconds * config.audio_tokens_per_second
+            )
+            assert details["seconds"] == wav_seconds
+            assert usage["prompt_tokens"] == (
+                details["prompt_tokens"]
+                + details["image_tokens"]
+                + details["video_tokens"]
+                + details["audio_tokens"]
+            )
+            assert usage["total_tokens"] == (
+                usage["prompt_tokens"] + usage["completion_tokens"]
+            )
+
+    @pytest.mark.smoke
+    @pytest.mark.asyncio
+    async def test_chat_completions_text_only_no_details(self, mock_server_instance):
+        """Test text-only requests report no prompt_tokens_details breakdown.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, _ = mock_server_instance
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello!"}],
+            "max_tokens": 5,
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/chat/completions", json=payload, timeout=10.0
+            )
+            assert response.status_code == 200
+            assert response.json()["usage"]["prompt_tokens_details"] is None
+
+    @pytest.mark.smoke
+    @pytest.mark.asyncio
+    async def test_streaming_chat_completions_multimodal_usage(
+        self, mock_server_instance
+    ):
+        """Test streaming multimodal requests report usage with details.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, config = mock_server_instance
+
+        payload = {
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 5,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+
+        async with (
+            httpx.AsyncClient() as client,
+            client.stream(
+                "POST",
+                f"{server_url}/v1/chat/completions",
+                json=payload,
+                timeout=10.0,
+            ) as response,
+        ):
+            assert response.status_code == 200
+
+            usage_chunks = []
+            async for line in response.aiter_lines():
+                if not line or not line.startswith("data: "):
+                    continue
+                data_str = line[6:]
+                if data_str.strip() == "[DONE]":
+                    break
+                chunk = json.loads(data_str)
+                if chunk.get("usage"):
+                    usage_chunks.append(chunk["usage"])
+
+            assert len(usage_chunks) == 1
+            usage = usage_chunks[0]
+            details = usage["prompt_tokens_details"]
+            assert details["image_tokens"] == config.image_tokens
+            assert usage["prompt_tokens"] == (
+                details["prompt_tokens"] + details["image_tokens"]
+            )
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content_part",
+        [
+            {"type": "unknown_modality", "data": "x"},
+            {"type": "image_url", "image_url": {"url": ""}},
+            {"type": "image_url", "image_url": "http://example.com/image.png"},
+            {"type": "input_audio", "input_audio": {"data": "@@not-base64@@"}},
+            {"type": "video_url"},
+        ],
+    )
+    async def test_chat_completions_invalid_multimodal_part(
+        self, mock_server_instance, content_part
+    ):
+        """Test malformed multimodal content parts return HTTP 400.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, _ = mock_server_instance
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": [content_part]}],
+            "max_tokens": 5,
+        }
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/chat/completions", json=payload, timeout=10.0
+            )
+            assert response.status_code == 400
+            assert response.json()["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.smoke
+    @pytest.mark.asyncio
+    async def test_audio_transcriptions_endpoint(self, mock_server_instance):
+        """Test the audio transcriptions endpoint returns text and usage.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, config = mock_server_instance
+
+        wav_seconds = 2.0
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/audio/transcriptions",
+                files={"file": ("speech.wav", b"\x00" * 64000, "audio/wav")},
+                data={"model": "test-model"},
+                timeout=10.0,
+            )
+            assert response.status_code == 200
+
+            data = response.json()
+            assert data["text"] == "Mock transcription for speech.wav"
+            assert data["file_size"] == 64000
+            assert data["model_used"] == "test-model"
+
+            usage = data["usage"]
+            assert usage["prompt_tokens"] == math.ceil(
+                wav_seconds * config.audio_tokens_per_second
+            )
+            assert usage["seconds"] == wav_seconds
+            assert usage["completion_tokens"] > 0
+            assert usage["total_tokens"] == (
+                usage["prompt_tokens"] + usage["completion_tokens"]
+            )
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_audio_translations_endpoint(self, mock_server_instance):
+        """Test the audio translations endpoint serializes and reports usage.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, config = mock_server_instance
+
+        mp3_seconds = 1.0
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/audio/translations",
+                files={"file": ("speech.mp3", b"\x00" * 8000, "audio/mpeg")},
+                data={"model": "test-model"},
+                timeout=10.0,
+            )
+            assert response.status_code == 200
+
+            data = response.json()
+            assert data["text"]
+            assert data["filename"] == "speech.mp3"
+            assert data["model_used"] == "test-model"
+
+            usage = data["usage"]
+            assert usage["prompt_tokens"] == math.ceil(
+                mp3_seconds * config.audio_tokens_per_second
+            )
+            assert usage["seconds"] == mp3_seconds
+            assert usage["total_tokens"] == (
+                usage["prompt_tokens"] + usage["completion_tokens"]
+            )
 
     @pytest.mark.sanity
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

GuideLLM supports multimodal benchmarking, but the mock server ignored multimodal chat content: `image_url`, `video_url`, and `input_audio` parts contributed zero prompt tokens, malformed parts were silently dropped, and the audio endpoints returned no usage (the translations endpoint also failed to serialize its response due to a set literal). This PR implements multimodal mock interfaces so multimodal benchmarks run against the mock server with plausible per-modality usage accounting.

## Details

- [x] New `guidellm.mock_server.multimodal` module: validates the multimodal chat content part shapes GuideLLM's OpenAI backend produces (`image_url`, `video_url`, `input_audio`) and accumulates per-modality prompt token charges. Malformed parts (missing or non-string url, invalid base64 audio, unknown part type) return an OpenAI-style 400.
- [x] Configurable accounting heuristics on `MockServerConfig` (env and CLI): `image_tokens` (default 576, flat per image, 336px ViT-L/14), `video_tokens` (default 1024, flat per video), `audio_tokens_per_second` (default 25.0). Audio duration is estimated from payload size using the synthetic audio encoding defaults (PCM16 mono 16 kHz for WAV, 64 kbit/s for lossy).
- [x] Chat completions responses now include multimodal tokens in `usage.prompt_tokens` and report a vLLM-style `usage.prompt_tokens_details` breakdown (`prompt_tokens` for text, `image_tokens`, `video_tokens`, `audio_tokens`, `seconds`) in both non-streaming and streaming (`include_usage`) modes. These are the fields `ChatCompletionsRequestHandler.extract_metrics` parses into per-modality benchmark metrics. Text-only requests keep `prompt_tokens_details: null` so absent modalities do not record zero-valued metrics.
- [x] `/v1/audio/transcriptions` and `/v1/audio/translations` now return `usage` (`prompt_tokens` from the audio duration heuristic, which `AudioRequestHandler.extract_metrics` maps to `audio_tokens`), and the translations response `filename` field is fixed from a set literal `{file.name}` (unserializable) to the plain string.
- [x] Unit tests: new `tests/unit/mock_server/test_multimodal.py` covering accounting math, format heuristics, and validation errors; new HTTP-level tests in `tests/unit/mock_server/test_server.py` for non-streaming and streaming multimodal usage, 400s on malformed parts, and both audio endpoints.

Not included, possible follow-ups: multimodal accounting for `/v1/responses` (`input_image`, `input_file`) and a websocket `/v1/realtime` mock.

## Test Plan

All run locally on macOS arm64, Python 3.11, in the tox uv-lock env.

- Mock server unit tests (includes the 37 new tests): `pytest tests/unit/mock_server -q` -> `73 passed, 1 warning in 23.85s`
- Full unit suite `tox -e test-unit` on this branch: `14 failed, 2946 passed, 31 skipped, 163 xfailed, 1 warning in 147.87s`. The 14 failures are all `tests/unit/utils/test_audio.py` and are identical (diff of failure lists is empty) to a clean `main` baseline run in the same environment (`14 failed, 2909 passed, 31 skipped, 163 xfailed, 1 warning in 125.35s`), i.e. pre-existing local torchcodec/ffmpeg environment failures unrelated to this change. The passed count increases by exactly the 37 new tests.
- Integration, real synthetic image/video data pipeline against this mock server: `pytest tests/integration/data/test_synthetic_multimodal_benchmark.py -q` -> `2 passed, 1 warning in 45.33s`
- Lint: `ruff format --check` and `ruff check` on the changed paths pass (`All checks passed!`); `mdformat --check` passes.
- Types: `mypy --check-untyped-defs src/guidellm/mock_server/ src/guidellm/cli/mock_server.py` -> `Success: no issues found in 12 source files`

## Related Issues

- Fixes #582

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit 5408f1964da43e939334a8c519c27304e3d8d299
Author: Rishabh Sinha <rsinha17@terpmail.umd.edu>
Date:   Wed Aug 26 02:52:51 2026 -0700

    Add multimodal support to the mock server
    
    Extend the mock server to accept and account multimodal chat completion
    content (image_url, video_url, input_audio) per the request shapes the
    OpenAI-compatible backend produces:
    
    - Validate content part shapes and return OpenAI-style 400 errors for
      malformed parts instead of silently counting only text.
    - Charge prompt tokens per modality with configurable heuristics
      (image_tokens, video_tokens, audio_tokens_per_second config fields and
      CLI flags); audio duration is estimated from payload size using the
      synthetic audio encoding defaults (PCM16 mono 16 kHz WAV, 64 kbit/s
      lossy).
    - Report a vLLM-style usage.prompt_tokens_details breakdown (text
      prompt_tokens, image_tokens, video_tokens, audio_tokens, seconds) in
      non-streaming and streaming responses, matching what the benchmark
      response handlers parse into per-modality metrics.
    - Add usage statistics to the audio transcription and translation
      endpoints and fix a set literal in the translations response that
      failed JSON serialization.
    
    Fixes #582
    
    Generated-by: Claude Code claude-fable-5
    Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
    Signed-off-by: Rishabh Sinha <rsinha17@terpmail.umd.edu>

---------

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Generated-by: Claude Code claude-fable-5
Signed-off-by: Rishabh Sinha <rsinha17@terpmail.umd.edu>
