### PR TITLE
docs: clarify default benchmark outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,33 +142,54 @@ You will see progress updates and per-benchmark summaries during the run, as giv
 
 ### Inspect Outputs
 
-After the benchmark completes, GuideLLM saves JSON and CSV results into the output directory you specified (default: the current directory). You'll see a summary printed in the console along with the generated file locations. An HTML report is optional and must be requested explicitly with `--output kind=html,path=benchmarks.html`.
+After the benchmark completes, GuideLLM writes `benchmarks.json` and `benchmarks.csv` by default. The files are saved in the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or in the current directory when the variable is not set. GuideLLM also prints a summary and the generated file locations to the console.
+
+Additional file formats, such as HTML, YAML, and PLOT, must be requested with `--output`. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every format you want. For example, to keep both defaults and add an HTML report:
+
+```bash
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000 \
+  --profile kind=sweep \
+  --constraint kind=max_duration,seconds=30 \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
+  --output kind=json \
+  --output kind=csv \
+  --output kind=html
+```
+
+Each output type supplies a default filename, so `path` is only needed to change the name or destination.
 
 The following section, **Output Files and Reports**, explains what each file contains and how to use them for analysis, visualization, or automation.
 
 ## Output Files and Reports
 
-After running the Quick Start benchmark, GuideLLM writes several output files to the directory you specified. Each one focuses on a different layer of analysis, ranging from a quick on-screen summary to fully structured data for dashboards and regression pipelines.
+The Quick Start benchmark produces console, JSON, and CSV output. Other formats can be selected explicitly. Each format focuses on a different layer of analysis, ranging from a quick on-screen summary to fully structured data for dashboards and regression pipelines.
 
-**Console Output**
+**Console output**
 
-The console provides a lightweight summary with high-level statistics for each benchmark in the run. It's useful for quick checks to confirm that the server responded correctly, the load sweep completed, and the system behaved as expected. Additionally, the output tables can be copied and pasted into spreadsheet software using `|` as the delimiter. The sections will look similar to the following:
+The console provides a lightweight summary with high-level statistics for each benchmark in the run. It's useful for quick checks to confirm that the server responded correctly, the load sweep completed, and the system behaved as expected. Additionally, the output tables can be copied and pasted into spreadsheet software using `|` as the delimiter. Console output is independent of the file formats selected with `--output`; disable it with `--disable-console`. The sections will look similar to the following:
 
 <img alt="Sample GuideLLM benchmark output" src="https://raw.githubusercontent.com/vllm-project/guidellm/main/docs/assets/sample-output.png" />
 
-**benchmarks.json**
+**JSON output (`benchmarks.json` by default)**
 
 This file is the authoritative record of the entire benchmark session. It includes configuration, metadata, per-benchmark statistics, and sample request entries with individual request timings. Use it for debugging, deeper analysis, or loading into Python with `GenerativeBenchmarksReport`.
 
-Alternatively, a YAML version of this file can be generated for easier human readability with the same content as `benchmarks.json` using `--output kind=yaml,path=benchmarks.yaml`.
-
-**benchmarks.csv**
+**CSV output (`benchmarks.csv` by default)**
 
 This file provides a compact tabular view of each benchmark with the fields most commonly used for reporting—throughput, latency percentiles, token counts, and rate information. It opens cleanly in spreadsheets and BI tools and is well-suited for comparisons across runs.
 
-**benchmarks.html** (optional)
+**YAML output (`benchmarks.yaml` by default)**
 
-A self-contained HTML report with charts and tables for throughput and latency (emphasizing P95/P99). The file embeds its own CSS and JavaScript, so it can be shared without network access or a versioned UI dependency.
+This file contains the same detailed benchmark data as the JSON output in a more human-readable format. Generate it with `--output kind=yaml`; it can be produced alongside any other format.
+
+**HTML output (`benchmarks.html` by default)**
+
+This self-contained report includes charts and tables for throughput and latency (emphasizing P95/P99). The file embeds its own CSS and JavaScript, so it can be shared without network access or a versioned UI dependency. Generate it with `--output kind=html`.
+
+**PLOT output (`benchmarks.png` by default)**
+
+This static image contains benchmark performance graphs. Generate it with `--output kind=plot`. The output format is selected by the `path` extension and can be PNG, JPG/JPEG, SVG, or PDF. For example, `--output kind=plot,path=benchmarks.pdf` creates a PDF, and the optional `dpi` parameter controls image resolution.
 
 ## Common Use Cases and Configurations
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You will see progress updates and per-benchmark summaries during the run, as giv
 
 ### Inspect Outputs
 
