### PR TITLE
Fix/stalled scheduled requests

### DIFF
--- a/docs/getting-started/benchmark.md
+++ b/docs/getting-started/benchmark.md
@@ -259,6 +259,8 @@ guidellm run \
 
 The replay profile parameter `time_scale` acts as a scaling factor for the intervals between trace events: `1.0` preserves the original timing, `2.0` doubles the intervals and runs twice as long, and `0.5` halves the intervals and runs twice as fast.
 
+`--constraint kind=max_duration,seconds=<n>` stops in-flight waits as well as new request starts. Workers sleeping until a future replay timestamp are cancelled when the duration elapses.
+
 GuideLLM orders trace rows by timestamp before scheduling and payload generation, so each scheduled event uses the token lengths from the same sorted row. Use `--data-loader kind=pytorch,samples=1000` to limit how many trace rows are loaded and replayed. `--constraint kind=max_requests,count=1000` remains a runtime completion constraint; it does not truncate the trace dataset.
 
 Every format by default looks for the columns "timestamp", "input_length", and "output_length". If your trace uses different column names, include `timestamp_column`, `prompt_tokens_column`, and `output_tokens_column` in the data config:

--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -218,7 +218,7 @@ GuideLLM supports various file formats for datasets, including text, CSV, JSON, 
     --data kind=trace_synthetic,path=replay.jsonl,timestamp_column=timestamp,prompt_tokens_column=input_length,output_tokens_column=output_length
   ```
 
-  For replay, `time_scale` on the profile is a time scale for the intervals between trace events rather than requests per second. Use `--data-loader kind=pytorch,samples=1000` to limit how many trace rows are loaded and replayed. Use `--constraint kind=max_requests,count=<n>` only as a runtime completion constraint; it does not limit the trace rows loaded from the file. `--constraint kind=max_duration,seconds=<n>` also cancels in-flight waits, including replay sleeps.
+  For replay, `time_scale` on the profile is a time scale for the intervals between trace events. Use `--data-loader kind=pytorch,samples=1000` to limit how many trace rows are loaded and replayed. Use `--constraint kind=max_requests,count=<n>` only as a runtime completion constraint; it does not limit the trace rows loaded from the file. `--constraint kind=max_duration,seconds=<n>` also cancels in-flight waits, including replay sleeps.
 
 - **JSON files (`.json`)**: Where the entire dataset is represented as a JSON array of objects nested under a specific key. To surface the correct key to use, a `--data-column-mapper` argument must be passed in of `"field": "NAME"` for where the array exists. The objects should include `prompt` or other common names for the prompt which will be used as the prompt column. Additional fields can be included based on the previously mentioned aliases for the `--data-column-mapper` argument.
 

--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -218,7 +218,7 @@ GuideLLM supports various file formats for datasets, including text, CSV, JSON, 
     --data kind=trace_synthetic,path=replay.jsonl,timestamp_column=timestamp,prompt_tokens_column=input_length,output_tokens_column=output_length
   ```
 
-  For replay, `time_scale` on the profile is a time scale for the intervals between trace events rather than requests per second. Use `--data-loader kind=pytorch,samples=1000` to limit how many trace rows are loaded and replayed. Use `--constraint kind=max_requests,count=<n>` only as a runtime completion constraint; it does not limit the trace rows loaded from the file.
+  For replay, `time_scale` on the profile is a time scale for the intervals between trace events rather than requests per second. Use `--data-loader kind=pytorch,samples=1000` to limit how many trace rows are loaded and replayed. Use `--constraint kind=max_requests,count=<n>` only as a runtime completion constraint; it does not limit the trace rows loaded from the file. `--constraint kind=max_duration,seconds=<n>` also cancels in-flight waits, including replay sleeps.
 
 - **JSON files (`.json`)**: Where the entire dataset is represented as a JSON array of objects nested under a specific key. To surface the correct key to use, a `--data-column-mapper` argument must be passed in of `"field": "NAME"` for where the array exists. The objects should include `prompt` or other common names for the prompt which will be used as the prompt column. Additional fields can be included based on the previously mentioned aliases for the `--data-column-mapper` argument.
 

--- a/src/guidellm/scheduler/constraints/constraint.py
+++ b/src/guidellm/scheduler/constraints/constraint.py
@@ -32,6 +32,7 @@ Example:
 
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from typing import Any, Literal, Protocol, runtime_checkable
 
@@ -47,7 +48,25 @@ __all__ = [
     "PydanticConstraintInitializer",
     "SerializableConstraintInitializer",
     "UnserializableConstraintInitializer",
+    "constraint_stop_time",
 ]
+
+
+def constraint_stop_time(request: RequestInfo | None, *, stopped: bool) -> float | None:
+    """Return ``stop_time`` when a constraint has triggered.
+
+    Uses the request's ``completed_at`` when a real request is present;
+    otherwise wall-clock now (state-only rechecks during scheduler polls).
+
+    :param request: Request that triggered evaluation, or ``None`` on poll
+    :param stopped: Whether the constraint is currently stopping execution
+    :return: Stop timestamp, or ``None`` if the constraint has not triggered
+    """
+    if not stopped:
+        return None
+    if request is not None and request.completed_at is not None:
+        return request.completed_at
+    return time.time()
 
 
 @runtime_checkable
