### PR TITLE
fix: validate only the required columns in trace files

### DIFF
--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -316,16 +316,16 @@ def _validate_row(row: dict, config: TraceDataArgs) -> None:
         )
 
 
-def _raise_if_nonetype_found(dataset: Dataset) -> None:
-    for col in dataset.column_names:
+def _raise_if_nonetype_found(dataset: Dataset, features: Features) -> None:
+    for col in features:
         if dataset.data[col].null_count != 0:
             raise DataNotSupportedError(f"Missing column values in {col}")
 
 
 def _raise_if_incorrect_types(dataset: Dataset, features: Features) -> None:
     try:
-        dataset.cast(features)
-    except ValueError as e:
+        dataset.select_columns(list(features)).cast(features)
+    except (TypeError, ValueError) as e:
         raise DataNotSupportedError(str(e)) from e
 
 
@@ -343,7 +343,7 @@ def _validate_dataset(config: TraceDataArgs, trace_format: TraceFormatBase) -> N
             raise DataNotSupportedError("Trace conversation is empty")
         if config.conversation_id_column in features:
             features.pop(config.conversation_id_column)
-        _raise_if_nonetype_found(conv)
+        _raise_if_nonetype_found(conv, features)
         _raise_if_incorrect_types(conv, features)
         for row in conv:
             _validate_row(row, config)

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -220,6 +220,52 @@ class TestTraceDatasetDeserializer:
         for i, turn in enumerate(conv):
             assert turn.columns["relative_timestamp_column"][0] == i
 