-After the benchmark completes, GuideLLM saves all results into the output directory you specified (default: the current directory). You'll see a summary printed in the console along with a set of file locations (`.json,` `.csv`, `.html`) that contain the full results of the run.
+After the benchmark completes, GuideLLM saves JSON and CSV results into the output directory you specified (default: the current directory). You'll see a summary printed in the console along with the generated file locations. An HTML report is optional and must be requested explicitly with `--output kind=html,path=benchmarks.html`.
 
 The following section, **Output Files and Reports**, explains what each file contains and how to use them for analysis, visualization, or automation.
 
@@ -160,13 +160,13 @@ The console provides a lightweight summary with high-level statistics for each b
 
 This file is the authoritative record of the entire benchmark session. It includes configuration, metadata, per-benchmark statistics, and sample request entries with individual request timings. Use it for debugging, deeper analysis, or loading into Python with `GenerativeBenchmarksReport`.
 
-Alternatively, a YAML version of this file can be generated for easier human readability with the same content as `benchmarks.json` using `--output yaml "path=benchmarks.yaml"`.
+Alternatively, a YAML version of this file can be generated for easier human readability with the same content as `benchmarks.json` using `--output kind=yaml,path=benchmarks.yaml`.
 
 **benchmarks.csv**
 
 This file provides a compact tabular view of each benchmark with the fields most commonly used for reporting—throughput, latency percentiles, token counts, and rate information. It opens cleanly in spreadsheets and BI tools and is well-suited for comparisons across runs.
 
-**benchmarks.html**
+**benchmarks.html** (optional)
 
 A self-contained HTML report with charts and tables for throughput and latency (emphasizing P95/P99). The file embeds its own CSS and JavaScript, so it can be shared without network access or a versioned UI dependency.
 

--- a/README.md
+++ b/README.md
@@ -144,52 +144,15 @@ You will see progress updates and per-benchmark summaries during the run, as giv
 
 After the benchmark completes, GuideLLM writes `benchmarks.json` and `benchmarks.csv` by default. The files are saved in the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or in the current directory when the variable is not set. GuideLLM also prints a summary and the generated file locations to the console.
 
