### PR TITLE
fix: don't start in-process backends in the main process

### DIFF
--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -110,6 +110,21 @@ class Backend(
         """
         return None
 
+    @property
+    def requires_startup_for_resolution(self) -> bool:
+        """
+        Whether ``resolve_backend`` must start the backend up in the main process
+        to validate it and resolve its default model.
+
+        In-process backends that initialize heavyweight resources on
+        ``process_startup`` (e.g. an inference engine) return ``False`` so the
+        resources are only initialized once, in the worker process; their
+        ``default_model`` must be resolvable without a startup.
+
+        :return: True to start up during resolution (default), False to skip it.
+        """
+        return True
+
     @abstractmethod
     async def default_model(self) -> str:
         """

--- a/src/guidellm/backends/backend.py
+++ b/src/guidellm/backends/backend.py
@@ -9,7 +9,7 @@ provide a standard interface for distributed execution across worker processes.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any
+from typing import Any, ClassVar
 
 from guidellm.scheduler import BackendInterface
 from guidellm.schemas import GenerationRequest, GenerationResponse
@@ -110,20 +110,13 @@ class Backend(
         """
         return None
 
-    @property
-    def requires_startup_for_resolution(self) -> bool:
-        """
-        Whether ``resolve_backend`` must start the backend up in the main process
-        to validate it and resolve its default model.
-
-        In-process backends that initialize heavyweight resources on
-        ``process_startup`` (e.g. an inference engine) return ``False`` so the
-        resources are only initialized once, in the worker process; their
-        ``default_model`` must be resolvable without a startup.
-
-        :return: True to start up during resolution (default), False to skip it.
-        """
-        return True
+    #: Whether GuideLLM already knows this backend's default model from its
+    #: configuration, without querying a running engine. When ``True``,
+    #: ``resolve_backend`` reads the model directly and does not start the backend
+    #: in the main process. When ``False`` (the default), the backend must be
+    #: started to discover its model. This is independent of validation: workers
+    #: always start and validate the engine before making requests.
+    backend_defines_model: ClassVar[bool] = False
 
     @abstractmethod
     async def default_model(self) -> str:

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -109,6 +109,15 @@ class VLLMPythonAsyncBackend(Backend):
         """
         return 1
 
+    @property
+    def requires_startup_for_resolution(self) -> bool:
+        """
+        VLLM Python loads an entire engine on ``process_startup``, so it must only
+        be initialized in the worker process. ``resolve_backend`` resolves the
+        model from configuration without starting the engine in the main process.
+        """
+        return False
+
     async def process_startup(self):
         """
         Initialize VLLM AsyncLLMEngine instance with configured parameters.

--- a/src/guidellm/backends/vllm_python/vllm.py
+++ b/src/guidellm/backends/vllm_python/vllm.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import jinja2
 from more_itertools import roundrobin
@@ -109,14 +109,10 @@ class VLLMPythonAsyncBackend(Backend):
         """
         return 1
 
-    @property
-    def requires_startup_for_resolution(self) -> bool:
-        """
-        VLLM Python loads an entire engine on ``process_startup``, so it must only
-        be initialized in the worker process. ``resolve_backend`` resolves the
-        model from configuration without starting the engine in the main process.
-        """
-        return False
+    #: GuideLLM knows the model from configuration (VLLM Python serves a single
+    #: model per engine), so ``resolve_backend`` reads it directly instead of
+    #: starting the engine in the main process just to query it.
+    backend_defines_model: ClassVar[bool] = True
 
     async def process_startup(self):
         """

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -98,18 +98,30 @@ async def resolve_backend(
             f"{backend_instance.__class__.__name__} backend initialized"
         )
 
-    await backend_instance.process_startup()
-    try:
-        await backend_instance.validate()
+    if backend_instance.requires_startup_for_resolution:
+        await backend_instance.process_startup()
+        try:
+            await backend_instance.validate()
 
+            if console_step:
+                console_step.update(
+                    title="Resolving default model from backend.default_model",
+                    status_level="info",
+                )
+            model = await backend_instance.default_model()
+        finally:
+            await backend_instance.process_shutdown()
+    else:
+        # In-process backends (e.g. vllm_python) initialize heavyweight resources
+        # on startup and must only do so in the worker process. Resolve the model
+        # from configuration without starting the backend here; validation runs in
+        # the worker.
         if console_step:
             console_step.update(
                 title="Resolving default model from backend.default_model",
                 status_level="info",
             )
         model = await backend_instance.default_model()
-    finally:
-        await backend_instance.process_shutdown()
 
     if console_step:
         console_step.finish(

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -98,7 +98,17 @@ async def resolve_backend(
             f"{backend_instance.__class__.__name__} backend initialized"
         )
 
-    if backend_instance.requires_startup_for_resolution:
+    if backend_instance.backend_defines_model:
+        # GuideLLM already knows the model from configuration, so there is no need
+        # to start the backend in the main process just to query it. Workers always
+        # start and validate the engine before making requests.
+        if console_step:
+            console_step.update(
+                title="Resolving default model from backend.default_model",
+                status_level="info",
+            )
+        model = await backend_instance.default_model()
+    else:
         await backend_instance.process_startup()
         try:
             await backend_instance.validate()
@@ -111,17 +121,6 @@ async def resolve_backend(
             model = await backend_instance.default_model()
         finally:
             await backend_instance.process_shutdown()
-    else:
-        # In-process backends (e.g. vllm_python) initialize heavyweight resources
-        # on startup and must only do so in the worker process. Resolve the model
-        # from configuration without starting the backend here; validation runs in
-        # the worker.
-        if console_step:
-            console_step.update(
-                title="Resolving default model from backend.default_model",
-                status_level="info",
-            )
-        model = await backend_instance.default_model()
 
     if console_step:
         console_step.finish(

--- a/tests/unit/backends/vllm_python/test_vllm.py
+++ b/tests/unit/backends/vllm_python/test_vllm.py
@@ -1442,3 +1442,16 @@ class TestVLLMResolveAudioFromColumns:
             assert seen_prompt_arg[0]["multi_modal_data"]["audio"] is mock_audio_array
             prompt_str = seen_prompt_arg[0]["prompt"]
             assert "<|audio|>" in prompt_str
+
+
+@pytest.mark.sanity
+def test_requires_startup_for_resolution_is_false():
+    """
+    VLLM Python opts out of main-process startup during backend resolution so its
+    engine is only initialized once, in the worker process (#1083).
+
+    ## WRITTEN BY AI ##
+    """
+    backend = _make_vllm_backend(model="Qwen/Qwen3-0.6B")
+
+    assert backend.requires_startup_for_resolution is False

--- a/tests/unit/backends/vllm_python/test_vllm.py
+++ b/tests/unit/backends/vllm_python/test_vllm.py
@@ -1445,13 +1445,14 @@ class TestVLLMResolveAudioFromColumns:
 
 
 @pytest.mark.sanity
-def test_requires_startup_for_resolution_is_false():
+def test_backend_defines_model_is_true():
     """
-    VLLM Python opts out of main-process startup during backend resolution so its
-    engine is only initialized once, in the worker process (#1083).
+    VLLM Python defines its model from configuration, so resolve_backend reads it
+    without starting the engine in the main process; the engine is only
+    initialized once, in the worker process (#1083).
 
     ## WRITTEN BY AI ##
     """
     backend = _make_vllm_backend(model="Qwen/Qwen3-0.6B")
 
-    assert backend.requires_startup_for_resolution is False
+    assert backend.backend_defines_model is True

--- a/tests/unit/benchmark/test_entrypoints.py
+++ b/tests/unit/benchmark/test_entrypoints.py
@@ -7,7 +7,10 @@ import pytest
 
 from guidellm.benchmark.entrypoints import resolve_backend, resolve_output_formats
 from guidellm.benchmark.outputs import GenerativeBenchmarkerOutput
-from guidellm.schemas.backends import OpenAIHTTPBackendArgs
+from guidellm.schemas.backends import (
+    OpenAIHTTPBackendArgs,
+    VLLMPythonAsyncBackendArgs,
+)
 from guidellm.schemas.benchmark import JSONBenchmarkOutputArgs
 
 
@@ -61,4 +64,61 @@ async def test_resolve_backend_shuts_down_after_validation_error():
     backend.process_startup.assert_awaited_once_with()
     backend.validate.assert_awaited_once_with()
     backend.default_model.assert_not_awaited()
+    backend.process_shutdown.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_resolve_backend_skips_startup_for_in_process_backend():
+    """
+    resolve_backend does not start up or validate a backend that reports
+    requires_startup_for_resolution is False; it resolves the model directly so
+    the backend is only initialized in the worker process.
+
+    ## WRITTEN BY AI ##
+    """
+    backend = MagicMock()
+    backend.requires_startup_for_resolution = False
+    backend.process_startup = AsyncMock()
+    backend.validate = AsyncMock()
+    backend.default_model = AsyncMock(return_value="Qwen/Qwen3-0.6B")
+    backend.process_shutdown = AsyncMock()
+    args = VLLMPythonAsyncBackendArgs(model="Qwen/Qwen3-0.6B")
+
+    with patch("guidellm.benchmark.entrypoints.Backend.create", return_value=backend):
+        resolved_backend, model = await resolve_backend(args)
+
+    assert resolved_backend is backend
+    assert model == "Qwen/Qwen3-0.6B"
+    backend.process_startup.assert_not_awaited()
+    backend.validate.assert_not_awaited()
+    backend.process_shutdown.assert_not_awaited()
+    backend.default_model.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.regression
+async def test_resolve_backend_starts_up_for_remote_backend():
+    """
+    resolve_backend starts up, validates, resolves the model, and shuts down a
+    backend that reports requires_startup_for_resolution is True.
+
+    ## WRITTEN BY AI ##
+    """
+    backend = MagicMock()
+    backend.requires_startup_for_resolution = True
+    backend.process_startup = AsyncMock()
+    backend.validate = AsyncMock()
+    backend.default_model = AsyncMock(return_value="test-model")
+    backend.process_shutdown = AsyncMock()
+    args = OpenAIHTTPBackendArgs(target="http://localhost:8000")
+
+    with patch("guidellm.benchmark.entrypoints.Backend.create", return_value=backend):
+        resolved_backend, model = await resolve_backend(args)
+
+    assert resolved_backend is backend
+    assert model == "test-model"
+    backend.process_startup.assert_awaited_once_with()
+    backend.validate.assert_awaited_once_with()
+    backend.default_model.assert_awaited_once_with()
     backend.process_shutdown.assert_awaited_once_with()

--- a/tests/unit/benchmark/test_entrypoints.py
+++ b/tests/unit/benchmark/test_entrypoints.py
@@ -49,6 +49,7 @@ async def test_resolve_backend_shuts_down_after_validation_error():
     ## WRITTEN BY AI ##
     """
     backend = MagicMock()
+    backend.backend_defines_model = False
     backend.process_startup = AsyncMock()
     backend.validate = AsyncMock(side_effect=RuntimeError("validation failed"))
     backend.default_model = AsyncMock()
@@ -71,14 +72,14 @@ async def test_resolve_backend_shuts_down_after_validation_error():
 @pytest.mark.regression
 async def test_resolve_backend_skips_startup_for_in_process_backend():
     """
-    resolve_backend does not start up or validate a backend that reports
-    requires_startup_for_resolution is False; it resolves the model directly so
-    the backend is only initialized in the worker process.
+    resolve_backend does not start up or validate a backend that defines its own
+    model (backend_defines_model is True); it resolves the model directly so the
+    backend is only initialized in the worker process.
 
     ## WRITTEN BY AI ##
     """
     backend = MagicMock()
-    backend.requires_startup_for_resolution = False
+    backend.backend_defines_model = True
     backend.process_startup = AsyncMock()
     backend.validate = AsyncMock()
     backend.default_model = AsyncMock(return_value="Qwen/Qwen3-0.6B")
@@ -101,12 +102,12 @@ async def test_resolve_backend_skips_startup_for_in_process_backend():
 async def test_resolve_backend_starts_up_for_remote_backend():
     """
     resolve_backend starts up, validates, resolves the model, and shuts down a
-    backend that reports requires_startup_for_resolution is True.
+    backend that does not define its own model (backend_defines_model is False).
 
     ## WRITTEN BY AI ##
     """
     backend = MagicMock()
-    backend.requires_startup_for_resolution = True
+    backend.backend_defines_model = False
     backend.process_startup = AsyncMock()
     backend.validate = AsyncMock()
     backend.default_model = AsyncMock(return_value="test-model")


### PR DESCRIPTION
## Summary

When benchmarking with the `vllm_python` backend, vLLM starts up twice: `resolve_backend` starts and validates the backend in the main process to resolve the default model, and then the spawned worker starts it again. For an in-process backend this loads the entire engine twice.

As noted in the issue, this regressed with the switch to `spawn` as the default multiprocessing context — under `fork` the worker inherited the already-initialized backend, so the main-process startup was not duplicated work.

## Details

- Added a `Backend.requires_startup_for_resolution` property (default `True`). It indicates whether `resolve_backend` must start the backend up in the main process to validate it and resolve its default model.
- `VLLMPythonAsyncBackend` overrides it to `False` (inherited by `VLLMPythonBatchBackend`). Its `default_model` returns the configured model without an engine, so `resolve_backend` resolves the model directly and never loads the engine in the main process.
- `resolve_backend` branches on the flag: `True` keeps the existing startup → validate → resolve → shutdown behavior; `False` resolves the model without starting the backend. The worker (`scheduler/worker.py`) remains responsible for `process_startup`/`validate`, so validation is not skipped — only relocated to the worker for in-process backends.

Scope: only `vllm_python` / `vllm_python_batch` change behavior. All other backends default to `True` and are unchanged. `resolve_backend` already returned a shut-down (not-started) backend, so the returned object's state is identical either way; the only difference is the removed transient main-process engine load.

**One intended behavioral change:** for `vllm_python`, a misconfiguration/health-check error now surfaces at worker startup rather than in the main process. Validation still runs (in the worker); it is not skipped.

## Test Plan

- Added `resolve_backend` tests: it skips `process_startup`/`validate`/`process_shutdown` for a backend reporting `requires_startup_for_resolution=False` (resolving the model directly), and still performs the full startup/validate/shutdown for a backend reporting `True`. The existing validation-error test still passes.
- Added a test asserting `VLLMPythonAsyncBackend.requires_startup_for_resolution is False`.
- `tox -e lint-check`, `tox -e type-check`, and `tox -e test-unit` all pass (2979 passed).

Note: I was unable to reproduce end-to-end against a real vLLM engine locally (no GPU/vLLM install). The change is confined to `resolve_backend`; the vLLM startup path itself is untouched, and the behavior change (which lifecycle calls happen in the main process) is what the added tests verify.

## Related Issues

- Fixes #1083

<!-- begin:squash-data -->

---

# git log

commit 3215725517da345694b023f2dc96dde12ac1b3c3
Author: Pragadeesh122 <pragan189@gmail.com>
Date:   Thu Sep 3 22:19:07 2026 -0500

    fix: don't start in-process backends in the main process (#1083)
    
    resolve_backend started up and validated the backend in the main process to
    resolve the default model, then the spawned worker started it again. For
    in-process backends like vllm_python this loads the entire engine twice.
    
    Add a Backend.requires_startup_for_resolution flag (default True). vllm_python
    overrides it to False so resolve_backend resolves the model from config without
    starting the engine; the worker remains responsible for startup and validation.
    
    Signed-off-by: Pragadeesh122 <pragan189@gmail.com>

commit de2cc109f229640f1ffad369d8ef9052d7d4ff78
Author: Pragadeesh122 <pragan189@gmail.com>
Date:   Sun Sep 6 14:36:58 2026 -0500

    refactor: rename flag to backend_defines_model per review (#1083)
    
    Address review feedback: rename requires_startup_for_resolution to
    backend_defines_model, make it a ClassVar constant instead of a property, and
    reframe the docstrings/comment around GuideLLM knowing the model from config
    (validation always runs in the worker). No behavior change.
    
    Signed-off-by: Pragadeesh122 <pragan189@gmail.com>

---------

Signed-off-by: Pragadeesh122 <pragan189@gmail.com>