+    @pytest.mark.regression
+    def test_accepts_columns_beyond_the_required_ones(
+        self, tmp_path: Path, deserializer
+    ):
+        """Extra trace columns are ignored rather than rejected.
+
+        Real trace files carry per-request metadata (model, type, timings) that
+        the deserializer does not consume.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            '{"timestamp": 1, "input_length": 10, "output_length": 1, '
+            '"model": "a", "type": "s", "api_time": 4.87}\n'
+            '{"timestamp": 2, "input_length": 20, "output_length": 2, '
+            '"model": "a", "type": "n", "api_time": 2.87}\n',
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = load_graph_turns(next(iter(ds)))
+        assert len(turns) == 2
+        for i, turn in enumerate(turns):
+            assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
+            assert turn.columns["output_tokens_count_column"][0] == i + 1
+
+    @pytest.mark.regression
+    def test_accepts_missing_values_outside_the_required_columns(
+        self, tmp_path: Path, deserializer
+    ):
+        """Nulls outside the required columns do not fail validation.
+
+        Covers both shapes real traces produce: a column absent from some
+        records, and a column that is null on every record.
+
+        ## WRITTEN BY AI ##
+        """
+        trace = write_trace(
+            tmp_path,
+            '{"timestamp": 1, "input_length": 10, "output_length": 1, '
+            '"ttft": 0.4, "stop": null}\n'
+            '{"timestamp": 2, "input_length": 20, "output_length": 2, "stop": null}\n',
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = load_graph_turns(next(iter(ds)))
+        assert len(turns) == 2
+
     @pytest.mark.smoke
     def test_rejects_invalid_path(self, deserializer):
         with pytest.raises(ValidationError, match="not a valid path"):
@@ -276,6 +322,17 @@ class TestTraceDatasetDeserializer:
                 '{"timestamp": 0, "input_length": 10, "output_length": null}\n',
                 {},
                 "Missing column values",
+            ),
+            (
+                '{"timestamp": "bad", "input_length": 10, "output_length": 5, '
+                '"model": "a"}\n',
+                {},
+                "scalar of type float",
+            ),
+            (
+                '{"timestamp": 0, "input_length": [1, 2], "output_length": 5}\n',
+                {},
+                "Couldn't cast",
             ),
         ],
     )

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -330,6 +330,13 @@ class TestWEKATraceFormat:
                 '{"id": "conv0", "requests": []}\n',
                 "requests was empty",
             ),
+            (
+                '{"id": "conv0", "requests": [{"t": 0, "in": 10, "out": 5,'
+                '"hash_ids": [], "model": "a", "ttft": 0.5}]}\n'
+                '{"id": "conv1", "requests": [{"t": 0, "in": 10, "out": 5,'
+                '"model": "a"}]}\n',
+                "Missing column values in hash_ids",
+            ),
         ],
     )
     def test_trace_validation_raises(
@@ -355,6 +362,47 @@ class TestWEKATraceFormat:
         )
         with pytest.raises(DataNotSupportedError, match="conversation is empty"):
             self.deserialize(deserializer, trace)
+
+    @pytest.mark.regression
+    def test_accepts_spec_metadata_on_request_records(
+        self, tmp_path: Path, deserializer, default_block_size
+    ):
+        """Accept WEKA request records carrying the fields the specification defines.
+
+        Those are model, type, input_types, output_types and stop on every
+        record, plus api_time, ttft and think_time, which are optional.
+
+        ## WRITTEN BY AI ##
+        """
+        first_in = 2 * default_block_size
+        second_in = 3 * default_block_size
+        trace = write_trace(
+            tmp_path,
+            '{"id": "conv0", "hash_id_scope": "local", "requests": ['
+            f'{{"t": 0.0, "type": "s", "model": "a", "in": {first_in}, "out": 205, '
+            '"hash_ids": [1, 2], "input_types": ["text"], '
+            '"output_types": ["thinking", "tool_use"], "stop": "tool_use", '
+            '"api_time": 4.87, "ttft": 0.5, "think_time": 0.0}, '
+            f'{{"t": 17.0, "type": "n", "model": "a", "in": {second_in}, "out": 82, '
+            '"hash_ids": [1, 2, 3], "input_types": ["tool_result"], '
+            '"output_types": ["tool_use"], "stop": "tool_use", '
+            '"api_time": 2.87}]}\n',
+        )
+        ds = self.deserialize(deserializer, trace)
+        turns = load_graph_turns(next(iter(ds)))
+        assert len(turns) == 2
+        assert [turn.columns["prompt_tokens_count_column"][0] for turn in turns] == [
+            first_in,
+            second_in,
+        ]
+        assert [turn.columns["output_tokens_count_column"][0] for turn in turns] == [
+            205,
+            82,
+        ]
+        assert [turn.columns["relative_timestamp_column"][0] for turn in turns] == [
+            0.0,
+            17.0,
+        ]
 
     @pytest.mark.sanity
     def test_incompatible_encoding_raises(


### PR DESCRIPTION
## Summary

Trace validation casts each conversation to the required feature set and scans every column for nulls. `Dataset.cast` requires the column sets to match, so a trace carrying any column beyond the required ones is rejected before the benchmark starts. A null in a column the deserializer never reads fails the same way.

Real traces carry that metadata. The WEKA specification defines `model`, `type`, `input_types`, `output_types` and `stop` on every request record, plus optional `api_time`, `ttft` and `think_time`. A trace that follows it cannot be loaded:

```
DataNotSupportedError: The columns in features (['t', 'in', 'out', 'hash_ids'])
must be identical as the columns in the dataset:
['t', 'type', 'model', 'in', 'out', 'hash_ids', 'input_types', 'output_types', 'stop']
```

The reference trace from the specification fails on this, and so does `semianalysisai/cc-traces-weka-no-subagents-051226`, which `docs/guides/trace_replay.md` links to as an example. That dataset carries five of those fields, and 471 of its 949 conversations omit `ttft` or `think_time` on at least one record, which trips the null scan.

The guide already describes the intended behavior: `trace_synthetic` looks only at the timestamp, prompt token count and output token count columns, "ignoring all other features contained in a dataset". This change restores that for all three formats. Traces containing only the required columns are unaffected.

Before #1012 the validation loop ran per required column, and its docstring described the contract as "A required column contains a NoneType" and "A required column failed during cast to feature type". #1012 widened both checks to the whole dataset.

This does not implement nested WEKA subagent replay. With this fixed, the canonical subagent trace gets past top-level schema validation and then fails on the nested records, which is tracked by #992.

## Details

- [x] `_raise_if_incorrect_types` selects the required columns before casting, so unrelated columns are neither constrained nor copied
- [x] a shape mismatch in a required column raises `TypeError` rather than `ValueError` and previously escaped the deserializer uncaught, so both are now converted to `DataNotSupportedError`
- [x] `_raise_if_nonetype_found` takes the required features and checks only those columns
- [x] tests that extra columns and nulls outside the required columns are accepted, and that a null, a bad scalar type or a bad shape in a required column is still rejected

## Test Plan

- `tox -e lint-check` and `tox -e type-check`: clean
- `tox -e tests -- tests/unit/data/deserializers/`: 200 passed, 1 skipped
- `tox -e test-unit`: 2936 passed, excluding 14 `tests/unit/utils/test_audio.py` failures from a missing local FFmpeg library that fail identically on `main`
- `tox -e test-integration`: 27 passed
- `tox -e test-e2e`: 13 passed, with the same local FFmpeg error on `main`
- checked all three registered formats: `trace_synthetic`, `mooncake` and `weka` traces carrying extra columns are rejected on `main` and load on this branch
- loaded the reference `sample_trace.json` from the specification and the first 30 conversations of `cc-traces-weka-no-subagents-051226`, both of which fail on `main`

## Related Issues

- Prerequisite for #992

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit 08e5a77801fc1dc58b4a8ceb61c4ff5c01e9ffb9
Author: QHarshil <harshil_c@hotmail.com>
Date:   Mon Aug 31 13:36:36 2026 -0700

    fix: validate only the required columns in trace files
    
    Trace validation cast each conversation to the required feature set and
    scanned every column for nulls. Dataset.cast requires the column sets to
    match, so a trace carrying any extra column was rejected, and a null in a
    column the deserializer never reads failed validation the same way.
    
    The WEKA specification defines model, type, input_types, output_types and
    stop on every request record, alongside optional api_time, ttft and
    think_time, so no trace that follows it can be loaded. The reference trace
    from the specification fails on this, as does the
    semianalysisai/cc-traces-weka-no-subagents-051226 dataset linked from
    docs/guides/trace_replay.md, which carries five of those fields. That guide
    already describes trace_synthetic as ignoring all other features contained
    in a dataset.
    
    Select the required columns before casting, and check only those for nulls,
    so unrelated columns are ignored. A shape mismatch in a required column
    surfaces as TypeError rather than ValueError, and previously escaped the
    deserializer uncaught, so convert both to DataNotSupportedError.
    
    Signed-off-by: QHarshil <harshil_c@hotmail.com>
    Generated-by: Claude Code claude-opus-5

---------

Generated-by: Claude Code claude-opus-5
Signed-off-by: QHarshil <harshil_c@hotmail.com>
