### PR TITLE
feat: add OrcaRouter HTTP backend

### DIFF
--- a/docs/guides/backends.md
+++ b/docs/guides/backends.md
@@ -36,6 +36,24 @@ GuideLLM supports running inference in the same process using the **vLLM Python 
 
 The **vLLM Python batch backend** (`vllm_python_batch`) uses vLLM's synchronous `LLM` engine for batch-oriented inference. Requests are queued and dispatched in configurable batches, removing per-request scheduling overhead. This is ideal for throughput benchmarking. For setup and examples, see [vLLM Python batch backend](vllm-python-batch-backend.md).
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that exposes a provider/model namespace across many models. GuideLLM supports it as a first-class backend (`orcarouter_http`), so you can benchmark through OrcaRouter without treating it as an anonymous custom base URL. It defaults to the `https://api.orcarouter.ai` endpoint and the `orcarouter/auto` model, which routes each request to the best provider for the workload:
+
+```bash
+guidellm run \
+  --backend kind=orcarouter_http,api_key=sk-orca-...,model=orcarouter/auto \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128
+```
+
+Or with JSON:
+
+```bash
+--backend '{"kind":"orcarouter_http","api_key":"sk-orca-...","model":"orcarouter/auto"}'
+```
+
+The backend accepts the same parameters as `openai_http` (`request_format`, `stream`, `timeout`, `extras`, and more).
+
 ## Examples for Spinning Up Compatible Servers
 
 ### 1. vLLM

--- a/src/guidellm/backends/__init__.py
+++ b/src/guidellm/backends/__init__.py
@@ -19,6 +19,7 @@ from .openai import (
     OpenAIWebSocketBackend,
     TextCompletionsRequestHandler,
 )
