### PR TITLE
WEKA Subagent Support + Tool Calls

### DIFF
--- a/docs/guides/tool_calling.md
+++ b/docs/guides/tool_calling.md
@@ -144,7 +144,19 @@ guidellm run \
 
 The `tool_response_tokens_stdev`, `tool_response_tokens_min`, and `tool_response_tokens_max` fields work identically to the corresponding `prompt_tokens_*` / `output_tokens_*` variance parameters.
 
-**2. Datasets with a tools column** -- datasets that already contain tool definitions (e.g. `madroid/glaive-function-calling-openai`) work directly. The column mapper auto-detects columns named `tools`, `functions`, or `tool_definitions`:
+**2. WEKA traces** -- tool-call turns come from the file (`stop` / `input_types`), but schemas do not. Pass `tools` and optionally `tool_response_tokens` on `--data kind=weka` the same way as synthetic data. Which turns call tools is not configurable; `tool_call_turns` does not apply.
+
+```bash
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000 \
+  --profile kind=replay \
+  --data '{"kind":"weka","path":"trace.jsonl","tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}],"tool_response_tokens":50}' \
+  --constraint kind=max_requests,count=30
+```
+
+When `tools` is omitted, the same built-in placeholder tool as synthetic data is used.
+
+**3. Datasets with a tools column** -- datasets that already contain tool definitions (e.g. `madroid/glaive-function-calling-openai`) work directly. The column mapper auto-detects columns named `tools`, `functions`, or `tool_definitions`:
 
 ```bash
 guidellm run \

--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -50,13 +50,19 @@ The Mooncake format expects an additional column for prefix-based cache hash IDs
 
 ### `weka`
 
-**NOTE:** :construction: While the format is accepted, some features such as subagent conversations, tool call events and non-linear histories are still in active development. The results from datasets including these features will be unreliable.
+**NOTE:** Tool-call events (`stop: tool_use`), warm `tool_tokens`/`system_tokens` prefixes, and hash-id LCP splitting of flattened agents are not implemented. Declared `type: "subagent"` groups are replayed.
 
 The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must all be wrapped inside one JSON column (ex. "requests"), in the form of a list of JSON objects.
 
 Similar to Mooncake, WEKA uses prefix-based cache hash IDs. The original [specification](https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md) for the trace requires hash IDs to be 1 or greater, and for trailing hash IDs to be dropped if there are not enough input tokens to fill the hash ID block size. To accommodate for datasets which may not follow the specification exactly (ex. [semianalysisai/cc-traces-weka-no-subagents-051226](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-no-subagents-051226)), GuideLLM will accept any non-negative integer as a valid hash ID, and will drop partially filled hash IDs if they exist.
 
 GuideLLM will generate prompts starting from the first conversation. When the conversation ends, the next conversation will be used. Hash IDs and relative timestamps are local to the conversation. After a conversation ends, the hash ID tree is reset and the relative timestamp returns to 0.0.
+
+Declared `type: "subagent"` entries become isolated child chains. Each child spawns from the preceding parent API turn with a fresh history (`history_context="new"`) and the following parent turn waits for every sibling spawned since that turn (`history_context="last"`). Multiple subagents listed between the same parent turns therefore run in parallel; the parent resumes only after all of them complete. Outer `requests` order is preserved (it is the spawn/join topology) and is not sorted by timestamp.
+
+Inner request timestamps follow the spec when they are relative to spawn, and published Hugging Face corpora when they are already absolute: if the first inner `t` is less than the subagent entry's spawn `t`, inner times are treated as `spawn_t + inner_t`; otherwise they are left as-is. Conversation-relative timestamps are then `absolute_t - min_t` across all API requests in that conversation.
+
+A single agent's consecutive turns are still serialized. If those turns overlap in time (`t[i] + api_time[i] > t[i+1]`, or `t[i+1] <= t[i]` when `api_time` is absent), GuideLLM logs a debug message. Overlap between different subagents is intended parallelism and is not warned.
 
 | Argument                 | Default    | Description                                          |
 | ------------------------ | ---------- | ---------------------------------------------------- |

--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -50,7 +50,7 @@ The Mooncake format expects an additional column for prefix-based cache hash IDs
 
 ### `weka`
 
-**NOTE:** Tool-call events (`stop: tool_use`), warm `tool_tokens`/`system_tokens` prefixes, and hash-id LCP splitting of flattened agents are not implemented. Declared `type: "subagent"` groups are replayed.
+**NOTE:** Warm `tool_tokens`/`system_tokens` prefixes and hash-id LCP splitting of flattened agents are not implemented. Declared `type: "subagent"` groups and tool-call events (`stop: tool_use`, `input_types: ["tool_result"]`) are replayed.
 
 The WEKA format expects a column with conversation UUIDs that is not wrapped within another column. The timestamp, input token length, output token length and hash IDs columns must all be wrapped inside one JSON column (ex. "requests"), in the form of a list of JSON objects.
 
@@ -58,17 +58,24 @@ Similar to Mooncake, WEKA uses prefix-based cache hash IDs. The original [specif
 
 GuideLLM will generate prompts starting from the first conversation. When the conversation ends, the next conversation will be used. Hash IDs and relative timestamps are local to the conversation. After a conversation ends, the hash ID tree is reset and the relative timestamp returns to 0.0.
 
-Declared `type: "subagent"` entries become isolated child chains. Each child spawns from the preceding parent API turn with a fresh history (`history_context="new"`) and the following parent turn waits for every sibling spawned since that turn (`history_context="last"`). Multiple subagents listed between the same parent turns therefore run in parallel; the parent resumes only after all of them complete. Outer `requests` order is preserved (it is the spawn/join topology) and is not sorted by timestamp.
+Declared `type: "subagent"` entries become isolated child chains. Each child spawns from the preceding parent API turn with a fresh history (`history_context="new"`) and the following parent turn waits for every sibling spawned since that turn (`history_context="last"`). Multiple subagents listed between the same parent turns therefore run in parallel; the parent resumes only after all of them complete. Request-list order is preserved at every nesting level (it is the spawn/join topology) and is not sorted by timestamp.
 
 Inner request timestamps follow the spec when they are relative to spawn, and published Hugging Face corpora when they are already absolute: if the first inner `t` is less than the subagent entry's spawn `t`, inner times are treated as `spawn_t + inner_t`; otherwise they are left as-is. Conversation-relative timestamps are then `absolute_t - min_t` across all API requests in that conversation.
 
 A single agent's consecutive turns are still serialized. If those turns overlap in time (`t[i] + api_time[i] > t[i+1]`, or `t[i+1] <= t[i]` when `api_time` is absent), GuideLLM logs a debug message. Overlap between different subagents is intended parallelism and is not warned.
 
-| Argument                 | Default    | Description                                          |
-| ------------------------ | ---------- | ---------------------------------------------------- |
-| `conversation_id_column` | "id"       | Column name for conversation UUIDs in the trace file |
-| `hash_ids_column`        | "hash_ids" | Column name for lists of hash IDs in the trace file  |
-| `hash_id_block_size`     | 64         | Amount of tokens represented by one hash ID          |
+Tool-call events map onto GuideLLM's existing client tool-call pipeline. A request with `stop: "tool_use"` and user text input becomes a `client_tool_call` turn. The following request with `input_types: ["tool_result"]` (or, if `input_types` is absent, the next request after `stop: "tool_use"` on the same agent chain) becomes a `tool_response_injection`. When that injection row also has `stop: "tool_use"`, it still sends tool results and keeps `tools` so the model may emit further tool calls. Traces do not contain real tool schemas or results. Pass `tools` and optionally `tool_response_tokens` the same way as [synthetic data](tool_calling.md#providing-tool-definitions); otherwise GuideLLM uses the default synthetic tool definition and placeholder tool response. Chat handlers do not send the hash-id prompt as a user message on injection turns.
+
+| Argument                     | Default    | Description                                                                                           |
+| ---------------------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
+| `conversation_id_column`     | "id"       | Column name for conversation UUIDs in the trace file                                                  |
+| `hash_ids_column`            | "hash_ids" | Column name for lists of hash IDs in the trace file                                                   |
+| `hash_id_block_size`         | 64         | Amount of tokens represented by one hash ID                                                           |
+| `tools`                      | `None`     | OpenAI-format tool definitions for tool-call turns. When unset, the built-in placeholder tool is used |
+| `tool_response_tokens`       | `None`     | Average tokens for mocked tool results. When unset, a short placeholder (`{"status": "ok"}`) is used  |
+| `tool_response_tokens_stdev` | `None`     | Standard deviation for tool response token count                                                      |
+| `tool_response_tokens_min`   | `None`     | Minimum number of tokens for tool response                                                            |
+| `tool_response_tokens_max`   | `None`     | Maximum number of tokens for tool response                                                            |
 
 Modified defaults:
 

--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -440,6 +440,37 @@ def _compile_streaming_response(
 _FUNCTION_DETAIL_KEYS = ("name", "description", "parameters", "strict")
 
 
+def _constrain_tool_call_body(
+    body: dict[str, Any],
+    data: GenerationRequest,
+    *token_limit_keys: str,
+) -> None:
+    """Set tool_choice and drop sampling keys that break constrained tool decoding.
+
+    Tools must already be present in ``body``. An injection that also carries
+    ``tools_column`` is a multi-step loop: keep ``tool_choice=required`` and
+    drop the same sampling keys as ``client_tool_call``. ``token_limit_keys``
+    are API-specific caps such as ``max_completion_tokens``.
+    """
+    if "tools" not in body:
+        body.pop("tool_choice", None)
+        return
+
+    injection_requests_tools = data.turn_type == "tool_response_injection" and bool(
+        data.columns.get("tools_column")
+    )
+    if data.turn_type == "standard" or (
+        data.turn_type == "tool_response_injection" and not injection_requests_tools
+    ):
+        body["tool_choice"] = "none"
+
+    if data.turn_type == "client_tool_call" or injection_requests_tools:
+        body.pop("ignore_eos", None)
+        body.pop("stop", None)
+        for key in token_limit_keys:
+            body.pop(key, None)
+
+
 @OpenAIRequestHandlerFactory.register("/v1/completions")
 class TextCompletionsRequestHandler(OpenAIRequestHandler):
     """
@@ -880,23 +911,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
                 ]
                 body.setdefault("tool_choice", "required")
 
-        if "tools" not in body:
-            body.pop("tool_choice", None)
-            return
-
-        # Standard and injection turns should not produce tool calls even
-        # when tool definitions are in the body (e.g. from extras).
-        if data.turn_type in ("standard", "tool_response_injection"):
-            body["tool_choice"] = "none"
-
-        # Tool calling requires the model to stop naturally after producing
-        # valid JSON; ignore_eos would force generation past that point and
-        # break the server's constrained decoding grammar.
-        # max_completion_tokens would truncate output mid-JSON and corrupt
-        # the arguments sent in conversation history on follow-up turns.
-        if data.turn_type == "client_tool_call":
-            body.pop("ignore_eos", None)
-            body.pop("stop", None)
+        _constrain_tool_call_body(body, data, "max_completion_tokens")
 
     def _build_history_messages(
         self,
@@ -1800,21 +1815,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
                 ]
                 body.setdefault("tool_choice", "required")
 
-        if "tools" not in body:
-            body.pop("tool_choice", None)
-            return
-
-        if data.turn_type in ("standard", "tool_response_injection"):
-            body["tool_choice"] = "none"
-
-        # Tool calling requires the model to stop naturally after producing
-        # valid JSON; ignore_eos would force generation past that point.
-        # max_output_tokens would truncate output mid-JSON and corrupt
-        # the arguments sent in conversation history on follow-up turns.
-        if data.turn_type == "client_tool_call":
-            body.pop("ignore_eos", None)
-            body.pop("stop", None)
-            body.pop("max_output_tokens", None)
+        _constrain_tool_call_body(body, data, "max_output_tokens")
 
     def format(  # noqa: C901
         self,

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -126,6 +126,8 @@ def create_distinct_token_block(
 
 
 class TraceFormatBase(Protocol):
+    config: TraceDataArgs
+
     def __init__(self, config, dataset: Dataset) -> None: ...
 
     def __iter__(self) -> Iterable[Dataset]:
@@ -144,11 +146,73 @@ class TraceFormatBase(Protocol):
         """Called during initialization, immediately after doing
         format-agnostic validation."""
 
+    def validate_conversation(self, conversation: Dataset) -> None:
+        """Validate one conversation yielded by ``__iter__``.
+
+        The default treats every row as an API request with timestamp and
+        token-count columns. Formats with mixed row types (for example WEKA
+        subagent groups) should override this.
+        """
+        features = Features(
+            {
+                self.config.timestamp_column: Value("float"),
+                self.config.prompt_tokens_column: Value("int32"),
+                self.config.output_tokens_column: Value("int32"),
+                **dict(self.required_columns()),
+            }
+        )
+        if self.config.conversation_id_column in features:
+            features.pop(self.config.conversation_id_column)
+        _raise_if_nonetype_found(conversation, features)
+        _raise_if_incorrect_types(conversation, features)
+        for row in conversation:
+            _validate_row(row, self.config)
+            self.validate_row(row)
+
     def create_prompt(
         self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
     ) -> str:
         """Called within `trace_common.TraceExamplesIterable` on each iteration.
         Returns a generated synthetic prompt."""
+
+    def build_conversation_graph(
+        self,
+        conversation: Dataset,
+        processor: PreTrainedTokenizerBase,
+        faker: Faker,
+    ) -> ConversationGraphData:
+        """Build a conversation graph from one ``__iter__`` conversation.
+
+        The default emits a linear ``main_*`` chain. Formats with branches
+        or subagents should override this rather than branching in the
+        shared iterable.
+        """
+        start_ts = conversation[0][self.config.timestamp_column]
+        turns = []
+        for turn_idx, turn in enumerate(conversation):
+            parents = []
+            if turn_idx > 0:
+                parents.append(
+                    ConversationParentRef(parent_node_id=f"main_{turn_idx - 1}")
+                )
+
+            prompt = self.create_prompt(turn, processor, faker)
+            relative_timestamp = turn[self.config.timestamp_column] - start_ts
+            columns = {
+                "text_column": [prompt],
+                "prompt_tokens_count_column": [turn[self.config.prompt_tokens_column]],
+                "output_tokens_count_column": [turn[self.config.output_tokens_column]],
+                "relative_timestamp_column": [relative_timestamp],
+            }
+            turns.append(
+                ConversationTurnData(
+                    node_id=f"main_{turn_idx}",
+                    agent_id="default",
+                    parents=parents,
+                    columns=columns,
+                )
+            )
+        return ConversationGraphData(turns=turns)
 
 
 class TraceFormatRegistry(RegistryMixin[type[TraceFormatBase]]):
@@ -192,53 +256,21 @@ class TraceExamplesIterable(_BaseExamplesIterable):
             time_scale=self.config.time_scale,
         )
         for conv in self.format:  # type: ignore[attr-defined]
-            start_ts = conv[0][self.config.timestamp_column]
-            row = self._create_conversation_row(conv, start_ts, timing)
-            samples_count += len(conv)
-            yield samples_count, row
+            graph_data = self.format.build_conversation_graph(
+                conv, self.processor, self.faker
+            )
+            timing.apply(graph_data)
+            samples_count += len(graph_data.turns)
+            payload = json.dumps(graph_data.model_dump(mode="json"))
+            yield (
+                samples_count,
+                {
+                    "conversation_turns": (
+                        payload.decode() if isinstance(payload, bytes) else payload
+                    )
+                },
+            )
             self.format.reset()
-
-    def _create_conversation_row(
-        self,
-        conversation: Dataset,
-        start_ts: float,
-        timing: TraceSessionTiming,
-    ) -> dict[str, Any]:
-        """Build a ``conversation_turns`` payload for linear or branched graphs."""
-        turns = []
-        for turn_idx, turn in enumerate(conversation):
-            parents = []
-            if turn_idx > 0:
-                parents.append(
-                    ConversationParentRef(parent_node_id=f"main_{turn_idx - 1}")
-                )
-
-            # TODO: Branches & subagents
-
-            prompt = self.format.create_prompt(turn, self.processor, self.faker)
-            relative_timestamp = turn[self.config.timestamp_column] - start_ts
-            columns = {
-                "text_column": [prompt],
-                "prompt_tokens_count_column": [turn[self.config.prompt_tokens_column]],
-                "output_tokens_count_column": [turn[self.config.output_tokens_column]],
-                "relative_timestamp_column": [relative_timestamp],
-            }
-            turns.append(
-                ConversationTurnData(
-                    node_id=f"main_{turn_idx}",
-                    agent_id="default",
-                    parents=parents,
-                    columns=columns,
-                )
-            )
-        graph_data = ConversationGraphData(turns=turns)
-        timing.apply(graph_data)
-        payload = json.dumps(graph_data.model_dump(mode="json"))
-        return {
-            "conversation_turns": (
-                payload.decode() if isinstance(payload, bytes) else payload
-            )
-        }
 
     @property
     def is_typed(self) -> bool:
@@ -341,25 +373,11 @@ def _raise_if_incorrect_types(dataset: Dataset, features: Features) -> None:
         raise DataNotSupportedError(str(e)) from e
 
 
-def _validate_dataset(config: TraceDataArgs, trace_format: TraceFormatBase) -> None:
-    features = Features(
-        {
-            config.timestamp_column: Value("float"),
-            config.prompt_tokens_column: Value("int32"),
-            config.output_tokens_column: Value("int32"),
-            **dict(trace_format.required_columns()),
-        }
-    )
+def _validate_dataset(trace_format: TraceFormatBase) -> None:
     for conv in trace_format:  # type: ignore[attr-defined]
         if len(conv) == 0:
             raise DataNotSupportedError("Trace conversation is empty")
-        if config.conversation_id_column in features:
-            features.pop(config.conversation_id_column)
-        _raise_if_nonetype_found(conv, features)
-        _raise_if_incorrect_types(conv, features)
-        for row in conv:
-            _validate_row(row, config)
-            trace_format.validate_row(row)
+        trace_format.validate_conversation(conv)
 
 
 def _handle_column_search(config: TraceDataArgs, trace_format: TraceFormatBase) -> None:
@@ -423,5 +441,5 @@ class TraceDatasetDeserializer(DatasetDeserializer):
         dataset = dataset.map(_deserialize_nested_data, batched=True)
         trace_format = TraceFormatRegistry.dispatch(config, dataset)
         _handle_column_search(config, trace_format)
-        _validate_dataset(config, trace_format)
+        _validate_dataset(trace_format)
         return TraceDataset(config, trace_format, processor_factory(), random_seed)

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -153,21 +153,12 @@ class TraceFormatBase(Protocol):
         token-count columns. Formats with mixed row types (for example WEKA
         subagent groups) should override this.
         """
-        features = Features(
-            {
-                self.config.timestamp_column: Value("float"),
-                self.config.prompt_tokens_column: Value("int32"),
-                self.config.output_tokens_column: Value("int32"),
-                **dict(self.required_columns()),
-            }
+        _validate_api_conversation(
+            conversation,
+            self.config,
+            self.required_columns(),
+            self.validate_row,
         )
-        if self.config.conversation_id_column in features:
-            features.pop(self.config.conversation_id_column)
-        _raise_if_nonetype_found(conversation, features)
-        _raise_if_incorrect_types(conversation, features)
-        for row in conversation:
-            _validate_row(row, self.config)
-            self.validate_row(row)
 
     def create_prompt(
         self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
@@ -348,6 +339,35 @@ def _validate_path(path: Path) -> None:
         raise DataNotSupportedError(f"Trace path is not a file: {path}")
     if path.stat().st_size == 0:
         raise DataNotSupportedError(f"Trace file is empty: {path}")
+
+
+def _validate_api_conversation(
+    conversation: Dataset,
+    config: TraceDataArgs,
+    extra_features: Features,
+    validate_row: Callable[[dict], None],
+) -> None:
+    """Null-check and cast required API columns, then run per-row validators.
+
+    Extra columns are ignored. ``extra_features`` are format-specific required
+    fields such as hash IDs. Conversation id is dropped; it lives on the outer
+    record, not on API rows.
+    """
+    features = Features(
+        {
+            config.timestamp_column: Value("float"),
+            config.prompt_tokens_column: Value("int32"),
+            config.output_tokens_column: Value("int32"),
+            **dict(extra_features),
+        }
+    )
+    if config.conversation_id_column in features:
+        features.pop(config.conversation_id_column)
+    _raise_if_nonetype_found(conversation, features)
+    _raise_if_incorrect_types(conversation, features)
+    for row in conversation:
+        _validate_row(row, config)
+        validate_row(row)
 
 
 def _validate_row(row: dict, config: TraceDataArgs) -> None:

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -11,13 +11,15 @@ When the conversation ends, the next conversation will be used.
 
 Declared ``type: "subagent"`` groups are replayed as isolated child
 chains that spawn from the preceding parent turn and join the following
-parent turn. Tool call events (``stop: tool_use``) are still missing.
+parent turn. ``stop: tool_use`` and ``input_types: tool_result`` map
+onto the existing client tool-call columns (``turn_type``, ``tools``,
+``tool_response``).
 """
 
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -33,8 +35,7 @@ from guidellm.data.deserializers.trace_common import (
     TraceDatasetDeserializer,
     TraceFormatBase,
     TraceFormatRegistry,
-    _raise_if_incorrect_types,
-    _raise_if_nonetype_found,
+    _validate_api_conversation,
     create_distinct_token_block,
     create_prompt_from_hash_ids,
     decode_prompt,
@@ -48,7 +49,14 @@ from guidellm.data.schemas.conversation_graph_data import (
 )
 from guidellm.logger import logger
 from guidellm.scheduler.schemas import HistoryContext
-from guidellm.schemas.data.deserializers import WEKATraceFormatArgs
+from guidellm.schemas import TurnType
+from guidellm.schemas.data.deserializers import (
+    DEFAULT_SYNTHETIC_TOOLS,
+    WEKATraceFormatArgs,
+)
+from guidellm.settings import settings
+from guidellm.utils.imports import json
+from guidellm.utils.random import IntegerRangeSampler
 
 __all__ = ["WEKATraceFormat"]
 
@@ -131,6 +139,53 @@ def _copy_api_row(row: dict[str, Any], hash_ids_column: str) -> dict[str, Any]:
     return copied
 
 
+def _weka_stop_reason(row: dict[str, Any]) -> str:
+    stop = row.get("stop")
+    return stop if isinstance(stop, str) else ""
+
+
+def _weka_input_types(row: dict[str, Any]) -> list[Any]:
+    raw = row.get("input_types")
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _serialized_tools(tools: list[dict[str, Any]] | None) -> str:
+    raw = json.dumps(tools or DEFAULT_SYNTHETIC_TOOLS)
+    return raw.decode() if isinstance(raw, bytes) else raw
+
+
+def _classify_weka_tool_turn(
+    row: dict[str, Any], prev_stop: str | None
+) -> tuple[TurnType | None, bool, bool]:
+    """Map a WEKA API row onto GuideLLM tool-call columns.
+
+    Each row is one HTTP request. ``stop`` is the model output; ``input_types``
+    is what the client added. A ``tool_result`` row is therefore an injection
+    for the previous row's tool calls, even when that same row also has
+    ``stop: tool_use`` (Claude Code multi-step loop). ``tools_column`` on an
+    injection only changes the expected output (``tool_choice=required``).
+
+    When ``input_types`` is absent, a row after ``stop: tool_use`` on the same
+    agent chain is treated as ``tool_result``. Explicit ``input_types: ["text"]``
+    is not.
+
+    :return: ``(turn_type, include_tools, include_tool_response)``. ``turn_type``
+        is ``None`` for ordinary text turns.
+    """
+    input_types = _weka_input_types(row)
+    stop = _weka_stop_reason(row)
+    is_tool_call = stop == "tool_use"
+    is_tool_result = "tool_result" in input_types
+    if not is_tool_result and not input_types and prev_stop == "tool_use":
+        is_tool_result = True
+
+    if is_tool_result:
+        return "tool_response_injection", is_tool_call, True
+    if is_tool_call:
+        return "client_tool_call", True, False
+    return None, False, False
+
+
 @dataclass
 class _TurnSpec:
     node_id: str
@@ -138,6 +193,9 @@ class _TurnSpec:
     parents: list[ConversationParentRef]
     row: dict[str, Any]
     absolute_t: float
+    turn_type: TurnType | None = None
+    include_tools: bool = False
+    include_tool_response: bool = False
 
 
 DatasetDeserializerFactory.register_decorator(TraceDatasetDeserializer, "weka")
@@ -160,6 +218,14 @@ class WEKATraceFormat(TraceFormatBase):
     subagents between the same parent turns run in parallel; the following
     parent waits for all of them.
 
+    ``stop: "tool_use"`` and ``input_types: ["tool_result"]`` map onto the
+    existing client tool-call pipeline. Tool schemas and results are not in
+    the trace (anonymized); pass ``tools`` / ``tool_response_tokens`` like
+    synthetic data, or the default placeholder schema and response are used.
+    A ``tool_result`` row that also has ``stop: "tool_use"`` is still an
+    injection on the input side and carries ``tools_column`` so the model
+    may emit further tool calls.
+
     For more details, see [the WEKA trace format specification][trace-spec].
 
     [trace-spec]: https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md
@@ -175,6 +241,8 @@ class WEKATraceFormat(TraceFormatBase):
         # Filled by each ``__iter__`` pass so mixed subagent/API schemas are
         # not forced through a single HuggingFace Arrow table.
         self._conversation_queue: list[tuple[str, list[dict[str, Any]]]] = []
+        self._tools_json = _serialized_tools(config.tools)
+        self._tool_response_sampler: Iterator[int] | None = None
         self.requests_col = _find_requests_column(dataset)
         if self.requests_col is None:
             raise DataNotSupportedError(
@@ -185,8 +253,8 @@ class WEKATraceFormat(TraceFormatBase):
         self._conversation_queue = []
         for row in self.dataset:
             conv_id = str(row[self.config.conversation_id_column])
-            # Preserve file order: outer request order is the spawn/join
-            # topology. Do not sort by timestamp.
+            # File order is spawn/join topology for every request list,
+            # including nested subagent groups. Do not sort by timestamp.
             requests = [dict(item) for item in row[self.requests_col]]
             index = len(self._conversation_queue)
             self._conversation_queue.append((conv_id, requests))
@@ -205,7 +273,8 @@ class WEKATraceFormat(TraceFormatBase):
         )
 
     def find_required_columns(self, columns: list[str]) -> list[str]:
-        """TODO: Handle edge cases"""
+        # Only the first API row is searchable here. Missing fields on later
+        # conversations are rejected in validate_conversation.
         conv_col = self.config.conversation_id_column
         if conv_col not in self.dataset.column_names:
             return [self.config.conversation_id_column]
@@ -242,26 +311,12 @@ class WEKATraceFormat(TraceFormatBase):
             raise DataNotSupportedError(
                 "WEKA format: conversation has no API requests to replay"
             )
-        features = Features(
-            {
-                self.config.timestamp_column: Value("float"),
-                self.config.prompt_tokens_column: Value("int32"),
-                self.config.output_tokens_column: Value("int32"),
-                self.config.hash_ids_column: List(Value("int32")),
-            }
+        _validate_api_conversation(
+            Dataset.from_list(api_rows),
+            self.config,
+            self.required_columns(),
+            self.validate_row,
         )
-        api_dataset = Dataset.from_list(api_rows)
-        _raise_if_nonetype_found(api_dataset, features)
-        _raise_if_incorrect_types(api_dataset, features)
-        for row in api_rows:
-            n_in = row[self.config.prompt_tokens_column]
-            n_out = row[self.config.output_tokens_column]
-            if n_in < 0 or n_out < 0:
-                raise DataNotSupportedError(
-                    f"Trace token counts must be non-negative, got "
-                    f"input_length={n_in}, output_length={n_out}"
-                )
-            self.validate_row(row)
 
     def create_prompt(
         self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
@@ -322,7 +377,7 @@ class WEKATraceFormat(TraceFormatBase):
         turns: list[ConversationTurnData] = []
         for spec in specs:
             prompt = self.create_prompt(spec.row, processor, faker)
-            columns = {
+            columns: dict[str, Any] = {
                 "text_column": [prompt],
                 "prompt_tokens_count_column": [
                     spec.row[self.config.prompt_tokens_column]
@@ -332,6 +387,14 @@ class WEKATraceFormat(TraceFormatBase):
                 ],
                 "relative_timestamp_column": [spec.absolute_t - min_t],
             }
+            if spec.turn_type is not None:
+                columns["turn_type_column"] = [spec.turn_type]
+            if spec.include_tools:
+                columns["tools_column"] = [self._tools_json]
+            if spec.include_tool_response:
+                columns["tool_response_column"] = [
+                    self._tool_response_text(processor, faker)
+                ]
             turns.append(
                 ConversationTurnData(
                     node_id=spec.node_id,
@@ -341,6 +404,32 @@ class WEKATraceFormat(TraceFormatBase):
                 )
             )
         return ConversationGraphData(turns=turns)
+
+    def _tool_response_text(
+        self, processor: PreTrainedTokenizerBase, faker: Faker
+    ) -> str:
+        """Build the mocked tool result for an injection turn.
+
+        Matches synthetic data: ``tool_response_tokens`` sizes a ``{"result": ...}``
+        payload; otherwise the global placeholder is used.
+        """
+        if self.config.tool_response_tokens is None:
+            return settings.default_synthetic_tool_response
+        if self._tool_response_sampler is None:
+            self._tool_response_sampler = iter(
+                IntegerRangeSampler(
+                    average=self.config.tool_response_tokens,
+                    variance=self.config.tool_response_tokens_stdev,
+                    min_value=self.config.tool_response_tokens_min,
+                    max_value=self.config.tool_response_tokens_max,
+                    random_seed=faker.random.getrandbits(32),
+                )
+            )
+        body = _generate_remaining_prompt(
+            next(self._tool_response_sampler), processor, faker
+        )
+        raw = json.dumps({"result": body})
+        return raw.decode() if isinstance(raw, bytes) else raw
 
     def _unpack_conversation(
         self, conversation: Dataset
@@ -376,11 +465,13 @@ class WEKATraceFormat(TraceFormatBase):
     ) -> tuple[list[_TurnSpec], str | None]:
         """Walk a request list into turn specs for one agent plus its children.
 
-        API rows continue this agent's chain. ``type: "subagent"`` groups
-        spawn a sibling chain from the latest API turn of this agent
-        (``history_context="new"``). The next API turn of this agent joins
-        every pending sibling (``history_context="last"``), so multiple
-        subagents between the same parent turns run in parallel.
+        File order is spawn/join topology. API rows continue this agent's
+        chain. ``type: "subagent"`` groups spawn a sibling chain from the
+        latest API turn of this agent (``history_context="new"``). The next
+        API turn of this agent joins every pending sibling
+        (``history_context="last"``), so multiple subagents between the same
+        parent turns run in parallel. Nested subagent groups keep the same
+        rule against the inner list.
         """
         ts_col = self.config.timestamp_column
         specs: list[_TurnSpec] = []
@@ -388,13 +479,16 @@ class WEKATraceFormat(TraceFormatBase):
         last_chain_id: str | None = None
         chain_idx = 0
         chain_events: list[tuple[float, float | None]] = []
+        # Previous API row's stop on this chain only. Subagent children are
+        # interleaved in the flattened spec list, so classification cannot
+        # use that list's adjacency.
+        prev_stop: str | None = None
 
         for item in requests:
             if _is_subagent_entry(item):
                 inner = [dict(row) for row in (item.get("requests") or [])]
                 if not inner:
                     continue
-                inner.sort(key=lambda row: float(row[ts_col]))
                 spawn_id = spawn_seq[0]
                 spawn_seq[0] += 1
                 child_agent = str(item.get("agent_id") or f"sa_{spawn_id}")
@@ -446,6 +540,9 @@ class WEKATraceFormat(TraceFormatBase):
 
             abs_t = t_transform(float(item[ts_col]))
             node_id = f"{node_prefix}_{chain_idx}"
+            turn_type, include_tools, include_tool_response = _classify_weka_tool_turn(
+                item, prev_stop
+            )
             specs.append(
                 _TurnSpec(
                     node_id=node_id,
@@ -453,11 +550,15 @@ class WEKATraceFormat(TraceFormatBase):
                     parents=parents,
                     row=_copy_api_row(item, self.config.hash_ids_column),
                     absolute_t=abs_t,
+                    turn_type=turn_type,
+                    include_tools=include_tools,
+                    include_tool_response=include_tool_response,
                 )
             )
             last_chain_id = node_id
             chain_idx += 1
             chain_events.append((abs_t, _optional_float(item.get("api_time"))))
+            prev_stop = _weka_stop_reason(item)
 
         if pending_join_ids:
             logger.debug(

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -9,15 +9,16 @@ same previous hash ID.
 Generates prompts starting from the first conversation.
 When the conversation ends, the next conversation will be used.
 
-Some features such as subagent conversations,
-tool call events and non-linear histories are still missing.
-The results from datasets including these features will be unreliable.
+Declared ``type: "subagent"`` groups are replayed as isolated child
+chains that spawn from the preceding parent turn and join the following
+parent turn. Tool call events (``stop: tool_use``) are still missing.
 """
 
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
 from datasets import Dataset, Features, List, Value
@@ -32,12 +33,21 @@ from guidellm.data.deserializers.trace_common import (
     TraceDatasetDeserializer,
     TraceFormatBase,
     TraceFormatRegistry,
+    _raise_if_incorrect_types,
+    _raise_if_nonetype_found,
     create_distinct_token_block,
     create_prompt_from_hash_ids,
     decode_prompt,
     generate_token_ids,
     get_missing_columns,
 )
+from guidellm.data.schemas.conversation_graph_data import (
+    ConversationGraphData,
+    ConversationParentRef,
+    ConversationTurnData,
+)
+from guidellm.logger import logger
+from guidellm.scheduler.schemas import HistoryContext
 from guidellm.schemas.data.deserializers import WEKATraceFormatArgs
 
 __all__ = ["WEKATraceFormat"]
@@ -63,6 +73,73 @@ def _generate_remaining_prompt(
     return decode_prompt(processor, list(token_ids))
 
 
+def _is_subagent_entry(row: dict[str, Any]) -> bool:
+    return row.get("type") == "subagent"
+
+
+def _first_api_request(requests: list[Any]) -> dict[str, Any] | None:
+    for row in requests:
+        if not isinstance(row, dict):
+            continue
+        if _is_subagent_entry(row):
+            found = _first_api_request(list(row.get("requests") or []))
+            if found is not None:
+                return found
+            continue
+        return row
+    return None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _inner_timestamp_transform(
+    entry: dict[str, Any],
+    inner_requests: list[dict[str, Any]],
+    timestamp_column: str,
+) -> Callable[[float], float]:
+    """Map inner ``t`` to conversation-absolute time.
+
+    The spec records inner timestamps relative to spawn. Published corpora
+    often store absolute ``t`` on the same timeline as the parent. If the
+    first inner timestamp is less than the subagent spawn time, treat
+    inners as relative (``spawn_t + inner_t``); otherwise leave them as-is.
+    """
+    spawn_t = float(entry[timestamp_column])
+    first_inner_t = float(inner_requests[0][timestamp_column])
+    if first_inner_t < spawn_t:
+
+        def _relative(inner_t: float) -> float:
+            return spawn_t + inner_t
+
+        return _relative
+
+    def _absolute(inner_t: float) -> float:
+        return inner_t
+
+    return _absolute
+
+
+def _copy_api_row(row: dict[str, Any], hash_ids_column: str) -> dict[str, Any]:
+    copied = dict(row)
+    hash_ids = copied.get(hash_ids_column)
+    if hash_ids is not None:
+        copied[hash_ids_column] = list(hash_ids)
+    return copied
+
+
+@dataclass
+class _TurnSpec:
+    node_id: str
+    agent_id: str
+    parents: list[ConversationParentRef]
+    row: dict[str, Any]
+    absolute_t: float
+
+
 DatasetDeserializerFactory.register_decorator(TraceDatasetDeserializer, "weka")
 
 
@@ -77,6 +154,12 @@ class WEKATraceFormat(TraceFormatBase):
     number of children. Two hash IDs can represent identical blocks of tokens so long
     as they do not share the same parent (previous ID).
 
+    Declared ``type: "subagent"`` groups become isolated child chains that
+    spawn from the preceding parent API turn (``history_context="new"``) and
+    join the following parent API turn (``history_context="last"``). Adjacent
+    subagents between the same parent turns run in parallel; the following
+    parent waits for all of them.
+
     For more details, see [the WEKA trace format specification][trace-spec].
 
     [trace-spec]: https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md
@@ -89,6 +172,9 @@ class WEKATraceFormat(TraceFormatBase):
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
+        # Filled by each ``__iter__`` pass so mixed subagent/API schemas are
+        # not forced through a single HuggingFace Arrow table.
+        self._conversation_queue: list[tuple[str, list[dict[str, Any]]]] = []
         self.requests_col = _find_requests_column(dataset)
         if self.requests_col is None:
             raise DataNotSupportedError(
@@ -96,10 +182,15 @@ class WEKATraceFormat(TraceFormatBase):
             )
 
     def __iter__(self) -> Iterable[Dataset]:
+        self._conversation_queue = []
         for row in self.dataset:
-            trace_rows = Dataset.from_list(row[self.requests_col])
-            trace_rows.sort(self.config.timestamp_column)
-            yield trace_rows
+            conv_id = str(row[self.config.conversation_id_column])
+            # Preserve file order: outer request order is the spawn/join
+            # topology. Do not sort by timestamp.
+            requests = [dict(item) for item in row[self.requests_col]]
+            index = len(self._conversation_queue)
+            self._conversation_queue.append((conv_id, requests))
+            yield Dataset.from_dict({"_weka_index": [index]})
 
     def reset(self) -> None:
         self.hash_id_table = {}
@@ -118,10 +209,11 @@ class WEKATraceFormat(TraceFormatBase):
         conv_col = self.config.conversation_id_column
         if conv_col not in self.dataset.column_names:
             return [self.config.conversation_id_column]
-        columns.remove(conv_col)
-        return get_missing_columns(
-            columns, self.dataset[self.requests_col][0][0].keys()
-        )
+        required = [col for col in columns if col != conv_col]
+        first_api = _first_api_request(self.dataset[self.requests_col][0])
+        if first_api is None:
+            return required
+        return get_missing_columns(required, list(first_api.keys()))
 
     def validate_row(self, row: dict) -> None:
         n_in = row[self.config.prompt_tokens_column]
@@ -140,6 +232,36 @@ class WEKATraceFormat(TraceFormatBase):
                 f"{block_size} full blocks + partially filled "
                 f"trailing block does not match given {n_blocks} blocks"
             )
+
+    def validate_conversation(self, conversation: Dataset) -> None:
+        _, requests = self._unpack_conversation(conversation)
+        if not requests:
+            raise DataNotSupportedError("Trace conversation is empty")
+        api_rows = self._collect_api_rows(requests)
+        if not api_rows:
+            raise DataNotSupportedError(
+                "WEKA format: conversation has no API requests to replay"
+            )
+        features = Features(
+            {
+                self.config.timestamp_column: Value("float"),
+                self.config.prompt_tokens_column: Value("int32"),
+                self.config.output_tokens_column: Value("int32"),
+                self.config.hash_ids_column: List(Value("int32")),
+            }
+        )
+        api_dataset = Dataset.from_list(api_rows)
+        _raise_if_nonetype_found(api_dataset, features)
+        _raise_if_incorrect_types(api_dataset, features)
+        for row in api_rows:
+            n_in = row[self.config.prompt_tokens_column]
+            n_out = row[self.config.output_tokens_column]
+            if n_in < 0 or n_out < 0:
+                raise DataNotSupportedError(
+                    f"Trace token counts must be non-negative, got "
+                    f"input_length={n_in}, output_length={n_out}"
+                )
+            self.validate_row(row)
 
     def create_prompt(
         self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
@@ -174,3 +296,222 @@ class WEKATraceFormat(TraceFormatBase):
         if not remainder:
             return prompt
         return f"{prompt} {remainder}"
+
+    def build_conversation_graph(
+        self,
+        conversation: Dataset,
+        processor: PreTrainedTokenizerBase,
+        faker: Faker,
+    ) -> ConversationGraphData:
+        conv_id, requests = self._unpack_conversation(conversation)
+        specs, _last = self._emit_chain(
+            requests,
+            agent_id="default",
+            node_prefix="main",
+            preceding_parent_id=None,
+            first_turn_history="new",
+            t_transform=lambda t: t,
+            spawn_seq=[0],
+            conversation_id=conv_id,
+        )
+        if not specs:
+            raise DataNotSupportedError(
+                "WEKA format: conversation has no API requests to replay"
+            )
+        min_t = min(spec.absolute_t for spec in specs)
+        turns: list[ConversationTurnData] = []
+        for spec in specs:
+            prompt = self.create_prompt(spec.row, processor, faker)
+            columns = {
+                "text_column": [prompt],
+                "prompt_tokens_count_column": [
+                    spec.row[self.config.prompt_tokens_column]
+                ],
+                "output_tokens_count_column": [
+                    spec.row[self.config.output_tokens_column]
+                ],
+                "relative_timestamp_column": [spec.absolute_t - min_t],
+            }
+            turns.append(
+                ConversationTurnData(
+                    node_id=spec.node_id,
+                    agent_id=spec.agent_id,
+                    parents=spec.parents,
+                    columns=columns,
+                )
+            )
+        return ConversationGraphData(turns=turns)
+
+    def _unpack_conversation(
+        self, conversation: Dataset
+    ) -> tuple[str, list[dict[str, Any]]]:
+        index = int(conversation[0]["_weka_index"])
+        return self._conversation_queue[index]
+
+    def _collect_api_rows(self, requests: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        api_rows: list[dict[str, Any]] = []
+        columns = (
+            self.config.timestamp_column,
+            self.config.prompt_tokens_column,
+            self.config.output_tokens_column,
+            self.config.hash_ids_column,
+        )
+        for row in requests:
+            if _is_subagent_entry(row):
+                api_rows.extend(self._collect_api_rows(list(row.get("requests") or [])))
+                continue
+            api_rows.append({col: row.get(col) for col in columns})
+        return api_rows
+
+    def _emit_chain(
+        self,
+        requests: list[dict[str, Any]],
+        agent_id: str,
+        node_prefix: str,
+        preceding_parent_id: str | None,
+        first_turn_history: HistoryContext,
+        t_transform: Callable[[float], float],
+        spawn_seq: list[int],
+        conversation_id: str,
+    ) -> tuple[list[_TurnSpec], str | None]:
+        """Walk a request list into turn specs for one agent plus its children.
+
+        API rows continue this agent's chain. ``type: "subagent"`` groups
+        spawn a sibling chain from the latest API turn of this agent
+        (``history_context="new"``). The next API turn of this agent joins
+        every pending sibling (``history_context="last"``), so multiple
+        subagents between the same parent turns run in parallel.
+        """
+        ts_col = self.config.timestamp_column
+        specs: list[_TurnSpec] = []
+        pending_join_ids: list[str] = []
+        last_chain_id: str | None = None
+        chain_idx = 0
+        chain_events: list[tuple[float, float | None]] = []
+
+        for item in requests:
+            if _is_subagent_entry(item):
+                inner = [dict(row) for row in (item.get("requests") or [])]
+                if not inner:
+                    continue
+                inner.sort(key=lambda row: float(row[ts_col]))
+                spawn_id = spawn_seq[0]
+                spawn_seq[0] += 1
+                child_agent = str(item.get("agent_id") or f"sa_{spawn_id}")
+                if last_chain_id is None:
+                    logger.warning(
+                        "WEKA subagent '{}' in conversation '{}' has no "
+                        "preceding parent turn; replaying as an independent root",
+                        child_agent,
+                        conversation_id,
+                    )
+                child_specs, child_last = self._emit_chain(
+                    inner,
+                    agent_id=child_agent,
+                    node_prefix=f"sa_{spawn_id}",
+                    preceding_parent_id=last_chain_id,
+                    first_turn_history="new",
+                    t_transform=_inner_timestamp_transform(item, inner, ts_col),
+                    spawn_seq=spawn_seq,
+                    conversation_id=conversation_id,
+                )
+                specs.extend(child_specs)
+                if child_last is not None:
+                    pending_join_ids.append(child_last)
+                continue
+
+            parents: list[ConversationParentRef] = []
+            if last_chain_id is not None:
+                parents.append(
+                    ConversationParentRef(
+                        parent_node_id=last_chain_id,
+                        history_context="full",
+                    )
+                )
+            elif preceding_parent_id is not None:
+                parents.append(
+                    ConversationParentRef(
+                        parent_node_id=preceding_parent_id,
+                        history_context=first_turn_history,
+                    )
+                )
+            for join_id in pending_join_ids:
+                parents.append(
+                    ConversationParentRef(
+                        parent_node_id=join_id,
+                        history_context="last",
+                    )
+                )
+            pending_join_ids = []
+
+            abs_t = t_transform(float(item[ts_col]))
+            node_id = f"{node_prefix}_{chain_idx}"
+            specs.append(
+                _TurnSpec(
+                    node_id=node_id,
+                    agent_id=agent_id,
+                    parents=parents,
+                    row=_copy_api_row(item, self.config.hash_ids_column),
+                    absolute_t=abs_t,
+                )
+            )
+            last_chain_id = node_id
+            chain_idx += 1
+            chain_events.append((abs_t, _optional_float(item.get("api_time"))))
+
+        if pending_join_ids:
+            logger.debug(
+                "WEKA subagent(s) in conversation '{}' on agent '{}' have no "
+                "following parent turn; replaying as background without a join",
+                conversation_id,
+                agent_id,
+            )
+
+        self._warn_chain_overlap(conversation_id, agent_id, chain_events)
+        return specs, last_chain_id
+
+    def _warn_chain_overlap(
+        self,
+        conversation_id: str,
+        agent_id: str,
+        events: list[tuple[float, float | None]],
+    ) -> None:
+        """Warn when consecutive turns of one agent overlap in time.
+
+        Overlap uses recorded ``api_time`` when present
+        (``t[i] + api_time[i] > t[i+1]``), otherwise non-increasing start
+        times. Parallel subagents overlapping each other is intended and
+        is not warned here; each agent chain is checked separately.
+        """
+        for idx in range(len(events) - 1):
+            t_i, api_time = events[idx]
+            t_next, _ = events[idx + 1]
+            if api_time is not None:
+                overlapped = t_i + api_time > t_next
+            else:
+                overlapped = t_next <= t_i
+            if not overlapped:
+                continue
+            if api_time is not None:
+                logger.debug(
+                    "WEKA conversation '{}' agent '{}' has overlapping requests: "
+                    "the request at t={} will run until t={}, which is after "
+                    "the next request at t={}; they will be serialized on "
+                    "this chain",
+                    conversation_id,
+                    agent_id,
+                    t_i,
+                    t_i + api_time,
+                    t_next,
+                )
+            else:
+                logger.debug(
+                    "WEKA conversation '{}' agent '{}' has overlapping requests: "
+                    "the request at t={} is followed by a request at t={} "
+                    "that does not start later; they will be serialized on "
+                    "this chain",
+                    conversation_id,
+                    agent_id,
+                    t_i,
+                    t_next,
+                )

--- a/src/guidellm/data/finalizers/conversation_graph.py
+++ b/src/guidellm/data/finalizers/conversation_graph.py
@@ -116,7 +116,12 @@ def _should_expand_client_tool_turn(
     tool_call_mode: Literal["client", "server"],
     existing_ids: set[str],
 ) -> bool:
-    """Return True when this logical turn should become tool-call + injection."""
+    """Return True when this logical turn should become tool-call + injection.
+
+    Explicit ``client_tool_call`` without ``tool_response_column`` is already
+    split (the injection is a later node). Only expand when the mocked
+    response is on this same turn, matching synthetic data.
+    """
     injection_id = f"{turn.node_id}_injection"
     if injection_id in existing_ids:
         return False
@@ -129,8 +134,11 @@ def _should_expand_client_tool_turn(
         return False
     if explicit_type == "server_tool_call":
         return False
+    # Pre-split graphs (WEKA) already emit a separate injection node and put
+    # tool_response_column there. Expand explicit client_tool_call only for
+    # the synthetic pattern where the mocked response lives on this turn.
     if explicit_type == "client_tool_call":
-        return True
+        return bool(turn.columns.get("tool_response_column"))
     if not turn.columns.get("tools_column"):
         return False
     return tool_call_mode == "client"

--- a/src/guidellm/data/schemas/conversation_graph_data.py
+++ b/src/guidellm/data/schemas/conversation_graph_data.py
@@ -2,7 +2,7 @@
 Data-layer conversation graph interchange with inline parent dependencies.
 
 Turns declare their parents explicitly so branched / multi-agent datasets
-(and future WEKA traces) can describe a DAG without a separate edges list.
+(including WEKA traces) can describe a DAG without a separate edges list.
 The finalizer derives :class:`~guidellm.scheduler.schemas.ConversationEdge`
 values from these parent refs when building a runtime graph.
 """

--- a/src/guidellm/schemas/data/deserializers/trace_weka.py
+++ b/src/guidellm/schemas/data/deserializers/trace_weka.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
+from guidellm.schemas.data.deserializers.synthetic import (
+    _require_mean_if_distribution_knobs,
+)
 from guidellm.schemas.data.deserializers.trace_common import TraceDataArgs
 from guidellm.schemas.data.entrypoints import DataArgs
+from guidellm.utils.imports import json
 
 __all__ = ["WEKATraceFormatArgs"]
 
@@ -42,3 +46,89 @@ class WEKATraceFormatArgs(TraceDataArgs):
         default=64,
         description="Amount of tokens represented by one hash ID.",
     )
+    tools: list[dict[str, Any]] | None = Field(
+        description=(
+            "Tool definitions in OpenAI format. Traces do not include schemas; "
+            "when this is None, a static placeholder tool definition is used "
+            "on tool-call turns."
+        ),
+        default=None,
+        examples=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_data",
+                    "description": "Retrieve data from the system",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string", "description": "The query"}
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ],
+    )
+    tool_response_tokens: int | None = Field(
+        description=(
+            "Average number of tokens for synthetic tool call responses. "
+            "When None (default), a short placeholder response is used."
+        ),
+        gt=0,
+        default=None,
+        examples=[10],
+    )
+    tool_response_tokens_stdev: int | None = Field(
+        description="Standard deviation for tool response token count.",
+        gt=0,
+        default=None,
+        examples=[1],
+    )
+    tool_response_tokens_min: int | None = Field(
+        description="Minimum number of tokens for tool response.",
+        gt=0,
+        default=None,
+        examples=[5],
+    )
+    tool_response_tokens_max: int | None = Field(
+        description="Maximum number of tokens for tool response.",
+        gt=0,
+        default=None,
+        examples=[20],
+    )
+
+    @field_validator("tools", mode="before")
+    @classmethod
+    def _coerce_tools(cls, v: Any) -> list[dict[str, Any]] | None:
+        """Accept a JSON string from CLI/env the same way synthetic ``tools`` is passed.
+
+        :param v: Parsed list, JSON string, or None.
+        :return: Tool definitions, or None for the placeholder schema.
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            try:
+                v = json.loads(v)
+            except (json.JSONDecodeError, ValueError) as err:
+                raise ValueError(
+                    f"tools string must be a JSON list of tool definitions, got {v!r}"
+                ) from err
+        if not isinstance(v, list):
+            raise ValueError(f"tools must be a list of dicts, got {type(v)}")
+        if not all(isinstance(item, dict) for item in v):
+            raise ValueError("tools must be a list of dicts")
+        return v
+
+    @model_validator(mode="after")
+    def _validate_tool_response_token_means(self) -> WEKATraceFormatArgs:
+        """Require tool_response_tokens when its distribution knobs are set."""
+        _require_mean_if_distribution_knobs(
+            self.tool_response_tokens,
+            self.tool_response_tokens_stdev,
+            self.tool_response_tokens_min,
+            self.tool_response_tokens_max,
+            "tool_response_tokens",
+        )
+        return self

--- a/src/guidellm/utils/hf_datasets.py
+++ b/src/guidellm/utils/hf_datasets.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from datasets import Dataset, load_dataset
 
+from guidellm.utils.imports import json
+
 SUPPORTED_TYPES = {
     ".json",
     ".jsonl",
@@ -10,14 +12,78 @@ SUPPORTED_TYPES = {
     ".parquet",
 }
 
+_JSON_SUFFIXES = {".json", ".jsonl"}
+
+
+def _read_json_records(path: Path) -> list[dict[str, Any]]:
+    """Parse a JSON array or JSON Lines file into Python dicts.
+
+    :param path: Path to a ``.json`` or ``.jsonl`` file.
+    :return: One dict per record.
+    :raises ValueError: If the file is not valid JSON or JSON Lines.
+    """
+    with path.open(encoding="utf-8") as handle:
+        prefix = handle.read(1)
+        while prefix and prefix.isspace():
+            prefix = handle.read(1)
+        if not prefix:
+            return []
+        handle.seek(0)
+        if prefix == "[":
+            try:
+                data = json.loads(handle.read())
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON in '{path}': {exc}") from exc
+            if not isinstance(data, list):
+                raise ValueError(
+                    f"JSON file '{path}' must contain a list of records or JSON Lines."
+                )
+            return data
+        records: list[dict[str, Any]] = []
+        for line_no, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                records.append(json.loads(stripped))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON on line {line_no} of '{path}': {exc}"
+                ) from exc
+        return records
+
+
+def load_json_dataset_from_file(path: str | Path) -> Dataset:
+    """Load JSON or JSONL without HuggingFace chunked schema inference.
+
+    The datasets json builder infers Arrow types from the first chunk.
+    Later rows that add optional nested fields (for example WEKA
+    ``ttft`` on only some ``requests``) then fail to cast. Parsing the
+    file in Python and building the Dataset from the full record list
+    lets Arrow union those keys.
+
+    :param path: Path to a ``.json`` or ``.jsonl`` file.
+    :return: Dataset with one row per JSON record.
+    :raises ValueError: If the file cannot be parsed or converted.
+    """
+    path = Path(path)
+    records = _read_json_records(path)
+    try:
+        return Dataset.from_list(records)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Failed to load JSON dataset from '{path}': {exc}") from exc
+
 
 def load_dataset_from_file(
     path: str | Path, split: str = "train", **data_kwargs: Any
 ) -> Dataset:
     path = Path(path)
     suffix = path.suffix.lower()
+    if suffix in _JSON_SUFFIXES:
+        # Bypass the HuggingFace json builder: its chunked Arrow schema
+        # cannot grow when later records add optional nested fields.
+        return load_json_dataset_from_file(path)
     if suffix in SUPPORTED_TYPES:
-        suffix = suffix.replace(".jsonl", ".json")
         return load_dataset(
             suffix.replace(".", ""), data_files=str(path), split=split, **data_kwargs
         )

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -4704,6 +4704,56 @@ class TestResponsesRequestHandler:
         assert result.body["tools"] == tools
         assert result.body["tool_choice"] == "none"
 
+    @pytest.mark.smoke
+    def test_format_injection_with_tools_keeps_tool_choice_required(
+        self, valid_instances
+    ):
+        """Injection plus tools_column keeps tool_choice=required and drops ignore_eos.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        tools = [{"type": "function", "function": {"name": "fn", "parameters": {}}}]
+        data = GenerationRequest(
+            columns={
+                "tools_column": [stdlib_json.dumps(tools)],
+                "tool_response_column": ['{"status": "ok"}'],
+            },
+            turn_type="tool_response_injection",
+            output_metrics=UsageMetrics(text_tokens=50),
+        )
+
+        result = instance.format(data)
+
+        assert result.body["tool_choice"] == "required"
+        assert "ignore_eos" not in result.body
+        assert "stop" not in result.body
+        assert "max_output_tokens" not in result.body
+
+    @pytest.mark.smoke
+    def test_format_injection_without_tools_forces_tool_choice_none(
+        self, valid_instances
+    ):
+        """Injection without tools_column still forces tool_choice=none.
+
+        ## WRITTEN BY AI ##
+        """
+        instance = valid_instances
+        tools = [{"type": "function", "function": {"name": "fn", "parameters": {}}}]
+        data = GenerationRequest(
+            columns={"tool_response_column": ['{"status": "ok"}']},
+            turn_type="tool_response_injection",
+            output_metrics=UsageMetrics(text_tokens=50),
+        )
+
+        result = instance.format(
+            data,
+            extras=GenerationRequestArguments(body={"tools": tools}),
+        )
+
+        assert result.body["tool_choice"] == "none"
+        assert result.body["ignore_eos"] is True
+
     @pytest.mark.sanity
     def test_format_strips_tool_choice_without_tools(self, valid_instances):
         """
@@ -5417,6 +5467,7 @@ class TestChatCompletionsToolChoiceOverride:
                 "tools_column": [json.dumps(tools)],
             },
             turn_type="client_tool_call",
+            output_metrics=UsageMetrics(text_tokens=50),
         )
         result = handler.format(data)
 
@@ -5491,6 +5542,48 @@ class TestChatCompletionsToolChoiceOverride:
         result = handler.format(data)
 
         assert result.body["max_completion_tokens"] == 100
+
+    @pytest.mark.smoke
+    def test_injection_with_tools_keeps_tool_choice_required(self, handler):
+        """Injection plus tools_column keeps tool_choice=required and drops ignore_eos.
+
+        ## WRITTEN BY AI ##
+        """
+        tools = [{"type": "function", "function": {"name": "fn"}}]
+        data = GenerationRequest(
+            columns={
+                "tools_column": [json.dumps(tools)],
+                "tool_response_column": ['{"status": "ok"}'],
+            },
+            turn_type="tool_response_injection",
+            output_metrics=UsageMetrics(text_tokens=50),
+        )
+        result = handler.format(data)
+
+        assert result.body["tool_choice"] == "required"
+        assert "ignore_eos" not in result.body
+        assert "stop" not in result.body
+        assert "max_completion_tokens" not in result.body
+
+    @pytest.mark.smoke
+    def test_injection_without_tools_forces_tool_choice_none(self, handler):
+        """Injection without tools_column still forces tool_choice=none.
+
+        ## WRITTEN BY AI ##
+        """
+        tools = [{"type": "function", "function": {"name": "fn"}}]
+        data = GenerationRequest(
+            columns={"tool_response_column": ['{"status": "ok"}']},
+            turn_type="tool_response_injection",
+            output_metrics=UsageMetrics(text_tokens=50),
+        )
+        result = handler.format(
+            data,
+            extras=GenerationRequestArguments(body={"tools": tools}),
+        )
+
+        assert result.body["tool_choice"] == "none"
+        assert result.body["ignore_eos"] is True
 
 
 class TestChatCompletionsToolResponseColumn:

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -5,7 +5,7 @@ import random
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -557,3 +557,290 @@ class TestWEKATraceFormat:
         turns = list(conv)
         assert turns[0].columns["prompt_tokens_count_column"][0] == 0
         assert turns[0].columns["output_tokens_count_column"][0] == 5
+        assert turns[0].node_id == "main_0"
+        assert turns[0].agent_id == "default"
+
+    @pytest.mark.smoke
+    def test_subagent_spawns_and_joins_parent(self, tmp_path: Path, deserializer):
+        """A declared subagent chain spawns from the preceding parent and
+        joins the following parent turn.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {"t": 0.0, "in": 8, "out": 2, "hash_ids": []},
+                                {"t": 0.5, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 10.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "sa_0_0", "sa_0_1", "main_1"}
+        assert turns["main_0"].agent_id == "default"
+        assert turns["sa_0_0"].agent_id == "explore"
+        assert turns["sa_0_1"].agent_id == "explore"
+        assert turns["sa_0_0"].parents[0].parent_node_id == "main_0"
+        assert turns["sa_0_0"].parents[0].history_context == "new"
+        assert turns["sa_0_1"].parents[0].parent_node_id == "sa_0_0"
+        assert turns["sa_0_1"].parents[0].history_context == "full"
+        main_1_parents = {
+            parent.parent_node_id: parent.history_context
+            for parent in turns["main_1"].parents
+        }
+        assert main_1_parents == {"main_0": "full", "sa_0_1": "last"}
+
+    @pytest.mark.smoke
+    def test_parallel_subagents_share_spawn_and_join(
+        self, tmp_path: Path, deserializer
+    ):
+        """Adjacent subagents between the same parent turns run in parallel.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "agentA",
+                            "requests": [
+                                {"t": 0.0, "in": 8, "out": 2, "hash_ids": []},
+                                {"t": 0.4, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "agentB",
+                            "requests": [
+                                {"t": 0.0, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 10.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["sa_0_0"].agent_id == "agentA"
+        assert turns["sa_1_0"].agent_id == "agentB"
+        assert turns["sa_0_0"].parents[0].parent_node_id == "main_0"
+        assert turns["sa_0_0"].parents[0].history_context == "new"
+        assert turns["sa_1_0"].parents[0].parent_node_id == "main_0"
+        assert turns["sa_1_0"].parents[0].history_context == "new"
+        sa_parent_ids = {
+            parent.parent_node_id for parent in turns["sa_0_0"].parents
+        } | {parent.parent_node_id for parent in turns["sa_1_0"].parents}
+        assert "sa_0_0" not in {
+            parent.parent_node_id for parent in turns["sa_1_0"].parents
+        }
+        assert "sa_1_0" not in {
+            parent.parent_node_id for parent in turns["sa_0_0"].parents
+        }
+        assert sa_parent_ids == {"main_0"}
+        main_1_parents = {
+            parent.parent_node_id: parent.history_context
+            for parent in turns["main_1"].parents
+        }
+        assert main_1_parents == {
+            "main_0": "full",
+            "sa_0_1": "last",
+            "sa_1_0": "last",
+        }
+
+    @pytest.mark.sanity
+    def test_inner_timestamps_relative_to_spawn(self, tmp_path: Path, deserializer):
+        """Inner t smaller than spawn t is treated as relative to spawn.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 100.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {"t": 0.0, "in": 8, "out": 2, "hash_ids": []},
+                                {"t": 3.0, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 200.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["main_0"].columns["relative_timestamp_column"][0] == 0.0
+        assert turns["sa_0_0"].columns["relative_timestamp_column"][0] == 100.0
+        assert turns["sa_0_1"].columns["relative_timestamp_column"][0] == 103.0
+        assert turns["main_1"].columns["relative_timestamp_column"][0] == 200.0
+
+    @pytest.mark.sanity
+    def test_inner_timestamps_absolute_when_not_before_spawn(
+        self, tmp_path: Path, deserializer
+    ):
+        """Inner t on the parent timeline is left as absolute.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 100.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {"t": 100.0, "in": 8, "out": 2, "hash_ids": []},
+                                {"t": 103.0, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 200.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["sa_0_0"].columns["relative_timestamp_column"][0] == 100.0
+        assert turns["sa_0_1"].columns["relative_timestamp_column"][0] == 103.0
+
+    @pytest.mark.sanity
+    def test_subagent_entries_do_not_fail_validation(
+        self, tmp_path: Path, deserializer
+    ):
+        """Subagent marker rows lack in/out/hash_ids and must still load.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [{"t": 0.0, "in": 8, "out": 2, "hash_ids": []}],
+                        },
+                        {"t": 2.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = load_graph_turns(next(iter(ds)))
+        assert len(turns) == 3
+
+    @pytest.mark.sanity
+    @patch("guidellm.data.deserializers.trace_weka.logger")
+    def test_overlap_warns_on_same_chain(
+        self, mock_logger, tmp_path: Path, deserializer
+    ):
+        """Consecutive turns of one agent that overlap in time are logged at debug.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "api_time": 5.0,
+                        },
+                        {"t": 1.0, "in": 10, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        load_graph_turns(next(iter(ds)))
+        messages = [
+            call.args[0].format(*call.args[1:]) if call.args else ""
+            for call in mock_logger.debug.call_args_list
+        ]
+        assert any("overlapping requests" in message for message in messages)
+        assert any("will run until t=" in message for message in messages)
+        assert any("default" in message for message in messages)
+
+    @pytest.mark.sanity
+    @patch("guidellm.data.deserializers.trace_weka.logger")
+    def test_overlap_does_not_warn_for_parallel_subagents(
+        self, mock_logger, tmp_path: Path, deserializer
+    ):
+        """Parallel subagents may share timestamps without an overlap debug log.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "agentA",
+                            "requests": [{"t": 0.0, "in": 8, "out": 2, "hash_ids": []}],
+                        },
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "agentB",
+                            "requests": [{"t": 0.0, "in": 8, "out": 2, "hash_ids": []}],
+                        },
+                        {"t": 10.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        load_graph_turns(next(iter(ds)))
+        messages = [
+            call.args[0].format(*call.args[1:]) if call.args else ""
+            for call in mock_logger.debug.call_args_list
+        ]
+        assert not any("overlapping requests" in message for message in messages)

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from guidellm.data.deserializers import DatasetDeserializerFactory
 from guidellm.data.deserializers.trace_common import TraceDatasetDeserializer
@@ -16,7 +17,8 @@ from guidellm.data.schemas.conversation_graph_data import (
     ConversationGraphData,
     ConversationTurnData,
 )
-from guidellm.schemas.data import WEKATraceFormatArgs
+from guidellm.schemas.data import DEFAULT_SYNTHETIC_TOOLS, WEKATraceFormatArgs
+from guidellm.settings import settings
 
 
 def ascending_processor() -> Mock:
@@ -144,6 +146,11 @@ class TestWEKATraceFormat:
                 "output_tokens_column",
                 "hash_ids_column",
                 "hash_id_block_size",
+                "tools",
+                "tool_response_tokens",
+                "tool_response_tokens_stdev",
+                "tool_response_tokens_min",
+                "tool_response_tokens_max",
             ),
             kwargs,
         )
@@ -670,6 +677,139 @@ class TestWEKATraceFormat:
         }
 
     @pytest.mark.sanity
+    def test_nested_subagent_preserves_file_order(self, tmp_path: Path, deserializer):
+        """A nested subagent spawns from the preceding inner API row.
+
+        Inner timestamps that would sort the nested group first must not
+        move it; file order is topology at every nesting level.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {"t": 10.0, "in": 8, "out": 2, "hash_ids": []},
+                                {
+                                    "t": 1.0,
+                                    "type": "subagent",
+                                    "agent_id": "nested",
+                                    "requests": [
+                                        {"t": 1.0, "in": 6, "out": 2, "hash_ids": []},
+                                    ],
+                                },
+                                {"t": 11.0, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 20.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "sa_0_0", "sa_1_0", "sa_0_1", "main_1"}
+        assert turns["sa_0_0"].agent_id == "explore"
+        assert turns["sa_1_0"].agent_id == "nested"
+        assert turns["sa_0_0"].parents[0].parent_node_id == "main_0"
+        assert turns["sa_0_0"].parents[0].history_context == "new"
+        assert turns["sa_1_0"].parents[0].parent_node_id == "sa_0_0"
+        assert turns["sa_1_0"].parents[0].history_context == "new"
+        sa_0_1_parents = {
+            parent.parent_node_id: parent.history_context
+            for parent in turns["sa_0_1"].parents
+        }
+        assert sa_0_1_parents == {"sa_0_0": "full", "sa_1_0": "last"}
+        main_1_parents = {
+            parent.parent_node_id: parent.history_context
+            for parent in turns["main_1"].parents
+        }
+        assert main_1_parents == {"main_0": "full", "sa_0_1": "last"}
+
+    @pytest.mark.sanity
+    def test_empty_inner_subagent_requests_are_skipped(
+        self, tmp_path: Path, deserializer
+    ):
+        """A subagent group with no inner API rows is omitted.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [],
+                        },
+                        {"t": 2.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "main_1"}
+        assert [parent.parent_node_id for parent in turns["main_1"].parents] == [
+            "main_0"
+        ]
+
+    @pytest.mark.sanity
+    @patch("guidellm.data.deserializers.trace_weka.logger")
+    def test_subagent_without_preceding_parent_is_independent_root(
+        self, mock_logger, tmp_path: Path, deserializer
+    ):
+        """A leading subagent is replayed as a root and the next parent joins it.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {"t": 0.0, "in": 8, "out": 2, "hash_ids": []},
+                            ],
+                        },
+                        {"t": 10.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["sa_0_0"].parents == []
+        main_parents = {
+            parent.parent_node_id: parent.history_context
+            for parent in turns["main_0"].parents
+        }
+        assert main_parents == {"sa_0_0": "last"}
+        messages = [
+            call.args[0].format(*call.args[1:]) if call.args else ""
+            for call in mock_logger.warning.call_args_list
+        ]
+        assert any("no preceding parent turn" in message for message in messages)
+
+    @pytest.mark.sanity
     def test_inner_timestamps_relative_to_spawn(self, tmp_path: Path, deserializer):
         """Inner t smaller than spawn t is treated as relative to spawn.
 
@@ -844,3 +984,517 @@ class TestWEKATraceFormat:
             for call in mock_logger.debug.call_args_list
         ]
         assert not any("overlapping requests" in message for message in messages)
+
+    @pytest.mark.smoke
+    def test_tool_use_then_tool_result_maps_to_call_and_injection(
+        self, tmp_path: Path, deserializer
+    ):
+        """stop=tool_use then input_types=tool_result become call then injection.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["text"],
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 8,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["tool_result"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "main_1"}
+        assert turns["main_0"].columns["turn_type_column"] == ["client_tool_call"]
+        assert json.loads(turns["main_0"].columns["tools_column"][0]) == (
+            DEFAULT_SYNTHETIC_TOOLS
+        )
+        assert "tool_response_column" not in turns["main_0"].columns
+        assert turns["main_1"].columns["turn_type_column"] == [
+            "tool_response_injection"
+        ]
+        assert turns["main_1"].columns["tool_response_column"] == [
+            settings.default_synthetic_tool_response
+        ]
+        assert "tools_column" not in turns["main_1"].columns
+
+    @pytest.mark.smoke
+    def test_tool_result_with_tool_use_stop_keeps_tools_on_injection(
+        self, tmp_path: Path, deserializer
+    ):
+        """tool_result + stop=tool_use is an injection that still carries tools.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["text"],
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["tool_result"],
+                        },
+                        {
+                            "t": 2.0,
+                            "in": 14,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["tool_result"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "main_1", "main_2"}
+        assert turns["main_0"].columns["turn_type_column"] == ["client_tool_call"]
+        assert turns["main_1"].columns["turn_type_column"] == [
+            "tool_response_injection"
+        ]
+        assert "tools_column" in turns["main_1"].columns
+        assert turns["main_1"].columns["tool_response_column"] == [
+            settings.default_synthetic_tool_response
+        ]
+        assert turns["main_2"].columns["turn_type_column"] == [
+            "tool_response_injection"
+        ]
+        assert "tools_column" not in turns["main_2"].columns
+
+    @pytest.mark.sanity
+    def test_tool_result_fallback_from_previous_stop(
+        self, tmp_path: Path, deserializer
+    ):
+        """After stop=tool_use, a row without input_types is treated as injection.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["main_0"].columns["turn_type_column"] == ["client_tool_call"]
+        assert turns["main_1"].columns["turn_type_column"] == [
+            "tool_response_injection"
+        ]
+
+    @pytest.mark.sanity
+    def test_trailing_unpaired_tool_use_does_not_invent_injection(
+        self, tmp_path: Path, deserializer
+    ):
+        """A last-row tool_use stays a single client_tool_call with no extra node.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["text"],
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["text"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert set(turns) == {"main_0", "main_1"}
+        assert "turn_type_column" not in turns["main_0"].columns
+        assert turns["main_1"].columns["turn_type_column"] == ["client_tool_call"]
+        assert "tool_response_column" not in turns["main_1"].columns
+
+    @pytest.mark.sanity
+    def test_end_turn_stays_standard(self, tmp_path: Path, deserializer):
+        """stop=end_turn with text input does not set a tool-call turn type.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["text"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert "turn_type_column" not in turns["main_0"].columns
+        assert "tools_column" not in turns["main_0"].columns
+
+    @pytest.mark.sanity
+    def test_subagent_inner_tool_use_is_classified(self, tmp_path: Path, deserializer):
+        """Subagent inner stop=tool_use maps onto client_tool_call + injection.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {
+                            "t": 1.0,
+                            "type": "subagent",
+                            "agent_id": "explore",
+                            "requests": [
+                                {
+                                    "t": 0.0,
+                                    "in": 8,
+                                    "out": 2,
+                                    "hash_ids": [],
+                                    "stop": "tool_use",
+                                    "input_types": ["text"],
+                                },
+                                {
+                                    "t": 0.5,
+                                    "in": 8,
+                                    "out": 2,
+                                    "hash_ids": [],
+                                    "stop": "end_turn",
+                                    "input_types": ["tool_result"],
+                                },
+                            ],
+                        },
+                        {"t": 10.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert turns["sa_0_0"].columns["turn_type_column"] == ["client_tool_call"]
+        assert turns["sa_0_1"].columns["turn_type_column"] == [
+            "tool_response_injection"
+        ]
+        assert "turn_type_column" not in turns["main_0"].columns
+        assert "turn_type_column" not in turns["main_1"].columns
+
+    @pytest.mark.sanity
+    def test_legacy_rows_without_stop_or_input_types_unchanged(
+        self, tmp_path: Path, deserializer
+    ):
+        """Rows missing stop and input_types stay standard text turns.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {"t": 0.0, "in": 10, "out": 5, "hash_ids": []},
+                        {"t": 1.0, "in": 12, "out": 5, "hash_ids": []},
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = load_graph_turns(next(iter(ds)))
+        assert len(turns) == 2
+        for turn in turns:
+            assert "turn_type_column" not in turn.columns
+            assert "tools_column" not in turn.columns
+            assert "tool_response_column" not in turn.columns
+
+    @pytest.mark.sanity
+    def test_custom_tools_used_instead_of_default(self, tmp_path: Path, deserializer):
+        """User-provided tools are attached instead of the placeholder schema.
+
+        ## WRITTEN BY AI ##
+        """
+        custom_tools = [{"type": "function", "function": {"name": "custom_fn"}}]
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["text"],
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 8,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["tool_result"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace, tools=custom_tools)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        assert json.loads(turns["main_0"].columns["tools_column"][0]) == custom_tools
+        assert turns["main_1"].columns["tool_response_column"] == [
+            settings.default_synthetic_tool_response
+        ]
+
+    @pytest.mark.sanity
+    def test_tool_response_tokens_sizes_injection(self, tmp_path: Path, deserializer):
+        """tool_response_tokens generates a sized mock result like synthetic data.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "conv0",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "in": 10,
+                            "out": 5,
+                            "hash_ids": [],
+                            "stop": "tool_use",
+                            "input_types": ["text"],
+                        },
+                        {
+                            "t": 1.0,
+                            "in": 12,
+                            "out": 8,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                            "input_types": ["tool_result"],
+                        },
+                    ],
+                }
+            ),
+        )
+        ds = self.deserialize(deserializer, trace, tool_response_tokens=8)
+        turns = {turn.node_id: turn for turn in load_graph_turns(next(iter(ds)))}
+        raw = turns["main_1"].columns["tool_response_column"][0]
+        assert raw != settings.default_synthetic_tool_response
+        payload = json.loads(raw)
+        assert "result" in payload
+        assert payload["result"]
+
+    @pytest.mark.regression
+    def test_optional_nested_request_fields_do_not_fail_load(
+        self, tmp_path: Path, deserializer
+    ):
+        """Conversations whose requests add optional fields still deserialize.
+
+        Published WEKA dumps mix API and subagent objects in ``requests``
+        and only some API rows include ``ttft``. HuggingFace's json loader
+        infers schema from the first chunk and then fails to cast.
+
+        ## WRITTEN BY AI ##
+        """
+        conv_without_ttft = {
+            "id": "conv0",
+            "requests": [
+                {
+                    "t": 0.0,
+                    "type": "api",
+                    "model": "m",
+                    "in": 10,
+                    "out": 5,
+                    "hash_ids": [],
+                    "input_types": ["text"],
+                    "stop": "end_turn",
+                    "api_time": 0.1,
+                    "think_time": 0.0,
+                },
+                {
+                    "t": 1.0,
+                    "type": "subagent",
+                    "agent_id": "explore",
+                    "subagent_type": "explore",
+                    "duration_ms": 10,
+                    "total_tokens": 3,
+                    "tool_use_count": 0,
+                    "status": "ok",
+                    "requests": [
+                        {
+                            "t": 0.0,
+                            "type": "api",
+                            "in": 8,
+                            "out": 2,
+                            "hash_ids": [],
+                            "stop": "end_turn",
+                        }
+                    ],
+                    "models": ["m"],
+                    "tool_tokens": 1,
+                    "system_tokens": 2,
+                },
+                {"t": 2.0, "in": 12, "out": 5, "hash_ids": []},
+            ],
+        }
+        conv_with_ttft = {
+            "id": "conv1",
+            "requests": [
+                {
+                    "t": 3.0,
+                    "type": "api",
+                    "model": "m",
+                    "in": 10,
+                    "out": 5,
+                    "hash_ids": [],
+                    "input_types": ["text"],
+                    "stop": "end_turn",
+                    "api_time": 0.1,
+                    "think_time": 0.0,
+                    "ttft": 0.05,
+                }
+            ],
+        }
+        trace = write_trace(
+            tmp_path,
+            "\n".join(json.dumps(row) for row in (conv_without_ttft, conv_with_ttft))
+            + "\n",
+        )
+        ds = self.deserialize(deserializer, trace)
+        rows = list(ds)
+        assert len(rows) == 2
+        assert len(load_graph_turns(rows[0])) == 3
+        assert len(load_graph_turns(rows[1])) == 1
+
+
+class TestWEKATraceFormatArgsTools:
+    """Validate WEKA tools and tool_response_tokens fields.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.smoke
+    def test_defaults_use_placeholder_tools(self, tmp_path: Path):
+        """Unset tools falls back to the synthetic placeholder at replay time.
+
+        ## WRITTEN BY AI ##
+        """
+        config = WEKATraceFormatArgs(path=tmp_path)
+        assert config.tools is None
+        assert config.tool_response_tokens is None
+
+    @pytest.mark.sanity
+    def test_custom_tools_accepted(self, tmp_path: Path):
+        """Custom OpenAI-format tools are stored on the config.
+
+        ## WRITTEN BY AI ##
+        """
+        custom_tools = [{"type": "function", "function": {"name": "my_func"}}]
+        config = WEKATraceFormatArgs(path=tmp_path, tools=custom_tools)
+        assert config.tools == custom_tools
+
+    @pytest.mark.sanity
+    def test_tools_json_string_coerced(self, tmp_path: Path):
+        """CLI JSON strings coerce to a list of tool dicts.
+
+        ## WRITTEN BY AI ##
+        """
+        config = WEKATraceFormatArgs(
+            path=tmp_path,
+            tools='[{"type":"function","function":{"name":"from_json"}}]',
+        )
+        assert config.tools == [{"type": "function", "function": {"name": "from_json"}}]
+
+    @pytest.mark.sanity
+    def test_tools_rejects_non_list(self, tmp_path: Path):
+        """Non-list tools values are rejected.
+
+        ## WRITTEN BY AI ##
+        """
+        with pytest.raises(ValidationError, match="tools must be a list"):
+            WEKATraceFormatArgs(path=tmp_path, tools={"name": "bad"})  # type: ignore[arg-type]
+
+    @pytest.mark.sanity
+    def test_tool_response_tokens_require_mean(self, tmp_path: Path):
+        """Distribution knobs require tool_response_tokens.
+
+        ## WRITTEN BY AI ##
+        """
+        with pytest.raises(ValidationError, match="tool_response_tokens must be set"):
+            WEKATraceFormatArgs(path=tmp_path, tool_response_tokens_stdev=1)

--- a/tests/unit/data/test_finalizers.py
+++ b/tests/unit/data/test_finalizers.py
@@ -678,6 +678,7 @@ class TestFinalizerToolCallMode:
             {
                 "text_column": ["hello"],
                 "tools_column": ['[{"type": "function"}]'],
+                "tool_response_column": ['{"status": "ok"}'],
                 "turn_type_column": ["client_tool_call"],
             },
         ]
@@ -685,11 +686,51 @@ class TestFinalizerToolCallMode:
         assert isinstance(graph, GenerativeConversationGraph)
         results = _ordered_requests(graph)
 
-        # turn_type_column says client_tool_call, so it should create
-        # a client_tool_call + injection pair despite server mode
+        # turn_type_column says client_tool_call with a same-turn response, so
+        # it should create a client_tool_call + injection pair despite server mode
         assert len(results) == 2
         assert results[0].turn_type == "client_tool_call"
         assert results[1].turn_type == "tool_response_injection"
+
+    @pytest.mark.sanity
+    def test_presplit_client_tool_call_without_response_is_not_expanded(self):
+        """Explicit client_tool_call without tool_response_column is not split.
+
+        ## WRITTEN BY AI ##
+        """
+        graph_data = ConversationGraphData(
+            turns=[
+                ConversationTurnData(
+                    node_id="main_0",
+                    columns={
+                        "text_column": ["hello"],
+                        "tools_column": ['[{"type": "function"}]'],
+                        "turn_type_column": ["client_tool_call"],
+                    },
+                ),
+                ConversationTurnData(
+                    node_id="main_1",
+                    parents=[
+                        ConversationParentRef(
+                            parent_node_id="main_0",
+                            history_context="full",
+                        )
+                    ],
+                    columns={
+                        "turn_type_column": ["tool_response_injection"],
+                        "tool_response_column": ['{"status": "ok"}'],
+                    },
+                ),
+            ]
+        )
+        finalizer = GenerativeRequestFinalizer(GenerativeRequestFinalizerArgs())
+        graph = finalizer(
+            [{"conversation_turns_column": [graph_data.model_dump(mode="json")]}]
+        )
+        assert isinstance(graph, GenerativeConversationGraph)
+        assert set(graph.nodes) == {"main_0", "main_1"}
+        assert graph.nodes["main_0"].request.turn_type == "client_tool_call"
+        assert graph.nodes["main_1"].request.turn_type == "tool_response_injection"
 
 
 class TestGenerativeRequestFinalizerRequestSettings:

--- a/tests/unit/utils/test_hf_datasets.py
+++ b/tests/unit/utils/test_hf_datasets.py
@@ -1,10 +1,11 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from datasets import Dataset
 
-from guidellm.utils.hf_datasets import save_dataset_to_file
+from guidellm.utils.hf_datasets import load_dataset_from_file, save_dataset_to_file
 
 
 @pytest.mark.regression
@@ -85,3 +86,44 @@ def test_save_dataset_to_file_unsupported_type(mock_mkdir):
     with pytest.raises(ValueError, match=r"Unsupported file suffix '.txt'.*"):
         save_dataset_to_file(mock_dataset, output_path)
     mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+
+@pytest.mark.regression
+def test_load_jsonl_unions_optional_nested_fields(tmp_path: Path):
+    """JSONL rows that add nested fields after earlier records still load.
+
+    HuggingFace's json builder infers schema from the first chunk and
+    cannot cast later structs that include extra keys such as ``ttft``.
+
+    ## WRITTEN BY AI ##
+    """
+    path = tmp_path / "mixed.jsonl"
+    rows = [
+        {"id": "a", "requests": [{"t": 1.0, "in": 10, "out": 5}]},
+        {"id": "b", "requests": [{"t": 2.0, "in": 11, "out": 6, "ttft": 0.05}]},
+    ]
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+    dataset = load_dataset_from_file(path)
+    assert len(dataset) == 2
+    assert dataset[0]["requests"][0]["in"] == 10
+    assert dataset[1]["requests"][0]["ttft"] == pytest.approx(0.05)
+
+
+@pytest.mark.sanity
+def test_load_json_array_file(tmp_path: Path):
+    """A ``.json`` file containing a top-level array of records still loads.
+
+    ## WRITTEN BY AI ##
+    """
+    path = tmp_path / "records.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"timestamp": 1, "input_length": 10, "output_length": 1},
+                {"timestamp": 2, "input_length": 20, "output_length": 2},
+            ]
+        )
+    )
+    dataset = load_dataset_from_file(path)
+    assert len(dataset) == 2
+    assert dataset[1]["input_length"] == 20


### PR DESCRIPTION
## Summary

Adds support for weka subagents and tool calls


## Details

- Adds WEKA subagent support
- Adds tool call support to WEKA implementation.
  - Tool calls do not include all of the info needed to reconstruct the tool call output, so the synthetic design has been used here.

## Test Plan

For subagents, you can test it with this huggingface dataset: https://huggingface.co/datasets/semianalysisai/cc-traces-weka-062126-256k
For tool calling, you can test it with this huggingface dataset: https://huggingface.co/datasets/semianalysisai/cc-traces-weka-042026 

For now you will need to download the file, and reference it.

Here is the command used to test it:
`
guidellm run     --backend "kind=openai_http,target=http://localhost:8000,request_format=/v1/chat/completions,validate_backend=false,model=Qwen/Qwen3-0.6B"     --tokenizer "kind=huggingface_auto,model=Qwen/Qwen3-0.6B"     --profile kind=replay  --constraint "kind=max_requests,count=150" --data "kind=weka,path=weka_traces.jsonl" --constraint kind=max_duration,seconds=240
`

## Related Issues

- Resolves #992 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 45bd6f231c1ddc4d6313fa69e35af4aaeca218b6
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Sep 2 14:42:35 2026 -0400

    Added subagent support for WEKA traces
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit a389a2bddd9b40f53277a96fc047f9f396a64948
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Sep 2 14:42:35 2026 -0400

    Add tool call support to WEKA traces
    
    A lot of the data for the tool call response is not present in the trace, so the synthetic design is used in those places.
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
