### PR TITLE
fix: ensure backend cleanup after resolution errors

### DIFF
--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -99,16 +99,17 @@ async def resolve_backend(
         )
 
     await backend_instance.process_startup()
-    await backend_instance.validate()
+    try:
+        await backend_instance.validate()
 
-    if console_step:
-        console_step.update(
-            title="Resolving default model from backend.default_model",
-            status_level="info",
-        )
-    model = await backend_instance.default_model()
-
-    await backend_instance.process_shutdown()
+        if console_step:
+            console_step.update(
+                title="Resolving default model from backend.default_model",
+                status_level="info",
+            )
+        model = await backend_instance.default_model()
+    finally:
+        await backend_instance.process_shutdown()
 
     if console_step:
         console_step.finish(

--- a/tests/unit/benchmark/test_entrypoints.py
+++ b/tests/unit/benchmark/test_entrypoints.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from guidellm.benchmark.entrypoints import resolve_output_formats
+from guidellm.benchmark.entrypoints import resolve_backend, resolve_output_formats
 from guidellm.benchmark.outputs import GenerativeBenchmarkerOutput
+from guidellm.schemas.backends import OpenAIHTTPBackendArgs
 from guidellm.schemas.benchmark import JSONBenchmarkOutputArgs
 
 
@@ -33,3 +35,30 @@ async def test_resolve_output_formats_preserves_duplicate_kinds(tmp_path: Path):
         tmp_path / "first.json",
         tmp_path / "second.json",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_resolve_backend_shuts_down_after_validation_error():
+    """
+    resolve_backend shuts down a started backend when validation fails.
+
+    ## WRITTEN BY AI ##
+    """
+    backend = MagicMock()
+    backend.process_startup = AsyncMock()
+    backend.validate = AsyncMock(side_effect=RuntimeError("validation failed"))
+    backend.default_model = AsyncMock()
+    backend.process_shutdown = AsyncMock()
+    args = OpenAIHTTPBackendArgs(target="http://localhost:8000")
+
+    with (
+        patch("guidellm.benchmark.entrypoints.Backend.create", return_value=backend),
+        pytest.raises(RuntimeError, match="validation failed"),
+    ):
+        await resolve_backend(args)
+
+    backend.process_startup.assert_awaited_once_with()
+    backend.validate.assert_awaited_once_with()
+    backend.default_model.assert_not_awaited()
+    backend.process_shutdown.assert_awaited_once_with()


### PR DESCRIPTION
Backend startup allocates clients and other resources before validation and model resolution. Ensure cleanup runs whenever startup succeeds, even when either phase raises, preventing leaked clients and connections in long-lived or retrying processes. Add a regression test covering validation failure.

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit a831de47bbad04df950cb4ae2c4329715eda00a2
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Tue Sep 1 14:09:51 2026 +0800

    fix: ensure backend cleanup after resolution errors
    
    Backend startup allocates clients and other resources before validation and model resolution. Ensure cleanup runs whenever startup succeeds, even when either phase raises, preventing leaked clients and connections in long-lived or retrying processes. Add a regression test covering validation failure.
    
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

---------

Signed-off-by: tangming1996 <ming.tang@daocloud.io>