-Additional file formats, such as HTML, YAML, and PLOT, must be requested with `--output`. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every format you want. For example, to keep both defaults and add an HTML report:
-
-```bash
-guidellm run \
-  --backend kind=openai_http,target=http://localhost:8000 \
-  --profile kind=sweep \
-  --constraint kind=max_duration,seconds=30 \
-  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json \
-  --output kind=csv \
-  --output kind=html
-```
-
-Each output type supplies a default filename, so `path` is only needed to change the name or destination.
-
-The following section, **Output Files and Reports**, explains what each file contains and how to use them for analysis, visualization, or automation.
+Specifying `--output` replaces the default JSON and CSV outputs. See [output configuration](docs/guides/outputs.md#cli-output-configuration) for examples of selecting formats, including generating HTML alongside JSON and CSV.
 
 ## Output Files and Reports
 
-The Quick Start benchmark produces console, JSON, and CSV output. Other formats can be selected explicitly. Each format focuses on a different layer of analysis, ranging from a quick on-screen summary to fully structured data for dashboards and regression pipelines.
+Use JSON or YAML for detailed analysis, CSV for spreadsheet comparisons, HTML for self-contained visual reports, and PLOT for static performance graphs. See [supported file formats](docs/guides/outputs.md#supported-file-formats) for their contents and default filenames, and [configuring file outputs](docs/guides/outputs.md#configuring-file-outputs) to choose output paths.
 
-**Console output**
-
-The console provides a lightweight summary with high-level statistics for each benchmark in the run. It's useful for quick checks to confirm that the server responded correctly, the load sweep completed, and the system behaved as expected. Additionally, the output tables can be copied and pasted into spreadsheet software using `|` as the delimiter. Console output is independent of the file formats selected with `--output`; disable it with `--disable-console`. The sections will look similar to the following:
+The console provides a summary of each benchmark. Its tables can be copied into spreadsheet software using `|` as the delimiter. See [console output](docs/guides/outputs.md#console-output) for progress and display controls.
 
 <img alt="Sample GuideLLM benchmark output" src="https://raw.githubusercontent.com/vllm-project/guidellm/main/docs/assets/sample-output.png" />
-
-**JSON output (`benchmarks.json` by default)**
-
-This file is the authoritative record of the entire benchmark session. It includes configuration, metadata, per-benchmark statistics, and sample request entries with individual request timings. Use it for debugging, deeper analysis, or loading into Python with `GenerativeBenchmarksReport`.
-
-**CSV output (`benchmarks.csv` by default)**
-
-This file provides a compact tabular view of each benchmark with the fields most commonly used for reporting—throughput, latency percentiles, token counts, and rate information. It opens cleanly in spreadsheets and BI tools and is well-suited for comparisons across runs.
-
-**YAML output (`benchmarks.yaml` by default)**
-
-This file contains the same detailed benchmark data as the JSON output in a more human-readable format. Generate it with `--output kind=yaml`; it can be produced alongside any other format.
-
-**HTML output (`benchmarks.html` by default)**
-
-This self-contained report includes charts and tables for throughput and latency (emphasizing P95/P99). The file embeds its own CSS and JavaScript, so it can be shared without network access or a versioned UI dependency. Generate it with `--output kind=html`.
-
-**PLOT output (`benchmarks.png` by default)**
-
-This static image contains benchmark performance graphs. Generate it with `--output kind=plot`. The output format is selected by the `path` extension and can be PNG, JPG/JPEG, SVG, or PDF. For example, `--output kind=plot,path=benchmarks.pdf` creates a PDF, and the optional `dpi` parameter controls image resolution.
 
 ## Common Use Cases and Configurations
 

--- a/docs/getting-started/analyze.md
+++ b/docs/getting-started/analyze.md
@@ -64,11 +64,12 @@ The p99 (99th percentile) values are particularly important for SLO analysis, as
 
 ## Analyzing the Results File
 
-For deeper analysis, GuideLLM saves detailed results to multiple files by default in your current directory:
+For deeper analysis, GuideLLM saves these detailed results by default in your current directory:
 
 - `benchmarks.json`: Complete benchmark data in JSON format
 - `benchmarks.csv`: Summary of key metrics in CSV format
-- `benchmarks.html`: Self-contained HTML report with visualizations
+
+To also generate a self-contained HTML report, add `--output kind=html,path=benchmarks.html` to the benchmark command.
 
 ### File Formats
 

--- a/docs/getting-started/analyze.md
+++ b/docs/getting-started/analyze.md
@@ -62,24 +62,37 @@ This is the most critical section for performance analysis. It displays detailed
 
 The p99 (99th percentile) values are particularly important for SLO analysis, as they represent the worst-case performance for 99% of requests.
 
-## Analyzing the Results File
+## Analyzing Saved Results
 
-For deeper analysis, GuideLLM saves these detailed results by default in your current directory:
+For deeper analysis, GuideLLM saves detailed results to these files by default:
 
 - `benchmarks.json`: Complete benchmark data in JSON format
 - `benchmarks.csv`: Summary of key metrics in CSV format
 
-To also generate a self-contained HTML report, add `--output kind=html,path=benchmarks.html` to the benchmark command.
+The files are written to the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or to the current directory when the variable is not set.
+
+Additional formats must be requested with `--output`. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every format you want. For example, to keep the default files and add a self-contained HTML report:
+
+```bash
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000 \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
+  --output kind=json \
+  --output kind=csv \
+  --output kind=html
+```
+
+Each file output has a default filename. Add `path=` only when you want to change its name or destination.
 
 ### File Formats
 
-GuideLLM supports multiple output formats that can be customized:
+GuideLLM supports multiple file output formats that can be customized:
 
 - **JSON**: Complete benchmark data in JSON format with full request samples
 - **YAML**: Complete benchmark data in YAML format with full request samples
 - **CSV**: Summary of key metrics in CSV format suitable for spreadsheets
 - **HTML**: Self-contained HTML report with charts and tables
-- **Console**: Terminal output displayed during execution
+- **PLOT**: Static performance graphs in PNG, JPG/JPEG, SVG, or PDF format
 
 To specify which formats to generate, and where to save them, use the `--output` option, which can be repeated for multiple formats:
 
@@ -90,6 +103,8 @@ guidellm run \
   --output kind=json,path=results/benchmarks.json \
   --output kind=csv,path=results/summary.csv
 ```
+
+Console output is an independent implicit default. Selecting file outputs does not disable it, and specifying `--output kind=console` does not customize it. Use `--disable-console` to suppress all console output or `--disable-console-interactive` to suppress only interactive progress updates.
 
 ### Programmatic Analysis
 

--- a/docs/getting-started/analyze.md
+++ b/docs/getting-started/analyze.md
@@ -69,42 +69,11 @@ For deeper analysis, GuideLLM saves detailed results to these files by default:
 - `benchmarks.json`: Complete benchmark data in JSON format
 - `benchmarks.csv`: Summary of key metrics in CSV format
 
-The files are written to the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or to the current directory when the variable is not set.
-
-Additional formats must be requested with `--output`. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every format you want. For example, to keep the default files and add a self-contained HTML report:
-
-```bash
-guidellm run \
-  --backend kind=openai_http,target=http://localhost:8000 \
-  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json \
-  --output kind=csv \
-  --output kind=html
-```
-
-Each file output has a default filename. Add `path=` only when you want to change its name or destination.
+The files are written to the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or to the current directory when the variable is not set. See [configuring file outputs](../guides/outputs.md#configuring-file-outputs) to choose filenames and destinations.
 
 ### File Formats
 
-GuideLLM supports multiple file output formats that can be customized:
-
-- **JSON**: Complete benchmark data in JSON format with full request samples
-- **YAML**: Complete benchmark data in YAML format with full request samples
-- **CSV**: Summary of key metrics in CSV format suitable for spreadsheets
-- **HTML**: Self-contained HTML report with charts and tables
-- **PLOT**: Static performance graphs in PNG, JPG/JPEG, SVG, or PDF format
-
-To specify which formats to generate, and where to save them, use the `--output` option, which can be repeated for multiple formats:
-
-```bash
-guidellm run \
-  --backend kind=openai_http,target=http://localhost:8000 \
-  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json,path=results/benchmarks.json \
-  --output kind=csv,path=results/summary.csv
-```
-
-Console output is an independent implicit default. Selecting file outputs does not disable it, and specifying `--output kind=console` does not customize it. Use `--disable-console` to suppress all console output or `--disable-console-interactive` to suppress only interactive progress updates.
+See [supported file formats](../guides/outputs.md#supported-file-formats) for the available reports and [output configuration](../guides/outputs.md#cli-output-configuration) for examples of selecting them. Explicit `--output` options replace the default JSON and CSV selection. Console display controls are described in [console output](../guides/outputs.md#console-output).
 
 ### Programmatic Analysis
 

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -298,7 +298,7 @@ guidellm run \
 
 ## Output Options
 
-By default, complete results are saved to `benchmarks.json` and `benchmarks.csv` in your current directory. Specify outputs explicitly with the `--output` option, which can be repeated for multiple formats:
+By default, complete results are saved to `benchmarks.json` and `benchmarks.csv`. The files use `GUIDELLM__DEFAULT_RESULTS_DIR` when set and the current directory otherwise. Specifying any `--output` replaces both defaults, so repeat the option for every format you want:
 
 ```bash
 guidellm run \

--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -298,18 +298,7 @@ guidellm run \
 
 ## Output Options
 
-By default, complete results are saved to `benchmarks.json` and `benchmarks.csv`. The files use `GUIDELLM__DEFAULT_RESULTS_DIR` when set and the current directory otherwise. Specifying any `--output` replaces both defaults, so repeat the option for every format you want:
-
-```bash
-guidellm run \
-  --backend kind=openai_http,target=http://localhost:8000 \
-  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json,path=results/benchmark.json \
-  --output kind=csv,path=results/benchmark.csv \
-  --output kind=html,path=results/benchmark.html
-```
-
-Learn more about output options in the [Outputs documentation](../guides/outputs.md).
+By default, benchmark results are saved to `benchmarks.json` and `benchmarks.csv`. Specifying `--output` replaces this default selection. See [output configuration](../guides/outputs.md#cli-output-configuration) for examples of selecting formats and [configuring file outputs](../guides/outputs.md#configuring-file-outputs) for default directories and custom paths.
 
 ## Authentication
 

--- a/docs/guides/outputs.md
+++ b/docs/guides/outputs.md
@@ -4,22 +4,24 @@ GuideLLM provides flexible options for outputting benchmark results, catering to
 
 ## CLI Output Configuration
 
-Outputs follows the typed registry-backed CLI pattern. Repeat `--output` with the appropriate type for each format:
+Without any `--output` options, GuideLLM writes `benchmarks.json` and `benchmarks.csv`. These files use the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or the current directory when the variable is not set.
+
+Output configuration follows the typed registry-backed CLI pattern. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every file format you want. This example keeps both default formats and adds HTML:
 
 ```bash
 guidellm run \
   --backend kind=openai_http,target=http://localhost:8000 \
   --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json,path=results/benchmark.json \
-  --output kind=csv,path=results/benchmark.csv \
-  --output kind=html,path=results/benchmark.html
+  --output kind=json \
+  --output kind=csv \
+  --output kind=html
 ```
 
-Supported output types: `json`, `yaml`, `csv`, `html`, `plot`, and `console`. Each accepts a `path` parameter (defaults vary by type; for example `benchmarks.json` for JSON).
+Supported file output types are `json`, `yaml`, `csv`, `html`, and `plot`. Each supplies a default filename, so `path` is only needed to change the name or destination. Console output is configured separately as described below.
 
 ## Console Output
 
-By default, GuideLLM displays benchmark results and progress directly in the console. The console progress and outputs are divided into multiple sections:
+By default, GuideLLM displays benchmark results and progress directly in the console. Console output is an implicit default: it is not replaced by explicit `--output` options, and specifying `--output kind=console` has no additional effect. The console progress and outputs are divided into multiple sections:
 
 1. **Initial Setup Progress**: Displays the progress of the initial setup, including server connection and data preparation.
 2. **Benchmark Progress**: Shows the progress of the benchmark runs, including the number of requests completed and the current rate.
@@ -63,12 +65,13 @@ GuideLLM supports saving benchmark results to files in various formats, includin
 3. **CSV**: Provides a summary of the benchmark data, focusing on key metrics and statistics. Note that CSV does not include detailed request-level data.
 4. **HTML**: Self-contained static HTML report with throughput/latency charts and tables (no CDN or external assets).
 5. **PLOT**: Static image chart of benchmark metrics. The image format is selected from the `path` file extension — supported formats are PNG, JPG/JPEG, SVG, and PDF. A path with no extension defaults to `.png`, and an unsupported extension raises an error. The `dpi` parameter (default `100`) sets the output image resolution in dots per inch — for example, `--output kind=plot,path=plot.png,dpi=72`.
-6. **Console**: Terminal output displayed during execution (can be disabled).
 
 ### Configuring File Outputs
 
-- **Output path**: Pass `path=` in each `--output` config. Use an explicit filename to control the destination, or a directory-style path as supported by each output type.
+- **Default destination**: File outputs use `GUIDELLM__DEFAULT_RESULTS_DIR` when set and the current directory otherwise.
+- **Output path**: Each file type has a default filename. Pass `path=` to control the name or destination.
 - **Multiple formats**: Repeat `--output` with different types.
+- **Explicit selection**: Any `--output` replaces the default JSON and CSV selection. Include `--output kind=json` and `--output kind=csv` explicitly when you want to preserve them.
 
 #### Example commands to save results in specific formats:
 
@@ -85,6 +88,8 @@ guidellm run \
 ```
 
 **Example: Single output format**
+
+This command writes only JSON (in addition to the independent console output):
 
 ```bash
 guidellm run \

--- a/docs/guides/outputs.md
+++ b/docs/guides/outputs.md
@@ -4,7 +4,7 @@ GuideLLM provides flexible options for outputting benchmark results, catering to
 
 ## CLI Output Configuration
 
-Without any `--output` options, GuideLLM writes `benchmarks.json` and `benchmarks.csv`. These files use the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or the current directory when the variable is not set.
+Without any `--output` options, `guidellm run` writes `benchmarks.json` and `benchmarks.csv` to the [default results directory](#configuring-file-outputs).
 
 Output configuration follows the typed registry-backed CLI pattern. Specifying any `--output` replaces the default JSON and CSV outputs, so repeat the option for every file format you want. This example keeps both default formats and adds HTML:
 
@@ -17,7 +17,7 @@ guidellm run \
   --output kind=html
 ```
 
-Supported file output types are `json`, `yaml`, `csv`, `html`, and `plot`. Each supplies a default filename, so `path` is only needed to change the name or destination. Console output is configured separately as described below.
+Choose from the [supported file formats](#supported-file-formats) and see [configuring file outputs](#configuring-file-outputs) to set paths. Console output is controlled separately as described below.
 
 ## Console Output
 
@@ -60,36 +60,21 @@ GuideLLM supports saving benchmark results to files in various formats, includin
 
 ### Supported File Formats
 
-1. **JSON**: Contains all benchmark results, including full statistics and request data. This format is ideal for reloading into Python for in-depth analysis.
-2. **YAML**: Contains all benchmark results, including full statistics and request data, in YAML format which is human-readable and easy to work with in various tools.
-3. **CSV**: Provides a summary of the benchmark data, focusing on key metrics and statistics. Note that CSV does not include detailed request-level data.
-4. **HTML**: Self-contained static HTML report with throughput/latency charts and tables (no CDN or external assets).
-5. **PLOT**: Static image chart of benchmark metrics. The image format is selected from the `path` file extension — supported formats are PNG, JPG/JPEG, SVG, and PDF. A path with no extension defaults to `.png`, and an unsupported extension raises an error. The `dpi` parameter (default `100`) sets the output image resolution in dots per inch — for example, `--output kind=plot,path=plot.png,dpi=72`.
+| Format (`kind`) | Default filename  | Contents                                                                                                                                          |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `json`          | `benchmarks.json` | Configuration, metadata, benchmark statistics, and retained request data for debugging or reloading into Python.                                  |
+| `yaml`          | `benchmarks.yaml` | The same detailed benchmark data as JSON in a human-readable YAML representation.                                                                 |
+| `csv`           | `benchmarks.csv`  | A tabular summary of throughput, latency, token counts, and rates for spreadsheets and comparisons. Does not include detailed request-level data. |
+| `html`          | `benchmarks.html` | A self-contained report with throughput and latency charts and tables. CSS and JavaScript are embedded for offline sharing.                       |
+| `plot`          | `benchmarks.png`  | Static benchmark performance graphs.                                                                                                              |
+
+For PLOT, the `path` extension selects the image format: PNG, JPG/JPEG, SVG, or PDF. For example, `--output kind=plot,path=benchmarks.pdf` creates a PDF. A path without an extension defaults to `.png`; unsupported extensions raise an error. The `dpi` parameter (default `100`) controls image resolution, for example `--output kind=plot,path=benchmarks.jpg,dpi=72`.
 
 ### Configuring File Outputs
 
-- **Default destination**: File outputs use `GUIDELLM__DEFAULT_RESULTS_DIR` when set and the current directory otherwise.
-- **Output path**: Each file type has a default filename. Pass `path=` to control the name or destination.
-- **Multiple formats**: Repeat `--output` with different types.
-- **Explicit selection**: Any `--output` replaces the default JSON and CSV selection. Include `--output kind=json` and `--output kind=csv` explicitly when you want to preserve them.
+Omit `path` to use the format's default filename in the directory configured by `GUIDELLM__DEFAULT_RESULTS_DIR`, or in the current directory when the variable is not set. Specify `path=` to set the filename or destination.
 
-#### Example commands to save results in specific formats:
-
-```bash
-# JSON, CSV, and HTML to a results directory
-guidellm run \
-  --backend kind=openai_http,target=http://localhost:8000 \
-  --profile kind=sweep \
-  --constraint kind=max_duration,seconds=30 \
-  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
-  --output kind=json,path=results/benchmark.json \
-  --output kind=csv,path=results/benchmark.csv \
-  --output kind=html,path=results/benchmark.html
-```
-
-**Example: Single output format**
-
-This command writes only JSON (in addition to the independent console output):
+For example, this command writes JSON to a custom path, in addition to the independent console output:
 
 ```bash
 guidellm run \


### PR DESCRIPTION
Clarify that guidellm run writes JSON and CSV files by default, while HTML reports require an explicit output option. Update the README and analysis guide, and correct the YAML output example.

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 6d0caabc2e6e2e88de804207242330d0eb0c1c9d
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Wed Sep 2 13:48:19 2026 +0800

    docs: clarify default benchmark outputs
    
    Clarify that guidellm run writes JSON and CSV files by default, while HTML reports require an explicit output option. Update the README and analysis guide, and correct the YAML output example.
    
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

commit b881fe24ce63eec8daffe88884956007973c5857
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Thu Sep 3 10:00:27 2026 +0800

    docs: document benchmark output selection
    
    Explain output override behavior, default result directories, all supported file formats, and console handling across the README and output guides.
    
    Generated-by: Codex GPT-5
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

commit bbb5bbc10fd11f6df06dfa409a58327ce298ed2c
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Mon Sep 7 09:43:42 2026 +0800

    docs: centralize benchmark output guidance
    
    Replace repeated output configuration examples with links to the output guide. Consolidate supported formats and default filenames, and clarify that path may be omitted or specified explicitly.
    
    Generated-by: Codex
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

---------

Generated-by: Codex
Generated-by: Codex GPT-5
Signed-off-by: tangming1996 <ming.tang@daocloud.io>
