### PR TITLE
fix: filter warmup/cooldown by request start time instead of overlap

### DIFF
--- a/src/guidellm/benchmark/schemas/generative/accumulator.py
+++ b/src/guidellm/benchmark/schemas/generative/accumulator.py
@@ -623,16 +623,9 @@ class GenerativeRequestsAccumulator(StandardBaseModel):
         return [
             stats
             for stats in self.requests_stats
-            if (
-                stats.request_start_time is not None
-                and stats.request_start_time >= start_time
-                and stats.request_start_time <= end_time
-            )
-            or (
-                stats.request_start_time is None
-                and stats.request_end_time >= start_time
-                and stats.request_end_time <= end_time
-            )
+            if stats.request_start_time is not None
+            and stats.request_start_time >= start_time
+            and stats.request_start_time <= end_time
         ]
 
     def update_estimate(

--- a/src/guidellm/benchmark/schemas/generative/accumulator.py
+++ b/src/guidellm/benchmark/schemas/generative/accumulator.py
@@ -608,25 +608,30 @@ class GenerativeRequestsAccumulator(StandardBaseModel):
         self, start_time: float, end_time: float
     ) -> list[GenerativeRequestStats]:
         """
-        Retrieve request statistics within a specified time range.
+        Retrieve request statistics that were initiated within a time range.
 
-        :param start_time: Start timestamp for filtering (requests must end after this)
-        :param end_time: End timestamp for filtering (requests must start before this)
-        :return: List of request statistics within the time range
+        Filters by request start time so that warmup/cooldown phases cleanly
+        exclude requests that began outside the measurement window, even if
+        those requests completed during (overlapped with) the window.
+
+        :param start_time: Start timestamp for filtering (requests must have
+            started at or after this timestamp)
+        :param end_time: End timestamp for filtering (requests must have started
+            at or before this timestamp)
+        :return: List of request statistics initiated within the time range
         """
         return [
             stats
             for stats in self.requests_stats
-            if (stats.request_end_time >= start_time)
-            and (
-                (
-                    stats.request_start_time is not None
-                    and stats.request_start_time <= end_time
-                )
-                or (
-                    stats.request_start_time is None
-                    and stats.request_end_time <= end_time
-                )
+            if (
+                stats.request_start_time is not None
+                and stats.request_start_time >= start_time
+                and stats.request_start_time <= end_time
+            )
+            or (
+                stats.request_start_time is None
+                and stats.request_end_time >= start_time
+                and stats.request_end_time <= end_time
             )
         ]
 


### PR DESCRIPTION
## Summary

- **Fixes warmup/cooldown request filtering** in `get_within_range()` to use request start time instead of time-range overlap.
- Previously, requests that *started* during warmup but *completed* during the measurement window would leak into final metrics. This made `--warmup` ineffective for excluding the initial "thundering herd" in high-concurrency benchmarks.
- With this fix, `--warmup` behaves intuitively: requests that started during warmup are excluded regardless of when they completed.

## Problem

When running concurrent benchmarks (e.g., concurrency 200-300), guidellm launches all requests simultaneously at t=0. These initial requests queue up on the server and get inflated TTFT values (up to 14 seconds at concurrency 300 vs ~1.2s steady state). Setting `--warmup` was intended to exclude these, but the overlap-based filter in `get_within_range()` would still include them because their `request_end_time` fell after `measure_start`.

Example at concurrency 300 with `--warmup 70`:
- Thundering herd request: starts at t=0, TTFT=14s, ends at t=66s
- `measure_start` = t+70s
- **Old behavior**: included (end_time 66 >= measure_start 70? No — but a request ending at t=80 would pass)
- Requests starting at t=20 with latency 55s end at t=75 > measure_start=70 → **included despite being a warmup request**
- **New behavior**: excluded (start_time 0 < measure_start 70)

## Change

**File**: `src/guidellm/benchmark/schemas/generative/accumulator.py`

**Before** (overlap-based):
```python
if (stats.request_end_time >= start_time)
and (stats.request_start_time <= end_time)
```

**After** (start-time-based):
```python
if (stats.request_start_time >= start_time)
and (stats.request_start_time <= end_time)
```

A request is now included only if it was *initiated* within the measurement window. The fallback for `request_start_time is None` uses `request_end_time` with the same bounded check.

## Test plan

- [ ] Verified with mock data: warmup requests (started before measure_start, ended after) are correctly excluded
- [ ] Verified clean requests (started within measurement window) are correctly included  
- [ ] Verified cooldown requests (started after measure_end) are correctly excluded
- [ ] Verified fallback behavior when request_start_time is None
- [ ] Needs validation with a real benchmark run using `--warmup` + `--rampup` to confirm TTFT p95 is clean


Made with [Cursor](https://cursor.com)

<!-- begin:squash-data -->

---

# git log

commit 74d0e0641222afbe0a56f56b491826e55645e1b5
Author: Harshith-umesh <harshith.umesh.nat@gmail.com>
Date:   Mon Aug 31 20:30:33 2026 -0400

    fix: filter warmup/cooldown by request start time instead of overlap
    
    The `get_within_range` method previously used an overlap-based filter:
    a request was included if its time range [start, end] overlapped with
    the measurement window. This meant requests that started during warmup
    but completed during the measurement period would leak into the final
    metrics, defeating the purpose of warmup.
    
    This is particularly problematic for high-concurrency benchmarks where
    the initial "thundering herd" of requests creates inflated TTFT values.
    These requests take 50-65s to complete and would pass through warmup
    windows shorter than the request latency, contaminating TTFT p95.
    
    The fix changes the filter to use request start time: a request is
    included only if it was initiated within the measurement window
    [measure_start, measure_end]. This makes --warmup behave intuitively -
    requests that started during warmup are excluded regardless of when
    they completed.
    
    Signed-off-by: Harshith-umesh
    Co-authored-by: Cursor <cursoragent@cursor.com>

commit 8e1a0be8978a50fbfc40f123538c01df6473da4d
Author: Harshith-umesh <harshith.umesh.nat@gmail.com>
Date:   Tue Sep 1 15:54:58 2026 -0400

    simplify: drop unreachable None fallback in get_within_range
    
    request_start_time falls back to resolve_start, and update_estimate
    only ever adds a request to requests_stats after resolve_start is
    set (cancelled-before-start requests are dropped entirely). So
    request_start_time can never be None for anything this method
    iterates over, making the fallback branch dead code.
    
    Co-authored-by: Cursor <cursoragent@cursor.com>

---------

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Harshith-umesh