@@ -64,7 +83,7 @@ class Constraint(Protocol):
     Example:
     ::
         def my_constraint(
-            state: SchedulerState, request: RequestInfo
+            state: SchedulerState, request: RequestInfo | None
         ) -> SchedulerUpdateAction:
             if state.processing_requests > 100:
                 return SchedulerUpdateAction(request_queuing="stop")
@@ -72,13 +91,14 @@ class Constraint(Protocol):
     """
 
     def __call__(
-        self, state: SchedulerState, request: RequestInfo
+        self, state: SchedulerState, request: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
-        Evaluate constraint against scheduler state and request information.
+        Evaluate constraint against scheduler state and optional request information.
 
         :param state: Current scheduler state with metrics and timing information
-        :param request: Individual request information and metadata
+        :param request: Individual request metadata, or ``None`` for a state-only
+            recheck (for example the coordinator poll loop)
         :return: Action indicating whether to continue or stop scheduler operations
         """
 
@@ -264,7 +284,7 @@ class UnserializableConstraintInitializer(PydanticConstraintInitializer):
         )
 
     def __call__(
-        self, state: SchedulerState, request: RequestInfo
+        self, state: SchedulerState, request: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Raise error since unserializable constraints cannot be invoked.

--- a/src/guidellm/scheduler/constraints/error.py
+++ b/src/guidellm/scheduler/constraints/error.py
@@ -8,7 +8,6 @@ when to stop benchmark execution due to excessive errors.
 
 from __future__ import annotations
 
-import time
 from typing import Literal, cast
 
 from pydantic import Field
@@ -25,7 +24,7 @@ from guidellm.schemas.scheduler.constraints import (
     MaxGlobalErrorRateConstraintArgs,
 )
 
-from .constraint import Constraint, PydanticConstraintInitializer
+from .constraint import Constraint, PydanticConstraintInitializer, constraint_stop_time
 from .factory import ConstraintsInitializerFactory
 
 __all__ = [
@@ -63,16 +62,15 @@ class MaxErrorsConstraint(PydanticConstraintInitializer):
         return cast("Constraint", self.model_copy())
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against current error count.
 
         :param state: Current scheduler state with error counts
-        :param request_info: Individual request information (unused)
+        :param request_info: Individual request information, or ``None`` on poll
         :return: Action indicating whether to continue or stop operations
         """
-        _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_errors = (
             self.args.count
@@ -80,9 +78,7 @@ class MaxErrorsConstraint(PydanticConstraintInitializer):
             else self.args.count[min(current_index, len(self.args.count) - 1)]
         )
         errors_exceeded = state.errored_requests >= max_errors
-        stop_time = (
-            None if not errors_exceeded else request_info.completed_at or time.time()
-        )
+        stop_time = constraint_stop_time(request_info, stopped=errors_exceeded)
 
         return SchedulerUpdateAction(
             request_queuing="stop" if errors_exceeded else "continue",
@@ -133,13 +129,14 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
         return cast("Constraint", self.model_copy())
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against sliding window error rate.
 
         :param state: Current scheduler state with request counts
-        :param request_info: Individual request with completion status
+        :param request_info: Individual request with completion status, or ``None``
+            on poll (does not record a window sample)
         :return: Action indicating whether to continue or stop operations
         """
         current_index = max(0, self.current_index)
@@ -149,7 +146,11 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
             else self.args.rate[min(current_index, len(self.args.rate) - 1)]
         )
 
-        if request_info.status in ["completed", "errored", "cancelled"]:
+        if request_info is not None and request_info.status in [
+            "completed",
+            "errored",
+            "cancelled",
+        ]:
             self.error_window.append(request_info.status == "errored")
             if len(self.error_window) > self.args.window:
                 self.error_window.pop(0)
@@ -162,7 +163,7 @@ class MaxErrorRateConstraint(PydanticConstraintInitializer):
         exceeded_min_processed = state.processed_requests >= self.args.window
         exceeded_error_rate = error_rate >= max_error_rate
         exceeded = exceeded_min_processed and exceeded_error_rate
-        stop_time = None if not exceeded else request_info.completed_at or time.time()
+        stop_time = constraint_stop_time(request_info, stopped=exceeded)
 
         return SchedulerUpdateAction(
             request_queuing="stop" if exceeded else "continue",
@@ -214,16 +215,15 @@ class MaxGlobalErrorRateConstraint(PydanticConstraintInitializer):
         return cast("Constraint", self.model_copy())
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against global error rate.
 
         :param state: Current scheduler state with global request and error counts
-        :param request_info: Individual request information (unused)
+        :param request_info: Individual request information, or ``None`` on poll
         :return: Action indicating whether to continue or stop operations
         """
-        _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_error_rate = (
             self.args.rate
@@ -241,7 +241,7 @@ class MaxGlobalErrorRateConstraint(PydanticConstraintInitializer):
         )
         exceeded_error_rate = error_rate >= max_error_rate
         exceeded = exceeded_min_processed and exceeded_error_rate
-        stop_time = None if not exceeded else request_info.completed_at or time.time()
+        stop_time = constraint_stop_time(request_info, stopped=exceeded)
 
         return SchedulerUpdateAction(
             request_queuing="stop" if exceeded else "continue",

--- a/src/guidellm/scheduler/constraints/request.py
+++ b/src/guidellm/scheduler/constraints/request.py
@@ -16,6 +16,7 @@ from pydantic import Field
 from guidellm.scheduler.constraints.constraint import (
     Constraint,
     PydanticConstraintInitializer,
+    constraint_stop_time,
 )
 from guidellm.scheduler.constraints.factory import ConstraintsInitializerFactory
 from guidellm.scheduler.schemas import (
@@ -67,16 +68,15 @@ class MaxNumberConstraint(PydanticConstraintInitializer):
         return cast("Constraint", self.model_copy())
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against current scheduler state and request count.
 
         :param state: Current scheduler state with request counts
-        :param request_info: Individual request information (unused)
+        :param request_info: Individual request information, or ``None`` on poll
         :return: Action indicating whether to continue or stop operations
         """
-        _ = request_info  # Unused parameters
         current_index = max(0, self.current_index)
         max_num = (
             self.args.count
@@ -87,9 +87,7 @@ class MaxNumberConstraint(PydanticConstraintInitializer):
         create_exceeded = state.created_requests >= max_num
         processed_exceeded = state.processed_requests >= max_num
         remaining_requests = min(max(0, max_num - state.processed_requests), max_num)
-        stop_time = (
-            None if remaining_requests > 0 else request_info.completed_at or time.time()
-        )
+        stop_time = constraint_stop_time(request_info, stopped=remaining_requests <= 0)
 
         return SchedulerUpdateAction(
             request_queuing="stop" if create_exceeded else "continue",
@@ -140,7 +138,7 @@ class MaxDurationConstraint(PydanticConstraintInitializer):
         return cast("Constraint", self.model_copy())
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against current scheduler state and elapsed time.
@@ -198,15 +196,12 @@ class RequestsExhaustedConstraint(StandardBaseModel, InfoMixin):
         return self.model_dump()
 
     def __call__(
-        self, state: SchedulerState, request: RequestInfo
+        self, state: SchedulerState, request: RequestInfo | None
     ) -> SchedulerUpdateAction:
-        _ = request  # Unused parameter
         create_exceeded = state.created_requests >= self.num_requests
         processed_exceeded = state.processed_requests >= self.num_requests
         remaining_requests = max(0, self.num_requests - state.processed_requests)
-        stop_time = (
-            None if remaining_requests > 0 else request.completed_at or time.time()
-        )
+        stop_time = constraint_stop_time(request, stopped=remaining_requests <= 0)
 
         return SchedulerUpdateAction(
             request_queuing="stop" if create_exceeded else "continue",

--- a/src/guidellm/scheduler/constraints/saturation.py
+++ b/src/guidellm/scheduler/constraints/saturation.py
@@ -510,23 +510,27 @@ class OverSaturationConstraint(Constraint):
         return is_concurrent_slope_positive and is_ttft_slope_positive
 
     def __call__(
-        self, state: SchedulerState, request_info: RequestInfo
+        self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
         """
         Evaluate constraint against current scheduler state.
 
         :param state: Current scheduler state.
-        :param request_info: Individual request information.
+        :param request_info: Individual request information, or ``None`` on poll
+            (does not record concurrent/TTFT samples).
         :return: Action indicating whether to continue or stop operations.
         """
         duration = time.time() - state.start_time
 
-        if request_info.status == "in_progress":
+        if request_info is not None and request_info.status == "in_progress":
             concurrent_requests = state.processing_requests
             self._add_started(
                 {"concurrent_requests": concurrent_requests, "duration": duration}
             )
-        elif request_info.status in ("first_token", "completed"):
+        elif request_info is not None and request_info.status in (
+            "first_token",
+            "completed",
+        ):
             if (
                 request_info.request_id not in self._ttft_reported_request_ids
                 and request_info.timings

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -405,6 +405,9 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
 
                 yield response, request, request_info, scheduler_state
             except asyncio.TimeoutError:
+                if self.shutdown_event.is_set():  # type: ignore[union-attr]
+                    # Everything yielded, exit
+                    break
                 # Time-based constraints (max_duration) must be evaluated even when
                 # workers are sleeping until a future target start, because no
                 # request updates arrive during that wait.
@@ -418,9 +421,6 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
                         self.constraint_reached_event.set()
                     if state_update.stop_queueing:
                         self.state.stop_send_requests_event.set()
-                if self.shutdown_event.is_set():  # type: ignore[union-attr]
-                    # Everything yielded, exit
-                    break
 
     async def shutdown(self) -> list[Exception]:
         """

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -416,7 +416,6 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
                     if (
                         state_update.stop_processing
                         and self.constraint_reached_event is not None
-                        and not self.constraint_reached_event.is_set()
                     ):
                         self.constraint_reached_event.set()
                     if state_update.stop_queueing:
@@ -807,9 +806,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         if info.timings.request_start is not None:
             self._state.start_requests_time = min(
                 info.timings.request_start,
-                self._state.start_requests_time
-                if self._state.start_requests_time is not None
-                else info.timings.request_start,
+                self._state.start_requests_time or float("inf"),
             )
         self._state.end_requests_time = max(
             info.timings.request_end or float("-inf"),

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -405,17 +405,32 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
 
                 yield response, request, request_info, scheduler_state
             except asyncio.TimeoutError:
+                # Time-based constraints (max_duration) must be evaluated even when
+                # workers are sleeping until a future target start, because no
+                # request updates arrive during that wait.
+                if self.state is not None:
+                    state_update = self.state.update_state()
+                    if (
+                        state_update.stop_processing
+                        and self.constraint_reached_event is not None
+                        and not self.constraint_reached_event.is_set()
+                    ):
+                        self.constraint_reached_event.set()
+                    if state_update.stop_queueing:
+                        self.state.stop_send_requests_event.set()
                 if self.shutdown_event.is_set():  # type: ignore[union-attr]
                     # Everything yielded, exit
                     break
 
-    async def shutdown(self) -> list[Exception]:  # noqa: C901
+    async def shutdown(self) -> list[Exception]:
         """
         Gracefully shut down the worker process group and clean up resources.
 
         Performs safe shutdown of worker processes, background tasks, and
         multiprocessing resources. Coordinates orderly termination across
         all workers and collects any exceptions encountered during shutdown.
+        Workers that ignore the shutdown event are terminated, then killed,
+        so ``Manager.shutdown`` cannot block indefinitely on live connections.
 
         :return: List of exceptions encountered during shutdown; empty if no errors
         """
@@ -441,22 +456,10 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
 
         # Clear out create processes values
         if self.processes is not None:
-            for proc in self.processes:
-                try:
-                    await asyncio.to_thread(proc.join, timeout=5.0)
-                    if proc.exitcode is not None and proc.exitcode != 0:
-                        exit_info = (
-                            f"signal {-proc.exitcode}"
-                            if proc.exitcode < 0
-                            else f"exit code {proc.exitcode}"
-                        )
-                        exceptions.append(
-                            RuntimeError(
-                                f"Worker {proc.pid} exited abnormally ({exit_info})"
-                            )
-                        )
-                except Exception as err:  # noqa: BLE001
-                    exceptions.append(err)
+            join_errors = await asyncio.gather(
+                *[self._join_or_kill_process(proc) for proc in self.processes]
+            )
+            exceptions.extend(err for err in join_errors if err is not None)
         self.processes = None
         self.startup_barrier = None
         self.requests_generated_event = None
@@ -465,13 +468,49 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         self.error_event = None
         if self.mp_manager is not None:
             try:
-                self.mp_manager.shutdown()
+                # Bound this: a live worker holding a Manager connection
+                # can otherwise block here until the process is killed externally.
+                await asyncio.wait_for(
+                    asyncio.to_thread(self.mp_manager.shutdown),
+                    timeout=5.0,
+                )
             except Exception as err:  # noqa: BLE001
                 exceptions.append(err)
         self.mp_manager = None
         self.mp_context = None
 
         return exceptions
+
+    async def _join_or_kill_process(self, proc: BaseProcess) -> Exception | None:
+        """Join a worker, then terminate and kill if it does not exit.
+
+        :param proc: Worker process to wait for
+        :return: Abnormal-exit error if the process exited on its own with a
+            non-zero code; ``None`` if it exited cleanly or was force-stopped
+        """
+        try:
+            await asyncio.to_thread(proc.join, timeout=5.0)
+            force_stopped = False
+            if proc.is_alive():
+                proc.terminate()
+                await asyncio.to_thread(proc.join, timeout=2.0)
+                force_stopped = True
+            if proc.is_alive():
+                proc.kill()
+                await asyncio.to_thread(proc.join, timeout=2.0)
+                force_stopped = True
+            if not force_stopped and proc.exitcode is not None and proc.exitcode != 0:
+                exit_info = (
+                    f"signal {-proc.exitcode}"
+                    if proc.exitcode < 0
+                    else f"exit code {proc.exitcode}"
+                )
+                return RuntimeError(
+                    f"Worker {proc.pid} exited abnormally ({exit_info})"
+                )
+        except Exception as err:  # noqa: BLE001
+            return err
+        return None
 
 
 class _StateUpdate(NamedTuple):
@@ -590,7 +629,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                         scheduler_start_time=self.start_time,
                         settings=node.settings,
                     )
-                    state_update = self._locked_update(request_info)
+                    state_update = self.update_state(request_info)
                     request_info.timings.queued = time.time()
                     if self.messaging.buffer_receive_queue is None:
                         raise RuntimeError("buffer receive queue is None")
@@ -618,8 +657,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
                     self.stop_send_requests_event.set()
                     return
 
-            self._locked_update(
-                info=None,
+            self.update_state(
                 add_constraints={
                     "requests_exhausted": RequestsExhaustedConstraint(
                         num_requests=count
@@ -657,7 +695,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         """
         try:
             response, request, request_info = update
-            state_update = self._locked_update(info=request_info)
+            state_update = self.update_state(info=request_info)
 
             # Check if we need to tell workers to stop pulling new requests
             # based on no more requests sent and all requests removed from queue
@@ -697,19 +735,30 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
             state_update.state,  # inject state for updates to be yielded back
         )
 
-    def _locked_update(
+    def update_state(
         self,
         info: RequestInfo | None = None,
         add_constraints: dict[str, Constraint] | None = None,
     ) -> _StateUpdate:
+        """Update scheduler state and re-evaluate constraints.
+
+        With no ``info``, only scheduler state is considered. The coordinator
+        poll loop uses that so time-based constraints such as ``max_duration``
+        can fire while workers are sleeping and no request updates arrive.
+
+        :param info: Request that changed, or ``None`` for a state-only recheck
+        :param add_constraints: Constraints to register before evaluation
+        :return: Copied scheduler state and stop flags
+        """
         with self._update_lock:
             if add_constraints is not None:
                 self.constraints.update(add_constraints)
 
+            self._state.end_time = time.time()  # Always update in case last update
             if info is not None:
-                self._state.end_time = time.time()  # Always update in case last update
                 self._update_state_request_counts(info)
-                self._update_with_constraints(info)
+
+            self._update_with_constraints(info)
 
             state_copy: SchedulerState = self._state.model_copy()
 
@@ -751,11 +800,17 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         else:
             raise ValueError(f"Unknown request_info status {info.status} for {info}")
 
+        self._update_request_time_bounds(info, finalized)
+
+    def _update_request_time_bounds(self, info: RequestInfo, finalized: float) -> None:
         # Keep global count of the earliest start and latest end
-        self._state.start_requests_time = min(
-            info.timings.request_start or float("inf"),
-            self._state.start_requests_time or float("inf"),
-        )
+        if info.timings.request_start is not None:
+            self._state.start_requests_time = min(
+                info.timings.request_start,
+                self._state.start_requests_time
+                if self._state.start_requests_time is not None
+                else info.timings.request_start,
+            )
         self._state.end_requests_time = max(
             info.timings.request_end or float("-inf"),
             self._state.end_requests_time or float("-inf"),
@@ -802,7 +857,7 @@ class WorkerGroupState(Generic[RequestT, ResponseT]):
         self._state.cancelled_requests += 1 if info.status == "cancelled" else 0
         return True
 
-    def _update_with_constraints(self, info: RequestInfo):
+    def _update_with_constraints(self, info: RequestInfo | None):
         actions: dict[str, SchedulerUpdateAction] = {
             name: const(self._state, info) for name, const in self.constraints.items()
         }

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -467,8 +467,9 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         self.error_event = None
         if self.mp_manager is not None:
             try:
-                # Bound this: a live worker holding a Manager connection
-                # can otherwise block here until the process is killed externally.
+                # Enforce a time limit because a live worker holding a Manager
+                # connection can otherwise block here until the process is
+                # killed externally.
                 await asyncio.wait_for(
                     asyncio.to_thread(self.mp_manager.shutdown),
                     timeout=5.0,

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -21,19 +21,30 @@ from guidellm.data.finalizers.generative import GenerativeRequestFinalizer
 from guidellm.data.preprocessors.mappers import GenerativeColumnMapper
 from guidellm.scheduler import (
     BackendInterface,
+    MaxDurationConstraint,
     MaxNumberConstraint,
     TraceReplayStrategy,
     WorkerProcessGroup,
 )
-from guidellm.scheduler.schemas import ConversationGraph, ConversationNode
-from guidellm.scheduler.schemas.conversation_graph import GenerativeConversationGraph
+from guidellm.scheduler.schemas import (
+    ConversationGraph,
+    ConversationNode,
+    HistoryContext,
+)
+from guidellm.scheduler.schemas.conversation_graph import (
+    GenerativeConversationGraph,
+    GenerativeConversationNode,
+)
 from guidellm.schemas import GenerationRequest, RequestSettings
 from guidellm.schemas.data import (
     GenerativeColumnMapperArgs,
     GenerativeRequestFinalizerArgs,
     MinimalTraceFormatArgs,
 )
-from guidellm.schemas.scheduler import MaxRequestsConstraintArgs
+from guidellm.schemas.scheduler import (
+    MaxDurationConstraintArgs,
+    MaxRequestsConstraintArgs,
+)
 from tests.unit.testing_utils import async_timeout
 
 TIME_SCALE = 2.0
@@ -129,7 +140,9 @@ class FastMockBackend(BackendInterface):
         pass
 
     async def resolve(self, request, request_info, history=None):
+        request_info.timings.request_start = time.time()
         await asyncio.sleep(self._resolve_delay)
+        request_info.timings.request_end = time.time()
         rid = (
             request.request_id
             if hasattr(request, "request_id")
@@ -236,3 +249,68 @@ async def test_trace_replay_multiprocess_from_trace_file(tmp_path: Path):
             expected_target,
             abs=0.05,
         )
+
+
+def _linear_replay_graph(
+    timestamps: list[float],
+    *,
+    graph_id: str = "linear_replay",
+    request_prefix: str = "req",
+) -> GenerativeConversationGraph:
+    nodes: dict[str, GenerativeConversationNode] = {}
+    parents_by_node: dict[str, list[tuple[str, HistoryContext]]] = {}
+    prev: str | None = None
+    for index, relative_timestamp in enumerate(timestamps):
+        node_id = f"n{index}"
+        nodes[node_id] = GenerativeConversationNode(
+            node_id=node_id,
+            agent_id="default",
+            request=GenerationRequest(request_id=f"{request_prefix}_{index}"),
+            settings=RequestSettings(relative_timestamp=relative_timestamp),
+        )
+        parents_by_node[node_id] = [(prev, "full")] if prev is not None else []
+        prev = node_id
+    return GenerativeConversationGraph.from_nodes_with_parents(
+        nodes=nodes,
+        parents_by_node=parents_by_node,
+        graph_id=graph_id,
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.asyncio
+@async_timeout(60.0)
+async def test_max_duration_cancels_long_replay_sleep():
+    """max_duration stops workers sleeping on a future relative_timestamp.
+
+    ## WRITTEN BY AI ##
+    """
+    graph = _linear_replay_graph([0.0, 5.0])
+    strategy = TraceReplayStrategy(time_scale=1.0)
+    group = WorkerProcessGroup(
+        backend=FastMockBackend(resolve_delay=RESOLVE_DELAY),
+        requests=[graph],
+        strategy=strategy,
+        max_duration=MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=0.4)),
+    )
+    statuses: set[str] = set()
+    try:
+        await group.create_processes()
+        await group.start(time.time() + 0.05)
+        run_started = time.time()
+        async for _, _, request_info, _state in group.request_updates():
+            statuses.add(request_info.status)
+            if (
+                request_info.status in ("cancelled", "completed", "errored")
+                and _state.end_processing_time is not None
+                and _state.processed_requests >= _state.created_requests
+            ):
+                break
+        elapsed = time.time() - run_started
+    finally:
+        exceptions = await group.shutdown()
+        assert exceptions == []
+
+    assert "cancelled" in statuses
+    assert elapsed < 2.5

--- a/tests/unit/scheduler/test_constraints.py
+++ b/tests/unit/scheduler/test_constraints.py
@@ -1243,3 +1243,93 @@ class TestConstraintsInitializerFactory:
         action_exceeded = constraint(state_exceeded, request)
         assert action_exceeded.request_queuing == "stop"
         assert action_exceeded.request_processing == "stop_local"
+
+
+class TestConstraintNoneRequest:
+    """State-only constraint evaluation with request=None."""
+
+    @pytest.mark.smoke
+    def test_max_duration_accepts_none_request(self):
+        """max_duration can fire from scheduler state without a request.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=1.0))
+        start_time = time.time() - 5.0
+        state = SchedulerState(node_id=0, num_processes=1, start_time=start_time)
+        action = constraint(state, None)
+        assert action.request_queuing == "stop"
+        assert action.request_processing == "stop_local"
+
+    @pytest.mark.smoke
+    def test_max_requests_accepts_none_request(self):
+        """max_requests evaluates counts with request=None.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxNumberConstraint(args=MaxRequestsConstraintArgs(count=10))
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=time.time(),
+            created_requests=3,
+            processed_requests=3,
+        )
+        action = constraint(state, None)
+        assert action.request_queuing == "continue"
+        assert action.request_processing == "continue"
+
+    @pytest.mark.smoke
+    def test_max_errors_accepts_none_request(self):
+        """max_errors evaluates error counts with request=None.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxErrorsConstraint(args=MaxErrorsConstraintArgs(count=5))
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=time.time(),
+            errored_requests=5,
+        )
+        action = constraint(state, None)
+        assert action.request_queuing == "stop"
+        assert action.request_processing == "stop_all"
+
+    @pytest.mark.smoke
+    def test_max_error_rate_none_request_does_not_record_sample(self):
+        """Poll rechecks must not append to the sliding error window.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxErrorRateConstraint(
+            args=MaxErrorRateConstraintArgs(rate=0.5, window=5)
+        )
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=time.time(),
+            processed_requests=0,
+        )
+        constraint(state, None)
+        assert constraint.error_window == []
+
+    @pytest.mark.smoke
+    def test_max_global_error_rate_accepts_none_request(self):
+        """Global error rate evaluates from state with request=None.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxGlobalErrorRateConstraint(
+            args=MaxGlobalErrorRateConstraintArgs(rate=0.5, minimum=1)
+        )
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=time.time(),
+            processed_requests=10,
+            errored_requests=1,
+        )
+        action = constraint(state, None)
+        assert action.request_queuing == "continue"
+        assert action.request_processing == "continue"

--- a/tests/unit/scheduler/test_over_saturation.py
+++ b/tests/unit/scheduler/test_over_saturation.py
@@ -542,3 +542,25 @@ class TestSlopeChecker:
         slope_checker.add_data_point(3.0, 6.0)
         result = slope_checker.check_slope(3.0)
         # Might be True or False depending on confidence intervals
+
+
+class TestOverSaturationNoneRequest:
+    @pytest.mark.smoke
+    def test_none_request_does_not_record_samples(self):
+        """Poll rechecks must not record concurrent or TTFT samples.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = OverSaturationConstraint(
+            minimum_duration=0.0, minimum_window_size=3, mode="enforce"
+        )
+        start_time = time.time()
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=start_time,
+            processing_requests=4,
+        )
+        constraint(state, None)
+        assert constraint.started_requests == []
+        assert constraint.finished_requests == []

--- a/tests/unit/scheduler/test_worker_group.py
+++ b/tests/unit/scheduler/test_worker_group.py
@@ -9,8 +9,8 @@ from multiprocessing.context import BaseContext
 from multiprocessing.managers import BaseManager
 from multiprocessing.process import BaseProcess
 from multiprocessing.synchronize import Barrier, Event
-from typing import Any, Generic, Literal
-from unittest.mock import patch
+from typing import Any, Generic, Literal, cast
+from unittest.mock import Mock, patch
 
 import pytest
 from pydantic import Field
@@ -264,6 +264,61 @@ class TestWorkerProcessGroup:
         """Test WorkerProcessGroup initialization without required fields."""
         with pytest.raises(TypeError):
             WorkerProcessGroup()
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_request_updates_swallows_asyncio_timeout_error(self):
+        """Idle polls from asyncio.wait_for must not abort request_updates.
+
+        On Python 3.10, asyncio.TimeoutError is not builtin TimeoutError, so the
+        poll loop must catch the asyncio type that wait_for actually raises.
+
+        ## WRITTEN BY AI ##
+        """
+        group = WorkerProcessGroup(
+            requests=["req"],
+            backend=MockBackend(),
+            strategy=SynchronousStrategy(),
+        )
+        error_event = Mock()
+        error_event.is_set.return_value = False
+        shutdown_event = Mock()
+        shutdown_checks = 0
+
+        def shutdown_is_set() -> bool:
+            nonlocal shutdown_checks
+            shutdown_checks += 1
+            return shutdown_checks > 1
+
+        shutdown_event.is_set.side_effect = shutdown_is_set
+        group.error_event = error_event
+        group.shutdown_event = shutdown_event
+        group.constraint_reached_event = Mock()
+        group.constraint_reached_event.is_set.return_value = False
+        state_update = Mock()
+        state_update.stop_processing = False
+        state_update.stop_queueing = False
+        group.state = Mock()
+        group.state.update_state.return_value = state_update
+
+        payload = (None, "req", Mock(), Mock())
+        get_calls = 0
+
+        async def mock_get(*, timeout: float | None = None):
+            nonlocal get_calls
+            get_calls += 1
+            if get_calls == 2:
+                return payload
+            raise asyncio.TimeoutError
+
+        group.messaging = Mock()
+        group.messaging.get = mock_get
+
+        results = [update async for update in group.request_updates()]
+
+        assert results == [payload]
+        assert get_calls == 3
+        group.state.update_state.assert_called()
 
     @pytest.mark.xfail(reason="old and broken", run=False)
     @pytest.mark.smoke
@@ -649,3 +704,124 @@ class TestWorkerGroupStateDuplicateTerminalUpdate:
         assert state._state.errored_requests == 1
         assert state._state.pending_requests == 0
         assert "req-7" not in state._pending_request_ids
+
+
+class TestWorkerGroupStateUpdate:
+    @pytest.mark.smoke
+    def test_update_state_max_duration_without_request(self):
+        """Elapsed max_duration stops processing on a state-only update.
+
+        ## WRITTEN BY AI ##
+        """
+        start_time = time.time() - 10.0
+        constraint = MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=1.0))
+        group_state = WorkerGroupState(
+            start_time=start_time,
+            processes=[],
+            strategy=SynchronousStrategy(),
+            constraints={"max_duration": constraint},
+            stop_send_requests_event=threading.Event(),
+            send_requests_stopped_event=threading.Event(),
+            requests_generated_event=threading.Event(),
+            constraint_reached_event=threading.Event(),
+            shutdown_event=threading.Event(),
+            error_event=threading.Event(),
+            messaging=Mock(),
+        )
+        update = group_state.update_state()
+        assert update.stop_processing
+        assert update.stop_queueing
+        assert group_state._state.end_processing_time is not None
+        assert "max_duration" in group_state._state.end_processing_constraints
+
+
+class _HangUntilSignaledProcess:
+    """Process double that stays alive until terminate or kill is called."""
+
+    def __init__(self, *, die_on: str):
+        self.pid = 4242
+        self.exitcode: int | None = None
+        self._alive = True
+        self._die_on = die_on
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_timeouts: list[float | None] = []
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeouts.append(timeout)
+        if not self._alive:
+            return
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self._die_on == "terminate":
+            self._alive = False
+            self.exitcode = -15
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        if self._die_on == "kill":
+            self._alive = False
+            self.exitcode = -9
+
+
+class TestWorkerProcessGroupForcedShutdown:
+    """Shutdown must not block forever on workers that ignore the stop event."""
+
+    def _group_with_process(
+        self, proc: _HangUntilSignaledProcess
+    ) -> tuple[WorkerProcessGroup, Mock, Mock]:
+        group = WorkerProcessGroup(
+            requests=["req"],
+            backend=MockBackend(),
+            strategy=SynchronousStrategy(),
+        )
+        shutdown_event = Mock()
+        mp_manager = Mock()
+        group.processes = [cast("BaseProcess", proc)]
+        group.shutdown_event = shutdown_event
+        group.mp_manager = mp_manager
+        return group, shutdown_event, mp_manager
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(5.0)
+    async def test_shutdown_terminates_worker_that_ignores_join(self):
+        """Workers still alive after join timeout are SIGTERM'd.
+
+        ## WRITTEN BY AI ##
+        """
+        proc = _HangUntilSignaledProcess(die_on="terminate")
+        group, shutdown_event, mp_manager = self._group_with_process(proc)
+
+        exceptions = await group.shutdown()
+
+        assert exceptions == []
+        assert proc.terminate_calls == 1
+        assert proc.kill_calls == 0
+        assert proc.join_timeouts == [5.0, 2.0]
+        mp_manager.shutdown.assert_called_once()
+        shutdown_event.set.assert_called_once()
+
+    @pytest.mark.sanity
+    @pytest.mark.asyncio
+    @async_timeout(5.0)
+    async def test_shutdown_kills_worker_that_ignores_terminate(self):
+        """Workers that ignore SIGTERM are SIGKILL'd.
+
+        ## WRITTEN BY AI ##
+        """
+        proc = _HangUntilSignaledProcess(die_on="kill")
+        group, shutdown_event, mp_manager = self._group_with_process(proc)
+
+        exceptions = await group.shutdown()
+
+        assert exceptions == []
+        assert proc.terminate_calls == 1
+        assert proc.kill_calls == 1
+        assert proc.join_timeouts == [5.0, 2.0, 2.0]
+        mp_manager.shutdown.assert_called_once()
+        shutdown_event.set.assert_called_once()

--- a/tests/unit/scheduler/test_worker_group.py
+++ b/tests/unit/scheduler/test_worker_group.py
@@ -320,6 +320,37 @@ class TestWorkerProcessGroup:
         assert get_calls == 3
         group.state.update_state.assert_called()
 
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_request_updates_skips_constraint_eval_when_shutdown(self):
+        """Idle timeout with shutdown already set must not re-evaluate constraints.
+
+        ## WRITTEN BY AI ##
+        """
+        group = WorkerProcessGroup(
+            requests=["req"],
+            backend=MockBackend(),
+            strategy=SynchronousStrategy(),
+        )
+        error_event = Mock()
+        error_event.is_set.return_value = False
+        shutdown_event = Mock()
+        shutdown_event.is_set.return_value = True
+        group.error_event = error_event
+        group.shutdown_event = shutdown_event
+        group.state = Mock()
+
+        async def mock_get(*, timeout: float | None = None):
+            raise asyncio.TimeoutError
+
+        group.messaging = Mock()
+        group.messaging.get = mock_get
+
+        results = [update async for update in group.request_updates()]
+
+        assert results == []
+        group.state.update_state.assert_not_called()
+
     @pytest.mark.xfail(reason="old and broken", run=False)
     @pytest.mark.smoke
     @async_timeout(10)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 description = Run integration tests
 base = tests
 commands =
-    python -m pytest tests/integration {posargs}
+    python -m pytest tests/integration --timeout=240 {posargs}
 
 
 [testenv:test-e2e]


### PR DESCRIPTION
## Summary

Makes it so the scheduler can signal to the scheduler to stop all waiting requests to fix the case where all requests being scheduled in the far-future result in the benchmark hanging until the request happens. 

## Test Plan

Attached is a basic trace file that has a few immediate requests, followed by some over a minute later.
Run a benchmark with that file with a 10 second timeout to observe main waiting, and this branch stopping after the 10 seconds.

```
uv run guidellm run \
  --backend kind=openai_http,target=http://localhost:8000 \
  --profile kind=replay,time_scale=1.0 \
  --data kind=trace_synthetic,path=replay_stall_delayed_requests.jsonl \
  --constraint kind=max_duration,seconds=10
```

## Related Issues

- Improves usability of real-world datasets for testing #1071 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3fa2c6d1f4279be65182d51a9b49b3828d40d568
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Sep 2 14:16:11 2026 -0400

    Poll for cancellation after end condition is reached
    
    This fixes the scheduler sleeping until the next scheduled request, which can be multiple minutes in the future.
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 1311d35b5268cb6a3cba05a7540aa6f513c75017
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Wed Sep 2 16:45:23 2026 -0400

    Address review comment
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit f6d4c5d8a53a8783a9e3d82219fc60a247771a25
Author: Jared O'Connell <46976761+jaredoconnell@users.noreply.github.com>
Date:   Thu Sep 3 15:24:19 2026 -0400

    Apply suggestions from code review
    
    Co-authored-by: Samuel Monson <smonson@irbash.net>
    Signed-off-by: Jared O'Connell <46976761+jaredoconnell@users.noreply.github.com>

commit f2c558cd9d20f86e2f915f42cf71f14091464a6c
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Sep 3 15:57:36 2026 -0400

    Address review feedback
    
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Co-authored-by: Samuel Monson <smonson@irbash.net>
Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
Signed-off-by: Jared O'Connell <46976761+jaredoconnell@users.noreply.github.com>