+from .orcarouter import OrcaRouterHTTPBackend
 from .vllm_python import (
     VLLMPythonAsyncBackend,
     VLLMPythonBatchBackend,
@@ -33,6 +34,7 @@ __all__ = [
     "OpenAIRequestHandler",
     "OpenAIRequestHandlerFactory",
     "OpenAIWebSocketBackend",
+    "OrcaRouterHTTPBackend",
     "TextCompletionsRequestHandler",
     "VLLMPythonAsyncBackend",
     "VLLMPythonBatchBackend",

--- a/src/guidellm/backends/orcarouter/__init__.py
+++ b/src/guidellm/backends/orcarouter/__init__.py
@@ -1,0 +1,7 @@
+"""OrcaRouter backend implementations for GuideLLM."""
+
+from guidellm.backends.orcarouter.http import OrcaRouterHTTPBackend
+
+__all__ = [
+    "OrcaRouterHTTPBackend",
+]

--- a/src/guidellm/backends/orcarouter/http.py
+++ b/src/guidellm/backends/orcarouter/http.py
@@ -1,0 +1,101 @@
+"""
+OrcaRouter HTTP backend implementation for GuideLLM.
+
+Provides an HTTP backend for the OrcaRouter API, an OpenAI-compatible AI
+gateway. Reuses the OpenAI-compatible request machinery while specializing
+the endpoint validation and default model behavior for OrcaRouter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from guidellm.backends.backend import Backend
+from guidellm.backends.openai.http import OpenAIHTTPBackend
+from guidellm.schemas.backends import OrcaRouterHTTPBackendArgs
+
+__all__ = [
+    "OrcaRouterHTTPBackend",
+]
+
+# Default model used when no model is explicitly configured. OrcaRouter routes
+# each request to the best provider for the workload, so this is a safe default.
+DEFAULT_ORCAROUTER_MODEL = "orcarouter/auto"
+
+
+@Backend.register("orcarouter_http")
+class OrcaRouterHTTPBackend(OpenAIHTTPBackend):
+    """
+    HTTP backend for the OrcaRouter API.
+
+    OrcaRouter is an OpenAI-compatible AI gateway that exposes a provider/model
+    namespace across many models, with adaptive routing and automatic failover.
+    This backend mirrors the ``openai_http`` backend but specializes validation
+    (OrcaRouter exposes no ``/health`` route) and defaults the model to
+    ``orcarouter/auto`` when none is configured.
+
+    Example:
+    ::
+        backend_args = OrcaRouterHTTPBackendArgs(
+            api_key="sk-orca-...",
+            model="orcarouter/auto",
+        )
+        backend = OrcaRouterHTTPBackend(backend_args)
+
+        await backend.process_startup()
+        async for response, request_info in backend.resolve(request, info):
+            process_response(response)
+        await backend.process_shutdown()
+    """
+
+    _args: OrcaRouterHTTPBackendArgs
+
+    def __init__(
+        self,
+        arguments: OrcaRouterHTTPBackendArgs,
+    ):
+        """
+        Initialize OrcaRouter HTTP backend with server configuration.
+
+        :param arguments: OrcaRouter backend arguments
+        """
+        super().__init__(arguments)
+
+    async def validate(self):
+        """
+        Validate backend connectivity against the OrcaRouter API.
+
+        Probes the ``/v1/models`` endpoint instead of ``/health`` because
+        OrcaRouter does not expose a health route.
+
+        :raises RuntimeError: If backend cannot connect or validate configuration
+        """
+        if self._async_client is None:
+            raise RuntimeError("Backend not started up for process.")
+
+        if not self._args.validate_backend:
+            return
+
+        try:
+            validate_kwargs: dict[str, Any] = {
+                "method": "GET",
+                "url": f"{self._args.target}/{self._args.api_routes['/v1/models']}",
+            }
+            existing_headers = validate_kwargs.get("headers")
+            built_headers = self._build_headers(existing_headers)
+            validate_kwargs["headers"] = built_headers
+            response = await self._async_client.request(**validate_kwargs)
+            response.raise_for_status()
+        except Exception as exc:
+            raise RuntimeError(
+                "Backend validation request failed. Could not connect to the "
+                "OrcaRouter API or validate the backend configuration."
+            ) from exc
+
+    async def default_model(self) -> str:
+        """
+        Get the default model for this backend.
+
+        :return: The configured model, or ``orcarouter/auto`` when none is set
+        """
+        return self._args.model or DEFAULT_ORCAROUTER_MODEL

--- a/src/guidellm/schemas/backends/__init__.py
+++ b/src/guidellm/schemas/backends/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from guidellm.schemas.backends.backend import BackendArgs
 from guidellm.schemas.backends.openai_http import OpenAIHTTPBackendArgs
 from guidellm.schemas.backends.openai_websocket import OpenAIWebSocketBackendArgs
+from guidellm.schemas.backends.orcarouter_http import OrcaRouterHTTPBackendArgs
 from guidellm.schemas.backends.vllm_python import VLLMPythonAsyncBackendArgs
 from guidellm.schemas.backends.vllm_python_batch import VLLMPythonBatchBackendArgs
 
@@ -14,6 +15,7 @@ __all__ = [
     "BackendArgs",
     "OpenAIHTTPBackendArgs",
     "OpenAIWebSocketBackendArgs",
+    "OrcaRouterHTTPBackendArgs",
     "VLLMPythonAsyncBackendArgs",
     "VLLMPythonBatchBackendArgs",
 ]

--- a/src/guidellm/schemas/backends/orcarouter_http.py
+++ b/src/guidellm/schemas/backends/orcarouter_http.py
@@ -1,0 +1,46 @@
+"""
+OrcaRouter HTTP backend Args schema.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, SecretStr
+
+from guidellm.schemas.backends.backend import BackendArgs
+from guidellm.schemas.backends.openai_http import OpenAIHTTPBackendArgs
+
+__all__ = ["OrcaRouterHTTPBackendArgs"]
+
+
+@BackendArgs.register("orcarouter_http")
+class OrcaRouterHTTPBackendArgs(OpenAIHTTPBackendArgs):
+    """
+    Pydantic model for OrcaRouter HTTP backend creation arguments.
+
+    OrcaRouter is an OpenAI-compatible AI gateway, so this schema extends the
+    ``openai_http`` backend arguments and specializes the default target and
+    model identifiers for the OrcaRouter API.
+    """
+
+    kind: Literal["orcarouter_http"] = Field(  # type: ignore[assignment]
+        default="orcarouter_http",
+        description="Type identifier for the backend configuration.",
+    )
+    target: str = Field(
+        default="https://api.orcarouter.ai",
+        description="Base URL of the OrcaRouter API",
+        examples=["https://api.orcarouter.ai"],
+    )
+    model: str = Field(
+        default_factory=str,
+        description="OrcaRouter model identifier, e.g. an 'orcarouter/*' or "
+        "provider-prefixed model",
+        examples=["orcarouter/auto", "anthropic/claude-sonnet-5"],
+    )
+    api_key: SecretStr | None = Field(
+        default=None,
+        description="HTTP Bearer token API key for authentication to OrcaRouter",
+        examples=["sk-orca-..."],
+    )

--- a/tests/unit/backends/orcarouter/test_http.py
+++ b/tests/unit/backends/orcarouter/test_http.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for OrcaRouterHTTPBackend implementation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from guidellm.backends.backend import Backend
+from guidellm.backends.orcarouter.http import (
+    DEFAULT_ORCAROUTER_MODEL,
+    OrcaRouterHTTPBackend,
+)
+from guidellm.schemas.backends import BackendArgs, OrcaRouterHTTPBackendArgs
+from tests.unit.testing_utils import async_timeout
+
+
+def _make_backend(**kwargs) -> OrcaRouterHTTPBackend:
+    """Create an OrcaRouterHTTPBackend from keyword arguments via BackendArgs."""
+    args = OrcaRouterHTTPBackendArgs(**kwargs)
+    return OrcaRouterHTTPBackend(args)
+
+
+class TestOrcaRouterHTTPBackend:
+    """Test cases for OrcaRouterHTTPBackend."""
+
+    @pytest.fixture
+    def valid_instances(self):
+        """Fixture providing valid OrcaRouterHTTPBackend instances."""
+        constructor_args = {"api_key": "sk-test"}
+        instance = _make_backend(**constructor_args)
+        return instance, constructor_args
+
+    @pytest.mark.smoke
+    def test_class_signatures(self):
+        """OrcaRouterHTTPBackend inherits Backend and exposes HTTP methods.
+
+        ### WRITTEN BY AI ###
+        """
+        assert issubclass(OrcaRouterHTTPBackend, Backend)
+        assert hasattr(OrcaRouterHTTPBackend, "process_startup")
+        assert hasattr(OrcaRouterHTTPBackend, "process_shutdown")
+        assert hasattr(OrcaRouterHTTPBackend, "validate")
+        assert hasattr(OrcaRouterHTTPBackend, "resolve")
+        assert hasattr(OrcaRouterHTTPBackend, "default_model")
+        assert hasattr(OrcaRouterHTTPBackend, "available_models")
+
+    @pytest.mark.smoke
+    def test_registered(self):
+        """orcarouter_http backend is registered and constructible.
+
+        ### WRITTEN BY AI ###
+        """
+        assert Backend.is_registered("orcarouter_http")
+        args = OrcaRouterHTTPBackendArgs()
+        backend = Backend.create(args)
+        assert isinstance(backend, OrcaRouterHTTPBackend)
+        assert backend.kind == "orcarouter_http"
+
+    @pytest.mark.smoke
+    def test_backend_args_registered(self):
+        """orcarouter_http args are registered with default target.
+
+        ### WRITTEN BY AI ###
+        """
+        assert BackendArgs.is_registered("orcarouter_http")
+        args = OrcaRouterHTTPBackendArgs()
+        assert args.kind == "orcarouter_http"
+        assert args.target == "https://api.orcarouter.ai"
+
+    @pytest.mark.smoke
+    def test_initialization(self, valid_instances):
+        """OrcaRouterHTTPBackend stores configuration on args.
+
+        ### WRITTEN BY AI ###
+        """
+        instance, _ = valid_instances
+        assert isinstance(instance, OrcaRouterHTTPBackend)
+        assert instance.kind == "orcarouter_http"
+        assert instance._args.target == "https://api.orcarouter.ai"
+
+    @pytest.mark.smoke
+    def test_target_stripped_of_v1(self):
+        """target values ending in /v1 are normalized.
+
+        ### WRITTEN BY AI ###
+        """
+        backend = _make_backend(target="https://api.orcarouter.ai/v1")
+        assert backend._args.target == "https://api.orcarouter.ai"
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_default_model(self):
+        """default_model returns configured model or orcarouter/auto.
+
+        ### WRITTEN BY AI ###
+        """
+        backend1 = _make_backend(model="anthropic/claude-sonnet-5")
+        assert await backend1.default_model() == "anthropic/claude-sonnet-5"
+
+        backend2 = _make_backend()
+        assert await backend2.default_model() == DEFAULT_ORCAROUTER_MODEL
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_validate_probes_models_endpoint(self, httpx_mock: HTTPXMock):
+        """validate probes /v1/models (not /health) on OrcaRouter.
+
+        ### WRITTEN BY AI ###
+        """
+        httpx_mock.add_response(
+            url="https://api.orcarouter.ai/v1/models",
+            method="GET",
+            json={"data": [{"id": "orcarouter/auto"}]},
+        )
+
+        backend = _make_backend()
+        await backend.process_startup()
+        await backend.validate()  # Should not raise
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_validate_disabled(self):
+        """validate is a no-op when validate_backend is False.
+
+        ### WRITTEN BY AI ###
+        """
+        backend = _make_backend(validate_backend=False)
+        await backend.process_startup()
+        await backend.validate()  # Should not raise
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_validate_not_in_process(self):
+        """validate raises when backend is not started.
+
+        ### WRITTEN BY AI ###
+        """
+        backend = _make_backend()
+        with pytest.raises(RuntimeError, match="Backend not started up"):
+            await backend.validate()
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_validate_failure(self):
+        """validate raises RuntimeError on failed validation request.
+
+        ### WRITTEN BY AI ###
+        """
+        backend = _make_backend()
+        await backend.process_startup()
+
+        def mock_fail(*args, **kwargs):
+            raise httpx.HTTPStatusError("Error", request=Mock(), response=Mock())
+
+        with (
+            patch.object(backend._async_client, "request", side_effect=mock_fail),
+            pytest.raises(RuntimeError, match="Backend validation request failed"),
+        ):
+            await backend.validate()
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(10.0)
+    async def test_available_models(self, httpx_mock: HTTPXMock):
+        """available_models lists models from the OrcaRouter API.
+
+        ### WRITTEN BY AI ###
+        """
+        httpx_mock.add_response(
+            url="https://api.orcarouter.ai/v1/models",
+            json={"data": [{"id": "orcarouter/auto"}, {"id": "orcarouter/fusion"}]},
+        )
+
+        backend = _make_backend()
+        await backend.process_startup()
+        models = await backend.available_models()
+        assert models == ["orcarouter/auto", "orcarouter/fusion"]


### PR DESCRIPTION
## Summary

GuideLLM lets teams benchmark real-world LLM workloads against OpenAI-compatible endpoints — but until now, benchmarking a hosted gateway meant treating it as an anonymous custom `openai_http` base URL. This PR adds **orcarouter_http** as a first-class backend, mirroring how GuideLLM already treats OpenAI-compatible HTTP servers, so users of the platform can point a benchmark at [OrcaRouter](https://www.orcarouter.ai) directly and get the gateway's full provider/model namespace out of the box.

## Details

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:

- New `orcarouter_http` backend kind registered in the `Backend` registry, mirroring the existing `openai_http` implementation (`src/guidellm/backends/orcarouter/http.py`).
- New `OrcaRouterHTTPBackendArgs` schema that extends `OpenAIHTTPBackendArgs`, defaulting `target` to `https://api.orcarouter.ai` and documenting `orcarouter/*` and provider-prefixed model identifiers (`src/guidellm/schemas/backends/orcarouter_http.py`).
- Specialized connectivity validation: OrcaRouter exposes no `/health` route, so `validate()` probes the `/v1/models` endpoint instead.
- Default model of `orcarouter/auto` when none is configured — OrcaRouter routes each request to the best provider for the workload.
- Re-exports from `guidellm.backends` and `guidellm.schemas.backends`, plus unit tests and a docs entry in `docs/guides/backends.md`.

## Test Plan

- `ruff check`, `ruff format --check`, and `mypy` pass on all changed files.
- All backend unit tests pass (`tests/unit/backends`, 516 tests), including 11 new tests for `orcarouter_http`.
- Import-linter contracts pass (`lint-imports`).
- Live-tested against the OrcaRouter API using a real key: `Backend.create` → `process_startup` → `validate` (200 on `/v1/models`) → `resolve` returned a chat completion from `orcarouter/auto`.

```bash
guidellm run \
  --backend kind=orcarouter_http,api_key=sk-orca-...,model=orcarouter/auto \
  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128
```

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit e95d4c26d0e74238fdbd16bcc5eec7251d4f6fe3
Author: nissrin2020ali-ux <nissrin2020ali-ux@users.noreply.github.com>
Date:   Mon Aug 31 13:02:51 2026 +0000

    feat: add OrcaRouter HTTP backend
    
    Add a first-class `orcarouter_http` backend that mirrors the existing
    `openai_http` backend and targets the OrcaRouter API, an OpenAI-compatible
    AI gateway. OrcaRouter exposes a provider/model namespace across many models
    with adaptive routing and automatic failover, so users can benchmark through
    it directly instead of configuring an anonymous custom base URL.
    
    The backend reuses the OpenAI-compatible request machinery, specializes the
    validation probe to the `/v1/models` endpoint (OrcaRouter has no `/health`
    route), and defaults the model to `orcarouter/auto` when none is configured.
    Documentation and unit tests are included.
    
    Generated-by: Claude
    Signed-off-by: nissrin2020ali-ux <nissrin2020ali-ux@users.noreply.github.com>

---------

Generated-by: Claude
Signed-off-by: nissrin2020ali-ux <nissrin2020ali-ux@users.noreply.github.com>
