### PR TITLE
Add goodput measurement against per-request latency objectives

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -41,6 +41,16 @@ These metrics provide a breakdown of the overall request statuses, helping users
 - **Definition**: The number of requests being processed simultaneously.
 - **Use Case**: Helps evaluate the system's capacity to handle parallel workloads.
 
+### SLO Attainment
+
+- **Definition**: The fraction of requests meeting every configured latency objective. Reported only when objectives are set through `--metrics`. Errored requests count as non-conforming. Requests cancelled at the run's duration limit, and requests whose objectives cannot be evaluated (such as time to first token on a non-streaming backend), are excluded from both the numerator and the denominator.
+- **Use Case**: States directly whether a deployment meets a target such as "TTFT under 200ms for 99% of requests". Because it is a ratio rather than a rate, it does not change with the length of the measurement window.
+
+### Request Goodput
+
+- **Definition**: The number of objective-conforming requests completed per second. Requests that complete but breach an objective count toward request rate and not toward goodput, so goodput is always at or below the request rate.
+- **Use Case**: Separates useful capacity from raw capacity. Past a server's saturation point the request rate can stay flat while goodput falls, because requests still complete but no longer complete quickly enough to be useful.
+
 ### Output Tokens Per Second
 
 - **Definition**: The average number of output tokens generated per second as a throughput metric across all requests.

--- a/docs/guides/service_level_objectives.md
+++ b/docs/guides/service_level_objectives.md
@@ -97,6 +97,31 @@ This category includes use cases where maximizing throughput is the primary conc
 - **SLOs**:
   - Maximize Throughput: ≥ 150 requests per second
 
+## Measuring Against These Objectives
+
+The targets above are stated as a threshold plus a share of requests, for example "TTFT ≤ 200ms for 99% of requests". GuideLLM measures both parts directly.
+
+### Declaring Objectives
+
+Objectives are set on `--metrics`. Each is a per-request threshold in milliseconds, and a request conforms only when it meets all of them:
+
+```bash
+guidellm run \
+  --backend kind=openai_http,target=http://localhost:8000 \
+  --profile kind=concurrent,streams=32 \
+  --data kind=synthetic_text,prompt_tokens=256,output_tokens=128 \
+  --metrics '{"kind":"generative","slo":{"ttft_ms":200,"tpot_ms":50}}' \
+  --constraint kind=max_duration,seconds=120
+```
+
+| Objective | Compared against    | Notes                                                                                                                                                                                                                                                                                                        |
+| --------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ttft_ms` | Time to First Token | Requires a streaming backend                                                                                                                                                                                                                                                                                 |
+| `tpot_ms` | Inter-Token Latency | Excludes the first token. This is not GuideLLM's Time Per Output Token, which includes it. It is the closest metric to vLLM's `tpot`, though not identical: vLLM measures to request completion, inter-token latency to the last token received. Requests producing one token or fewer are left undetermined |
+| `e2el_ms` | Request Latency     | Works with streaming and non-streaming backends                                                                                                                                                                                                                                                              |
+
+Two metrics are then reported: SLO attainment, the share of requests meeting every objective, and request goodput, the rate of those conforming requests. Errored requests count against attainment, since a request that failed did not deliver a response within its objective. Requests cancelled when the run hits its duration limit are excluded, since the run ended them rather than the server. An objective naming a metric the workload cannot measure, such as `ttft_ms` against a non-streaming backend, leaves every request undetermined and both metrics are reported as unset rather than zero.
+
 ## Conclusion
 
 Setting appropriate SLOs and SLAs is essential for optimizing LLM deployments to meet user expectations and business requirements. By balancing latency, throughput, and cost efficiency, organizations can ensure high-quality service while minimizing operational costs. The examples provided above serve as a starting point for defining SLOs and SLAs tailored to specific use cases.

--- a/src/guidellm/benchmark/benchmarker.py
+++ b/src/guidellm/benchmark/benchmarker.py
@@ -33,7 +33,7 @@ from guidellm.scheduler import (
     Scheduler,
     SchedulingStrategy,
 )
-from guidellm.schemas.benchmark import TransientPhaseConfig
+from guidellm.schemas.benchmark import GoodputSLO, TransientPhaseConfig
 from guidellm.utils.mixins import InfoMixin
 from guidellm.utils.singleton import ThreadSafeSingletonMixin
 
@@ -69,6 +69,7 @@ class Benchmarker(
         progress: (
             BenchmarkerProgress[BenchmarkAccumulatorT, BenchmarkT] | None
         ) = None,
+        slo: GoodputSLO | None = None,
     ) -> AsyncIterator[BenchmarkT]:
         """
         Execute benchmark runs across scheduling strategies in the profile.
@@ -87,6 +88,8 @@ class Benchmarker(
         :param prefer_response_metrics: Whether to prefer response metrics over
             request metrics, defaults to True
         :param progress: Optional tracker for benchmark lifecycle events
+        :param slo: Per-request latency objectives defining which requests count
+            toward goodput, or None to disable goodput measurement
         :yield: Compiled benchmark result for each strategy execution
         :raises Exception: If benchmark execution or compilation fails
         """
@@ -122,6 +125,7 @@ class Benchmarker(
                     warmup=warmup,
                     cooldown=cooldown,
                     prefer_response_metrics=prefer_response_metrics,
+                    slo=slo,
                     profile=InfoMixin.extract_from_obj(profile),
                     requests=InfoMixin.extract_from_obj(requests),
                     backend=InfoMixin.extract_from_obj(backend),

--- a/src/guidellm/benchmark/entrypoints.py
+++ b/src/guidellm/benchmark/entrypoints.py
@@ -551,6 +551,7 @@ async def benchmark_generative_text(
         warmup=warmup,
         cooldown=cooldown,
         prefer_response_metrics=metrics_args.prefer_response_metrics,
+        slo=metrics_args.slo,
     ):
         if benchmark:
             report.benchmarks.append(benchmark)

--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -485,6 +485,13 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
         :param report: The benchmark report containing throughput metrics
         """
         columns = ConsoleTableColumnsCollection()
+        # Widen the table whenever objectives were configured, not only when
+        # they could be evaluated. A workload that cannot measure an objective,
+        # such as time to first token without streaming, then shows empty cells
+        # instead of the table silently looking as though none were set.
+        report_has_goodput = any(
+            benchmark.config.slo is not None for benchmark in report.benchmarks
+        )
 
         for benchmark in report.benchmarks:
             columns.add_value(
@@ -528,6 +535,22 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
                 name="Per Sec",
                 types=("mean",),
             )
+            if report_has_goodput:
+                attainment = benchmark.metrics.slo_attainment
+                columns.add_value(
+                    None if attainment is None else attainment * 100.0,
+                    group="Goodput",
+                    name="Attainment",
+                    units="%",
+                    precision=1,
+                )
+                columns.add_stats(
+                    benchmark.metrics.request_goodput,
+                    status="total",
+                    group="Goodput",
+                    name="Per Sec",
+                    types=("mean",),
+                )
 
         headers, values = columns.get_table_data()
         self.console.print("\n")

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -499,6 +499,22 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
             "Server Throughput",
             "Concurrency",
         )
+        # Emitted whenever objectives were configured, so a workload that
+        # cannot evaluate them still reports attainment as empty rather than
+        # dropping the columns and reading as though none were set. Every
+        # benchmark in a run shares one objective set, so the columns stay
+        # aligned across rows.
+        if benchmark.config.slo is not None:
+            # Written directly rather than through _add_stats_for_metric,
+            # which drops any status whose total is 0.0. A run that conforms to
+            # nothing would otherwise lose these columns from the CSV while the
+            # console and JSON still report 0.0.
+            goodput = benchmark.metrics.request_goodput
+            headers.append(["Server Throughput", "Successful Goodput/Sec", "mean"])
+            values.append("" if goodput is None else goodput.successful.mean)
+            headers.append(["Server Throughput", "SLO Attainment", ""])
+            attainment = benchmark.metrics.slo_attainment
+            values.append("" if attainment is None else attainment)
         self._add_stats_for_metric(
             headers,
             values,

--- a/src/guidellm/benchmark/schemas/base.py
+++ b/src/guidellm/benchmark/schemas/base.py
@@ -29,6 +29,7 @@ from guidellm.schemas import (
     StandardBaseDict,
     StatusDistributionSummary,
 )
+from guidellm.schemas.benchmark.goodput import GoodputSLO
 from guidellm.schemas.benchmark.transient import TransientPhaseConfig
 
 __all__ = [
@@ -93,6 +94,13 @@ class BenchmarkConfig(StandardBaseDict):
     prefer_response_metrics: bool = Field(
         default=True,
         description="Prioritize response-based metrics over request-based metrics",
+    )
+    slo: GoodputSLO | None = Field(
+        default=None,
+        description=(
+            "Per-request latency objectives defining which requests count "
+            "toward goodput. None disables goodput measurement"
+        ),
     )
     profile: dict[str, Any] = Field(
         description="Profile instance coordinating multi-strategy execution",

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -25,6 +25,7 @@ from guidellm.schemas import (
     StatusBreakdown,
     StatusDistributionSummary,
 )
+from guidellm.schemas.benchmark import GoodputSLO
 
 __all__ = [
     "GenerativeAudioMetricsSummary",
@@ -879,6 +880,113 @@ class GenerativeMetrics(StandardBaseDict):
         description="Tool call metrics for tokens and call counts"
     )
 
+    # Goodput stats, populated only when latency objectives are configured
+    slo_attainment: float | None = Field(
+        default=None,
+        description=(
+            "Fraction of requests meeting every configured latency objective, "
+            "between 0.0 and 1.0. Errored requests count as non-conforming. "
+            "Requests cancelled at the measurement boundary, and requests whose "
+            "objectives cannot be evaluated, are excluded from both numerator "
+            "and denominator. None when no objectives are configured"
+        ),
+    )
+    slo_determined_requests: int = Field(
+        default=0,
+        description=(
+            "Number of requests slo_attainment is averaged over: successful "
+            "requests whose objectives could all be evaluated, plus errored "
+            "requests, which count as non-conforming"
+        ),
+    )
+    request_goodput: StatusDistributionSummary | None = Field(
+        default=None,
+        description=(
+            "Distribution of objective-conforming requests per second, computed "
+            "over the same measurement window as requests_per_second so the two "
+            "are directly comparable. None when no objectives are configured"
+        ),
+    )
+
+    @classmethod
+    def _compile_goodput(
+        cls,
+        slo: GoodputSLO | None,
+        successful: list[GenerativeRequestStats],
+        errored: list[GenerativeRequestStats],
+        start_time: float,
+        end_time: float,
+    ) -> tuple[float | None, int, StatusDistributionSummary | None]:
+        """
+        Compile goodput attainment and rate against configured latency objectives.
+
+        Errored requests count against attainment. A request that failed did not
+        deliver a response within its latency objective, and on a saturated
+        server overload usually surfaces as timeouts and errors rather than as
+        slow successes; scoring only successful requests would report a level
+        that is mostly failing as fully conforming. Incomplete requests are
+        excluded instead, because they were cancelled at the measurement
+        boundary by the run's own duration limit rather than by the server.
+
+        Attainment is a ratio over the measured request population and so is not
+        affected by how much of the measurement window the server spent filling
+        its pipeline. The rate shares the window convention of
+        ``requests_per_second`` and therefore shares its sensitivity to that
+        ramp, which is why callers comparing load levels should prefer
+        attainment.
+
+        :param slo: Configured latency objectives, or None to skip goodput
+        :param successful: Successful request statistics within the window
+        :param errored: Errored request statistics within the window
+        :param start_time: Measurement window start timestamp
+        :param end_time: Measurement window end timestamp
+        :return: Tuple of (attainment ratio, determined request count,
+            conforming request rate). The ratio and rate are None when no
+            objectives are configured or none could be evaluated
+        """
+        if slo is None:
+            return None, 0, None
+
+        conforming: list[GenerativeRequestStats] = []
+        determined = 0
+        for stats in successful:
+            verdict = slo.is_conforming(
+                ttft_ms=stats.time_to_first_token_ms,
+                tpot_ms=stats.inter_token_latency_ms,
+                e2el_ms=(
+                    stats.request_latency * 1000.0
+                    if stats.request_latency is not None
+                    else None
+                ),
+            )
+            if verdict is None:
+                continue
+            determined += 1
+            if verdict:
+                conforming.append(stats)
+
+        # An errored request produced no conforming response, so it lowers
+        # attainment without needing its latencies to be measurable.
+        determined += len(errored)
+
+        if determined == 0:
+            # Every request lacked a measurement for at least one objective, so
+            # there is no population to average over. Reporting 0.0 here would
+            # read as "nothing met the objectives" rather than "the objectives
+            # do not apply to this workload".
+            return None, 0, None
+
+        goodput = StatusDistributionSummary.rate_distribution_from_timings_function(
+            function=lambda req: req.request_end_time,
+            successful=conforming,
+            incomplete=[],
+            errored=[],
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        return len(conforming) / determined, determined, goodput
+
     @classmethod
     def compile(cls, accumulator: GenerativeBenchmarkAccumulator) -> GenerativeMetrics:
         """
@@ -921,7 +1029,18 @@ class GenerativeMetrics(StandardBaseDict):
                 errored=errored,
             )
 
+        slo_attainment, slo_determined, request_goodput = cls._compile_goodput(
+            slo=accumulator.config.slo,
+            successful=successful,
+            errored=errored,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
         return GenerativeMetrics(
+            slo_attainment=slo_attainment,
+            slo_determined_requests=slo_determined,
+            request_goodput=request_goodput,
             # Request stats
             request_totals=StatusBreakdown(
                 successful=len(successful),

--- a/src/guidellm/schemas/benchmark/__init__.py
+++ b/src/guidellm/schemas/benchmark/__init__.py
@@ -12,6 +12,7 @@ from guidellm.schemas.benchmark.entrypoints import (
     default_kind,
     default_kind_list,
 )
+from guidellm.schemas.benchmark.goodput import GoodputSLO
 from guidellm.schemas.benchmark.outputs import (
     BenchmarkOutputArgs,
     ConsoleBenchmarkOutputArgs,
@@ -45,6 +46,7 @@ __all__ = [
     "ConcurrentProfileArgs",
     "ConsoleBenchmarkOutputArgs",
     "GenerativeMetricsArgs",
+    "GoodputSLO",
     "HTMLBenchmarkOutputArgs",
     "JSONBenchmarkOutputArgs",
     "MetricsArgs",

--- a/src/guidellm/schemas/benchmark/entrypoints.py
+++ b/src/guidellm/schemas/benchmark/entrypoints.py
@@ -32,6 +32,7 @@ from guidellm.schemas import (
     standard_model_config,
 )
 from guidellm.schemas.backends import BackendArgs
+from guidellm.schemas.benchmark.goodput import GoodputSLO
 from guidellm.schemas.benchmark.outputs import BenchmarkOutputArgs
 from guidellm.schemas.benchmark.profiles import ProfileArgs
 from guidellm.schemas.benchmark.random import RandomArgs
@@ -133,6 +134,14 @@ class GenerativeMetricsArgs(MetricsArgs):
             "Prioritize server-reported metrics over client-calculated metrics "
             "when both are available."
         ),
+    )
+    slo: GoodputSLO | None = Field(
+        default=None,
+        description=(
+            "Per-request latency objectives defining which requests count "
+            "toward goodput. None disables goodput measurement."
+        ),
+        examples=[None, {"ttft_ms": 2000, "tpot_ms": 100}],
     )
 
 

--- a/src/guidellm/schemas/benchmark/goodput.py
+++ b/src/guidellm/schemas/benchmark/goodput.py
@@ -1,0 +1,119 @@
+"""
+Service level objective definitions for goodput measurement.
+
+Goodput is the rate of requests that complete within a set of per-request latency
+objectives, as opposed to throughput which counts every completed request. A
+request is conforming only when it satisfies every configured objective.
+
+Objective names follow the convention used by vLLM's ``benchmark_serving``
+(``ttft``, ``tpot``, ``e2el``, all in milliseconds) so that objectives can be
+carried between the two tools unchanged.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, PositiveFloat, model_validator
+
+from guidellm.schemas import StandardBaseModel
+
+__all__ = ["GoodputSLO"]
+
+
+class GoodputSLO(StandardBaseModel):
+    """
+    Per-request latency objectives defining which requests count as conforming.
+
+    Every objective left unset is ignored. A request conforms when it satisfies
+    all objectives that are set; a benchmark with no objectives set has no
+    meaningful goodput and reports it as None.
+
+    Note the mapping between objective names and GuideLLM metrics. ``tpot`` is
+    compared against :attr:`GenerativeRequestStats.inter_token_latency_ms`,
+    which excludes the first token, and not against GuideLLM's
+    ``time_per_output_token_ms``, which includes it. This is the closest
+    GuideLLM metric to vLLM's ``tpot`` but is not identical: vLLM divides by
+    the interval ending at the request's completion, while inter-token latency
+    ends at the last token received.
+
+    Example:
+    ::
+        slo = GoodputSLO(ttft_ms=2000, tpot_ms=100)
+        conforming = slo.is_conforming(ttft_ms=150.0, tpot_ms=12.0, e2el_ms=None)
+    """
+
+    ttft_ms: PositiveFloat | None = Field(
+        default=None,
+        description=(
+            "Maximum time to first token in milliseconds. Compared against "
+            "each request's time_to_first_token_ms"
+        ),
+        examples=[2000.0],
+    )
+    tpot_ms: PositiveFloat | None = Field(
+        default=None,
+        description=(
+            "Maximum time per output token in milliseconds, excluding the "
+            "first token. Compared against each request's "
+            "inter_token_latency_ms. Requests producing one token or fewer have "
+            "no inter-token latency and are left undetermined"
+        ),
+        examples=[100.0],
+    )
+    e2el_ms: PositiveFloat | None = Field(
+        default=None,
+        description=(
+            "Maximum end-to-end request latency in milliseconds. Compared "
+            "against each request's request_latency, converted from seconds"
+        ),
+        examples=[30000.0],
+    )
+
+    @model_validator(mode="after")
+    def _require_an_objective(self) -> GoodputSLO:
+        """
+        Validate that at least one objective is set.
+
+        :return: The validated instance
+        :raises ValueError: If no objective is set
+        """
+        if all(value is None for value in (self.ttft_ms, self.tpot_ms, self.e2el_ms)):
+            raise ValueError(
+                "GoodputSLO requires at least one of ttft_ms, tpot_ms, or e2el_ms"
+            )
+
+        return self
+
+    def is_conforming(
+        self,
+        ttft_ms: float | None,
+        tpot_ms: float | None,
+        e2el_ms: float | None,
+    ) -> bool | None:
+        """
+        Determine whether one request's measured latencies satisfy the objectives.
+
+        A request is undetermined as soon as any configured objective has no
+        corresponding measurement, even if another objective is already
+        breached. Deciding such a request on its measurable objectives alone
+        would bias the population it is averaged over: on a workload where an
+        objective is never measurable, only the requests that happen to breach
+        a different objective would remain, driving attainment to zero.
+
+        :param ttft_ms: Measured time to first token in milliseconds
+        :param tpot_ms: Measured inter-token latency in milliseconds
+        :param e2el_ms: Measured end-to-end latency in milliseconds
+        :return: True if conforming, False if violating, None if undetermined
+        """
+        measured = (ttft_ms, tpot_ms, e2el_ms)
+        objectives = (self.ttft_ms, self.tpot_ms, self.e2el_ms)
+
+        conforming = True
+        for value, objective in zip(measured, objectives, strict=True):
+            if objective is None:
+                continue
+            if value is None:
+                return None
+            if value > objective:
+                conforming = False
+
+        return conforming

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -26,6 +26,7 @@ from guidellm.schemas import (
     StatusDistributionSummary,
     UsageMetrics,
 )
+from guidellm.schemas.benchmark import GoodputSLO
 
 
 def _make_errored_tool_call_stats(request_id: str) -> GenerativeRequestStats:
@@ -488,3 +489,444 @@ class TestScheduleRelativeMetrics:
         assert metrics.request_dispatch_delay is not None
         assert metrics.request_dispatch_delay.successful.count == 1
         assert metrics.request_dispatch_delay.successful.mean == pytest.approx(4.0)
+
+
+def _make_latency_stats(
+    request_id: str,
+    request_start: float,
+    first_token: float,
+    request_end: float,
+    output_tokens: int = 9,
+) -> GenerativeRequestStats:
+    """Build a completed streaming request with explicit token timings.
+
+    ## WRITTEN BY AI ##
+    """
+    timings = RequestTimings(
+        resolve_start=request_start,
+        resolve_end=request_end,
+        request_start=request_start,
+        request_end=request_end,
+        first_token_iteration=first_token,
+        last_token_iteration=request_end,
+        token_iterations=output_tokens,
+    )
+    return GenerativeRequestStats(
+        request_id=request_id,
+        info=RequestInfo(request_id=request_id, status="completed", timings=timings),
+        input_metrics=UsageMetrics(text_tokens=8),
+        output_metrics=UsageMetrics(text_tokens=output_tokens),
+    )
+
+
+def _make_errored_stats(request_id: str, start: float) -> GenerativeRequestStats:
+    """
+    Build an errored request with no usable output metrics.
+
+    ## WRITTEN BY AI ##
+    """
+    timings = RequestTimings(
+        resolve_start=start,
+        resolve_end=start + 1.0,
+        request_start=start,
+        request_end=start + 1.0,
+    )
+    return GenerativeRequestStats(
+        request_id=request_id,
+        info=RequestInfo(request_id=request_id, status="errored", timings=timings),
+        input_metrics=UsageMetrics(text_tokens=8),
+        output_metrics=UsageMetrics(),
+    )
+
+
+def _make_goodput_accumulator(
+    successful: list[GenerativeRequestStats],
+    start_time: float,
+    end_time: float,
+    slo: GoodputSLO | None,
+) -> GenerativeBenchmarkAccumulator:
+    """Build an accumulator carrying latency objectives on its config.
+
+    ## WRITTEN BY AI ##
+    """
+    accumulator = _make_accumulator(successful, start_time, end_time)
+    accumulator.config.slo = slo
+
+    return accumulator
+
+
+class TestGoodputMetrics:
+    """
+    Verify goodput attainment and rate compiled against latency objectives.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.smoke
+    def test_no_objectives_reports_nothing(self):
+        """
+        Leave goodput unset when no objectives were configured.
+
+        ## WRITTEN BY AI ##
+        """
+        successful = [
+            _make_latency_stats(
+                "a",
+                SCHEDULE_BASE_TIME,
+                SCHEDULE_BASE_TIME + 0.1,
+                SCHEDULE_BASE_TIME + 1.0,
+            )
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                successful, SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 10.0, None
+            )
+        )
+
+        assert metrics.slo_attainment is None
+        assert metrics.request_goodput is None
+        assert metrics.slo_determined_requests == 0
+
+    @pytest.mark.sanity
+    def test_attainment_is_the_conforming_fraction(self):
+        """
+        Report attainment as the share of requests meeting every objective.
+
+        Three of four requests finish within a 2s end-to-end objective.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        successful = [
+            _make_latency_stats("a", base, base + 0.1, base + 1.0),
+            _make_latency_stats("b", base, base + 0.1, base + 1.5),
+            _make_latency_stats("c", base, base + 0.1, base + 1.9),
+            _make_latency_stats("d", base, base + 0.1, base + 5.0),
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                successful, base, base + 10.0, GoodputSLO(e2el_ms=2000)
+            )
+        )
+
+        assert metrics.slo_attainment == pytest.approx(0.75)
+        assert metrics.slo_determined_requests == 4
+
+    @pytest.mark.sanity
+    def test_goodput_never_exceeds_throughput(self):
+        """
+        Report a conforming-request rate at or below the overall request rate.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        successful = [
+            _make_latency_stats("a", base, base + 0.1, base + 1.0),
+            _make_latency_stats("b", base, base + 0.1, base + 5.0),
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                successful, base, base + 10.0, GoodputSLO(e2el_ms=2000)
+            )
+        )
+
+        assert metrics.request_goodput is not None
+        # One of two requests conforms over a 10s window. The ordering check
+        # alone is a tautology: conforming is a subset of successful over the
+        # same window, so it holds for any subset selection, right or wrong.
+        assert metrics.request_goodput.successful.mean == pytest.approx(0.1)
+        assert metrics.requests_per_second.successful.mean == pytest.approx(0.2)
+
+    @pytest.mark.regression
+    def test_unmeasurable_objective_reports_none_not_zero(self):
+        """
+        Report None when no request can be evaluated, rather than zero.
+
+        A non-streaming workload has no first-token timing, so a ttft objective
+        leaves every request undetermined. Reporting 0.0 would read as "nothing
+        met the objectives" instead of "the objectives do not apply here".
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        successful = [
+            _make_scheduled_stats("a", base, base, base + 1.0),
+            _make_scheduled_stats("b", base, base, base + 9.0),
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                successful, base, base + 10.0, GoodputSLO(ttft_ms=500, e2el_ms=2000)
+            )
+        )
+
+        assert metrics.slo_attainment is None
+        assert metrics.request_goodput is None
+        assert metrics.slo_determined_requests == 0
+
+    @pytest.mark.smoke
+    def test_goodput_fields_are_optional_for_existing_reports(self):
+        """
+        Carry defaults so reports written before goodput existed still validate.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                [_make_latency_stats("a", base, base + 0.1, base + 1.0)],
+                base,
+                base + 10.0,
+                GoodputSLO(e2el_ms=2000),
+            )
+        )
+
+        payload = metrics.model_dump()
+        for name in ("slo_attainment", "slo_determined_requests", "request_goodput"):
+            del payload[name]
+
+        restored = GenerativeMetrics.model_validate(payload)
+
+        assert restored.slo_attainment is None
+        assert restored.request_goodput is None
+        assert restored.slo_determined_requests == 0
+
+
+class TestGoodputObjectiveMapping:
+    """
+    Verify which measured latency each objective is compared against.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.regression
+    def test_tpot_uses_inter_token_latency_not_time_per_output_token(self):
+        """
+        Compare tpot against inter-token latency, which excludes the first
+        token, rather than against time per output token, which includes it.
+
+        The two differ whenever time to first token differs from the steady
+        inter-token interval, and the documented objective mapping depends on
+        this choice.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        # 9 output tokens: slow first token at 0.5s, then 1.0s of generation.
+        # inter-token latency = 1000 * 1.0 / 8 = 125ms
+        # time per output token = 1000 * 1.5 / 9 = 166.7ms
+        stats = _make_latency_stats("a", base, base + 0.5, base + 1.5, output_tokens=9)
+        assert stats.inter_token_latency_ms == pytest.approx(125.0, abs=0.1)
+        assert stats.time_per_output_token_ms == pytest.approx(166.7, abs=0.1)
+
+        # A threshold between the two must accept the request.
+        conforming = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                [stats], base, base + 10.0, GoodputSLO(tpot_ms=150)
+            )
+        )
+
+        assert conforming.slo_attainment == pytest.approx(1.0)
+
+    @pytest.mark.regression
+    def test_ttft_and_tpot_objectives_are_not_swapped(self):
+        """
+        Compare each objective against its own measurement.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        # ttft = 500ms, inter-token latency = 125ms.
+        stats = _make_latency_stats("a", base, base + 0.5, base + 1.5, output_tokens=9)
+
+        # Thresholds that pass only when each is matched to its own metric.
+        matched = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                [stats], base, base + 10.0, GoodputSLO(ttft_ms=600, tpot_ms=150)
+            )
+        )
+        # Swapping the thresholds must fail: ttft 500 > 150, tpot 125 <= 600.
+        swapped = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                [stats], base, base + 10.0, GoodputSLO(ttft_ms=150, tpot_ms=600)
+            )
+        )
+
+        assert matched.slo_attainment == pytest.approx(1.0)
+        assert swapped.slo_attainment == pytest.approx(0.0)
+
+    @pytest.mark.regression
+    def test_single_token_requests_are_undetermined_under_tpot(self):
+        """
+        Leave requests with one output token undetermined when tpot is set.
+
+        Inter-token latency needs two tokens, so such requests are excluded
+        from the population rather than counted either way.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        stats = _make_latency_stats("a", base, base + 0.1, base + 0.2, output_tokens=1)
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                [stats], base, base + 10.0, GoodputSLO(tpot_ms=1000)
+            )
+        )
+
+        assert metrics.slo_determined_requests == 0
+        assert metrics.slo_attainment is None
+
+
+class TestGoodputPopulation:
+    """
+    Verify which requests the attainment fraction is averaged over.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.regression
+    def test_denominator_counts_only_determined_requests(self):
+        """
+        Divide by the requests that could be evaluated, not by every
+        successful request.
+
+        A mixed population is the only case that separates the two, and it is
+        reachable whenever some requests carry token timings and others do not.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        # Two streaming requests that conform, two without token timings.
+        successful = [
+            _make_latency_stats("s1", base, base + 0.1, base + 1.0),
+            _make_latency_stats("s2", base, base + 0.1, base + 1.0),
+            _make_scheduled_stats("n1", base, base, base + 1.0),
+            _make_scheduled_stats("n2", base, base, base + 1.0),
+        ]
+        metrics = GenerativeMetrics.compile(
+            _make_goodput_accumulator(
+                successful, base, base + 10.0, GoodputSLO(ttft_ms=500)
+            )
+        )
+
+        assert metrics.slo_determined_requests == 2
+        assert metrics.slo_attainment == pytest.approx(1.0)
+
+    @pytest.mark.regression
+    def test_errored_requests_count_against_attainment(self):
+        """
+        Score errored requests as non-conforming.
+
+        On a saturated server overload surfaces as errors rather than slow
+        successes. Averaging over successful requests alone reports a level
+        that is mostly failing as fully conforming, which would make a search
+        driven by attainment climb straight past the knee.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        successful = [_make_latency_stats("ok", base, base + 0.1, base + 1.0)]
+        errored = [_make_errored_stats(f"err-{i}", base) for i in range(9)]
+        accumulator = _make_goodput_accumulator(
+            successful, base, base + 10.0, GoodputSLO(e2el_ms=5000)
+        )
+        accumulator.errored.requests_stats = errored
+        metrics = GenerativeMetrics.compile(accumulator)
+
+        assert metrics.slo_determined_requests == 10
+        assert metrics.slo_attainment == pytest.approx(0.1)
+
+    @pytest.mark.regression
+    def test_incomplete_requests_are_excluded(self):
+        """
+        Ignore requests cancelled at the measurement boundary.
+
+        Those were truncated by the run's own duration limit rather than by
+        the server, so counting them would penalise every duration-limited run.
+
+        ## WRITTEN BY AI ##
+        """
+        base = SCHEDULE_BASE_TIME
+        successful = [_make_latency_stats("ok", base, base + 0.1, base + 1.0)]
+        accumulator = _make_goodput_accumulator(
+            successful, base, base + 10.0, GoodputSLO(e2el_ms=5000)
+        )
+        accumulator.incomplete.requests_stats = [
+            _make_errored_stats(f"cancelled-{i}", base) for i in range(9)
+        ]
+        metrics = GenerativeMetrics.compile(accumulator)
+
+        assert metrics.slo_determined_requests == 1
+        assert metrics.slo_attainment == pytest.approx(1.0)
+
+
+class TestGoodputConfigWiring:
+    """
+    Verify latency objectives reach the accumulator from configuration.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.regression
+    def test_objectives_reach_benchmark_config(self):
+        """
+        Carry the configured objectives onto BenchmarkConfig so metric
+        compilation can read them.
+
+        Without this the plumbing between the metrics arguments and the
+        accumulator can be severed and every goodput metric silently becomes
+        None while the run still reports success.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000)
+        accumulator = _make_goodput_accumulator(
+            [], SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 1.0, slo
+        )
+
+        assert accumulator.config.slo == slo
+
+    @pytest.mark.regression
+    def test_config_round_trips_objectives(self):
+        """
+        Serialize and restore objectives on BenchmarkConfig.
+
+        ## WRITTEN BY AI ##
+        """
+        config = BenchmarkConfig(
+            run_id="goodput",
+            run_index=0,
+            strategy=AsyncConstantStrategy(rate=10.0),
+            constraints={},
+            profile={},
+            requests={},
+            backend={},
+            environment={},
+            slo=GoodputSLO(ttft_ms=2000, tpot_ms=100),
+        )
+        restored = BenchmarkConfig.model_validate(config.model_dump())
+
+        assert restored.slo is not None
+        assert restored.slo.ttft_ms == 2000
+        assert restored.slo.tpot_ms == 100
+
+    @pytest.mark.regression
+    def test_config_without_objectives_still_validates(self):
+        """
+        Restore a config written before the objectives field existed.
+
+        ## WRITTEN BY AI ##
+        """
+        config = BenchmarkConfig(
+            run_id="goodput",
+            run_index=0,
+            strategy=AsyncConstantStrategy(rate=10.0),
+            constraints={},
+            profile={},
+            requests={},
+            backend={},
+            environment={},
+        )
+        payload = config.model_dump()
+        del payload["slo"]
+
+        assert BenchmarkConfig.model_validate(payload).slo is None

--- a/tests/unit/benchmark/test_console_output.py
+++ b/tests/unit/benchmark/test_console_output.py
@@ -9,6 +9,15 @@ import pytest
 from guidellm.benchmark.outputs.console import GenerativeBenchmarkerConsole
 from guidellm.schemas import StatusDistributionSummary
 
+# Metrics read by GenerativeBenchmarkerConsole.print_server_throughput_table.
+THROUGHPUT_TABLE_METRICS = (
+    "request_concurrency",
+    "requests_per_second",
+    "prompt_tokens_per_second",
+    "output_tokens_per_second",
+    "tokens_per_second",
+)
+
 # Metrics read by GenerativeBenchmarkerConsole.print_request_latency_table.
 LATENCY_TABLE_METRICS = (
     "request_latency",
@@ -87,3 +96,125 @@ class TestRequestLatencyTable:
 
         for group in ("Request Latency", "TTFT", "TTFOT", "ITL", "TPOT"):
             assert group in headers
+
+
+def _make_throughput_benchmark(
+    attainment: float | None, goodput: StatusDistributionSummary | None
+) -> SimpleNamespace:
+    """Build a benchmark stub exposing every metric the throughput table reads.
+
+    ## WRITTEN BY AI ##
+    """
+    distribution = StatusDistributionSummary.from_values([1.0, 2.0, 3.0], [], [])
+    metrics = SimpleNamespace(
+        **dict.fromkeys(THROUGHPUT_TABLE_METRICS, distribution),
+        slo_attainment=attainment,
+        request_goodput=goodput,
+    )
+
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            strategy=SimpleNamespace(type_="concurrent"),
+            slo=None if attainment is None and goodput is None else object(),
+        ),
+        metrics=metrics,
+    )
+
+
+def _render_throughput_table(benchmarks) -> tuple[str, list]:
+    """Render the throughput table, returning flattened headers and value columns.
+
+    ## WRITTEN BY AI ##
+    """
+    captured: dict[str, object] = {}
+    output = GenerativeBenchmarkerConsole()
+    output.console.print = lambda *args, **kwargs: None
+    output.console.print_table = lambda headers, values, title=None: captured.update(
+        headers=headers, values=values
+    )
+    output.print_server_throughput_table(SimpleNamespace(benchmarks=benchmarks))
+
+    return (
+        " ".join(str(header) for header in captured["headers"]),  # type: ignore[union-attr]
+        captured["values"],  # type: ignore[return-value]
+    )
+
+
+class TestServerThroughputTableGoodput:
+    """
+    Verify goodput columns appear only when latency objectives were configured.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @pytest.mark.regression
+    def test_omits_goodput_columns_without_objectives(self):
+        """
+        A run with no configured objectives renders the table unchanged.
+
+        ## WRITTEN BY AI ##
+        """
+        headers, _ = _render_throughput_table(
+            [_make_throughput_benchmark(attainment=None, goodput=None)]
+        )
+
+        assert "Goodput" not in headers
+        assert "Attainment" not in headers
+
+    @pytest.mark.regression
+    def test_renders_goodput_columns_with_objectives(self):
+        """
+        A run with objectives adds attainment as a percentage and goodput rate.
+
+        ## WRITTEN BY AI ##
+        """
+        distribution = StatusDistributionSummary.from_values([1.0, 2.0, 3.0], [], [])
+        headers, values = _render_throughput_table(
+            [_make_throughput_benchmark(attainment=0.954, goodput=distribution)]
+        )
+
+        assert "Goodput" in headers
+        assert "Attainment" in headers
+        assert any("95.4" in str(column) for column in values)
+
+    @pytest.mark.regression
+    def test_shows_columns_when_objectives_cannot_be_evaluated(self):
+        """
+        Render the goodput columns with empty cells when objectives were
+        configured but no request could be evaluated against them.
+
+        Gating on the compiled metric instead would render the table exactly
+        as if no objectives had been set, hiding an objective the workload
+        cannot measure, such as time to first token without streaming.
+
+        ## WRITTEN BY AI ##
+        """
+        benchmark = _make_throughput_benchmark(attainment=None, goodput=None)
+        benchmark.config.slo = object()
+        headers, values = _render_throughput_table([benchmark])
+
+        assert "Goodput" in headers
+        assert any("--" in column for column in values)
+
+    @pytest.mark.regression
+    def test_keeps_columns_aligned_across_mixed_benchmarks(self):
+        """
+        Every column holds one value per benchmark even when only some report
+        goodput, so rows cannot shift relative to their headers.
+
+        ## WRITTEN BY AI ##
+        """
+        distribution = StatusDistributionSummary.from_values([1.0, 2.0, 3.0], [], [])
+        headers, values = _render_throughput_table(
+            [
+                _make_throughput_benchmark(attainment=0.99, goodput=distribution),
+                _make_throughput_benchmark(attainment=None, goodput=None),
+            ]
+        )
+
+        # The columns must be present when any benchmark reports goodput, not
+        # only when all of them do.
+        assert "Goodput" in headers
+        assert all(len(column) == 2 for column in values)
+        attainment_column = next(column for column in values if "99.0" in column)
+        assert attainment_column[1] == "--"

--- a/tests/unit/benchmark/test_csv_output.py
+++ b/tests/unit/benchmark/test_csv_output.py
@@ -375,3 +375,99 @@ class TestRequestLatencyCSVMetrics:
         assert "Dispatch Delay" not in groups
         assert "Scheduled Latency" not in groups
         assert "Request Latency" in groups
+
+
+class TestServerThroughputGoodputColumns:
+    """
+    Tests for goodput columns in the CSV server throughput section.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @staticmethod
+    def _render(attainment, goodput_mean):
+        """Render the throughput section for one benchmark and return headers."""
+        goodput = (
+            None
+            if goodput_mean is None
+            else StatusDistributionSummary.from_values(
+                successful=[goodput_mean], incomplete=[], errored=[]
+            )
+        )
+        distribution = StatusDistributionSummary.from_values([1.0, 2.0], [], [])
+        # Every distribution the throughput section reads, so the stub does not
+        # need updating when unrelated columns are added.
+        metric_names = (
+            "iter_tokens_per_iteration",
+            "output_token_count",
+            "output_tokens_per_iteration",
+            "output_tokens_per_second",
+            "prompt_token_count",
+            "prompt_tokens_per_second",
+            "request_concurrency",
+            "requests_per_second",
+            "tokens_per_second",
+            "total_token_count",
+        )
+        benchmark = SimpleNamespace(
+            config=SimpleNamespace(slo=object()),
+            metrics=SimpleNamespace(
+                **dict.fromkeys(metric_names, distribution),
+                slo_attainment=attainment,
+                request_goodput=goodput,
+            ),
+        )
+        csv_out = GenerativeBenchmarkerCSV.__new__(GenerativeBenchmarkerCSV)
+        headers: list[list[str]] = []
+        values: list[str | int | float] = []
+        csv_out._add_server_throughput_metrics(benchmark, headers, values)
+
+        return headers, values
+
+    @pytest.mark.regression
+    def test_columns_present_when_nothing_conforms(self):
+        """
+        The goodput columns are written even when no request met the
+        objectives.
+
+        _add_stats_for_metric drops any status whose total is 0.0, which would
+        omit the columns from the CSV while the console and JSON still report
+        0.0 for the same run.
+
+        ## WRITTEN BY AI ##
+        """
+        headers, values = self._render(attainment=0.0, goodput_mean=0.0)
+        flat = [h[1] for h in headers]
+
+        assert "Successful Goodput/Sec" in flat
+        assert "SLO Attainment" in flat
+        assert values[flat.index("Successful Goodput/Sec")] == 0.0
+        assert values[flat.index("SLO Attainment")] == 0.0
+
+    @pytest.mark.regression
+    def test_columns_match_between_conforming_and_non_conforming_runs(self):
+        """
+        A run that conforms to nothing produces the same columns as one that
+        conforms, so rows stay aligned across a multi-benchmark report.
+
+        ## WRITTEN BY AI ##
+        """
+        conforming, _ = self._render(attainment=0.9, goodput_mean=9.0)
+        failing, _ = self._render(attainment=0.0, goodput_mean=0.0)
+
+        assert conforming == failing
+
+    @pytest.mark.regression
+    def test_columns_empty_when_objectives_cannot_be_evaluated(self):
+        """
+        Objectives that no request can be evaluated against still produce the
+        columns, with empty values.
+
+        ## WRITTEN BY AI ##
+        """
+        headers, values = self._render(attainment=None, goodput_mean=None)
+        flat = [h[1] for h in headers]
+
+        assert "Successful Goodput/Sec" in flat
+        assert values[flat.index("Successful Goodput/Sec")] == ""
+        assert values[flat.index("SLO Attainment")] == ""

--- a/tests/unit/benchmark/test_entrypoints.py
+++ b/tests/unit/benchmark/test_entrypoints.py
@@ -5,13 +5,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from guidellm.benchmark import entrypoints as entrypoints_module
+from guidellm.benchmark.benchmarker import Benchmarker
 from guidellm.benchmark.entrypoints import resolve_backend, resolve_output_formats
 from guidellm.benchmark.outputs import GenerativeBenchmarkerOutput
+from guidellm.benchmark.profiles import ProfileFactory
 from guidellm.schemas.backends import (
     OpenAIHTTPBackendArgs,
     VLLMPythonAsyncBackendArgs,
 )
-from guidellm.schemas.benchmark import JSONBenchmarkOutputArgs
+from guidellm.schemas.benchmark import (
+    BenchmarkArgs,
+    BenchmarkScenario,
+    GoodputSLO,
+    JSONBenchmarkOutputArgs,
+    SynchronousProfileArgs,
+    TransientPhaseConfig,
+)
 
 
 @pytest.mark.asyncio
@@ -123,3 +133,133 @@ async def test_resolve_backend_starts_up_for_remote_backend():
     backend.validate.assert_awaited_once_with()
     backend.default_model.assert_awaited_once_with()
     backend.process_shutdown.assert_awaited_once_with()
+
+
+class _RecordingAccumulator:
+    """Accumulator stub that records the config the benchmarker builds."""
+
+    configs: list = []
+
+    def __init__(self, config):
+        type(self).configs.append(config)
+
+    def update_estimate(self, *args, **kwargs):
+        """Ignore request updates; only the config matters here."""
+
+
+class _StubBenchmark:
+    """Benchmark stub standing in for a compiled result."""
+
+    @classmethod
+    def compile(cls, accumulator, scheduler_state):
+        """Return a sentinel instead of compiling real metrics."""
+        _ = (accumulator, scheduler_state)
+        return "compiled"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_benchmarker_forwards_objectives_into_benchmark_config():
+    """
+    Carry latency objectives from Benchmarker.run onto each BenchmarkConfig.
+
+    This is the only link between the configured objectives and the accumulator
+    that compiles goodput. Severing it leaves every goodput metric None while
+    the run still reports success, so nothing else in the suite would fail.
+
+    ## WRITTEN BY AI ##
+    """
+
+    class _StubScheduler:
+        async def run(self, **kwargs):
+            _ = kwargs
+            yield (None, None, None, MagicMock())
+
+    def _info_stub():
+        stub = MagicMock()
+        stub.info = {}
+        return stub
+
+    _RecordingAccumulator.configs = []
+    slo = GoodputSLO(ttft_ms=1234)
+    profile = ProfileFactory.create(SynchronousProfileArgs(), 42, {})
+
+    with patch("guidellm.benchmark.benchmarker.Scheduler", _StubScheduler):
+        results = [
+            benchmark
+            async for benchmark in Benchmarker().run(
+                accumulator_class=_RecordingAccumulator,
+                benchmark_class=_StubBenchmark,
+                requests=_info_stub(),
+                backend=_info_stub(),
+                profile=profile,
+                environment=_info_stub(),
+                warmup=TransientPhaseConfig(),
+                cooldown=TransientPhaseConfig(),
+                slo=slo,
+            )
+        ]
+
+    assert results == ["compiled"]
+    assert _RecordingAccumulator.configs
+    assert all(config.slo == slo for config in _RecordingAccumulator.configs)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_entrypoint_passes_configured_objectives_to_benchmarker():
+    """
+    Forward the objectives from the metrics arguments into the benchmarker.
+
+    ## WRITTEN BY AI ##
+    """
+    captured: dict = {}
+
+    async def _fake_run(self, **kwargs):
+        captured.update(kwargs)
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    slo = GoodputSLO(ttft_ms=4321)
+    args = BenchmarkScenario(
+        spec=BenchmarkArgs.model_validate(
+            {
+                "backend": {
+                    "kind": "openai_http",
+                    "target": "http://localhost:8000",
+                },
+                "data": [
+                    {"kind": "synthetic_text", "prompt_tokens": 8, "output_tokens": 8}
+                ],
+                "profile": {"kind": "synchronous"},
+                "metrics": {"kind": "generative", "slo": slo.model_dump()},
+                "outputs": [],
+            }
+        )
+    )
+
+    with (
+        patch.object(entrypoints_module.Benchmarker, "run", _fake_run),
+        patch.object(
+            entrypoints_module,
+            "resolve_backend",
+            AsyncMock(return_value=(MagicMock(), "model")),
+        ),
+        patch.object(
+            entrypoints_module, "resolve_tokenizer", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            entrypoints_module,
+            "create_data_loader",
+            AsyncMock(return_value=MagicMock()),
+        ),
+        patch.object(
+            entrypoints_module, "resolve_profile", AsyncMock(return_value=MagicMock())
+        ),
+        patch.object(
+            entrypoints_module, "resolve_output_formats", AsyncMock(return_value=[])
+        ),
+    ):
+        await entrypoints_module.benchmark_generative_text(args=args)
+
+    assert captured.get("slo") == slo

--- a/tests/unit/schemas/benchmark/test_goodput.py
+++ b/tests/unit/schemas/benchmark/test_goodput.py
@@ -1,0 +1,141 @@
+"""Unit tests for goodput service level objective semantics."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from guidellm.schemas.benchmark import GoodputSLO
+
+
+class TestGoodputSLOValidation:
+    @pytest.mark.smoke
+    def test_requires_at_least_one_objective(self):
+        """
+        Reject an objective set with nothing configured.
+
+        ## WRITTEN BY AI ##
+        """
+        with pytest.raises(ValidationError, match="at least one of"):
+            GoodputSLO()
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            ({"ttft_ms": 2000}, (2000.0, None, None)),
+            ({"tpot_ms": 100}, (None, 100.0, None)),
+            ({"e2el_ms": 30000}, (None, None, 30000.0)),
+            (
+                {"ttft_ms": 2000, "tpot_ms": 100, "e2el_ms": 30000},
+                (2000.0, 100.0, 30000.0),
+            ),
+        ],
+    )
+    def test_accepts_any_single_objective(self, payload, expected):
+        """
+        Accept an objective set with any one threshold configured.
+
+        ## WRITTEN BY AI ##
+        """
+        # model_validate raises or returns an instance, so assert on the
+        # parsed thresholds rather than on the object existing.
+        parsed = GoodputSLO.model_validate(payload)
+
+        assert (parsed.ttft_ms, parsed.tpot_ms, parsed.e2el_ms) == expected
+
+    @pytest.mark.sanity
+    @pytest.mark.parametrize("field", ["ttft_ms", "tpot_ms", "e2el_ms"])
+    def test_rejects_non_positive_thresholds(self, field):
+        """
+        Reject a threshold of zero or below, which no request can satisfy.
+
+        ## WRITTEN BY AI ##
+        """
+        with pytest.raises(ValidationError, match=field):
+            GoodputSLO.model_validate({field: 0})
+
+
+class TestGoodputSLOConformance:
+    @pytest.mark.smoke
+    def test_all_objectives_met_conforms(self):
+        """
+        Report conformance when every configured objective is satisfied.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000, tpot_ms=100, e2el_ms=30000)
+        assert slo.is_conforming(ttft_ms=150.0, tpot_ms=12.0, e2el_ms=5000.0) is True
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        ("ttft", "tpot", "e2el"),
+        [
+            (2500.0, 12.0, 5000.0),
+            (150.0, 150.0, 5000.0),
+            (150.0, 12.0, 45000.0),
+        ],
+    )
+    def test_any_objective_breached_violates(self, ttft, tpot, e2el):
+        """
+        Report violation when any single configured objective is breached.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000, tpot_ms=100, e2el_ms=30000)
+        assert slo.is_conforming(ttft_ms=ttft, tpot_ms=tpot, e2el_ms=e2el) is False
+
+    @pytest.mark.sanity
+    def test_threshold_boundary_is_inclusive(self):
+        """
+        Treat a measurement exactly at the threshold as conforming.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000)
+        assert slo.is_conforming(ttft_ms=2000.0, tpot_ms=None, e2el_ms=None) is True
+        assert slo.is_conforming(ttft_ms=2000.1, tpot_ms=None, e2el_ms=None) is False
+
+    @pytest.mark.sanity
+    def test_unconfigured_objective_ignores_its_measurement(self):
+        """
+        Ignore a measurement whose objective is not configured.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(e2el_ms=30000)
+        assert (
+            slo.is_conforming(ttft_ms=999999.0, tpot_ms=999999.0, e2el_ms=5000.0)
+            is True
+        )
+
+    @pytest.mark.sanity
+    def test_missing_measurement_is_undetermined(self):
+        """
+        Report undetermined when a configured objective has no measurement.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000)
+        assert slo.is_conforming(ttft_ms=None, tpot_ms=None, e2el_ms=None) is None
+
+    @pytest.mark.regression
+    def test_missing_measurement_dominates_a_breach(self):
+        """
+        Report undetermined rather than violating when one objective is
+        unmeasurable and another is breached.
+
+        Deciding such a request on its measurable objectives alone would bias
+        the population attainment averages over: on a non-streaming workload,
+        where time to first token is never measured, only requests breaching
+        the end-to-end objective would remain determined and attainment would
+        collapse to zero regardless of how the server actually performed.
+
+        ## WRITTEN BY AI ##
+        """
+        slo = GoodputSLO(ttft_ms=2000, e2el_ms=15000)
+        assert slo.is_conforming(ttft_ms=None, tpot_ms=None, e2el_ms=20000.0) is None
+        assert slo.is_conforming(ttft_ms=None, tpot_ms=None, e2el_ms=5000.0) is None
+        # The same holds when the breach is measured before the gap, so the
+        # verdict cannot depend on the order objectives are checked in.
+        assert slo.is_conforming(ttft_ms=2500.0, tpot_ms=None, e2el_ms=None) is None


### PR DESCRIPTION
## Summary

The SLO guide in this repo documents targets such as "TTFT ≤ 200ms for 99% of requests" across eight use cases, but GuideLLM has no way to measure a run against them. This adds per-request latency objectives and two metrics derived from them.

## Details

- [x] Add `GoodputSLO` with `ttft_ms`, `tpot_ms` and `e2el_ms` thresholds, named after vLLM's `benchmark_serving` so objectives carry between the two tools. `tpot_ms` is compared against inter-token latency, not time per output token. That is the closest GuideLLM metric to vLLM's `tpot` but not identical: vLLM measures to request completion, inter-token latency to the last token received.
- [x] Compile `slo_attainment` (share of requests meeting every objective) and `request_goodput` (rate of those requests). Both are `None` when no objectives are configured.
- [x] Errored requests count as non-conforming, since a request that failed did not deliver a response within its objective. Requests cancelled when a run hits its duration limit are excluded, since the run ended them rather than the server. Requests whose objectives cannot be evaluated, such as time to first token on a non-streaming backend, are excluded from both numerator and denominator so the metric reads as inapplicable rather than as zero.
- [x] Thread objectives from `--metrics` through `Benchmarker.run` onto `BenchmarkConfig`.
- [x] Add console and CSV columns, emitted only when objectives are configured.
- [x] Document both metrics and how to declare objectives.

## Test Plan

- `tox -e lint-check`, `tox -e type-check` and `tox -e test-unit` pass.
- Attainment verified against independent recounts on live runs against the bundled mock server: 0.88 (22/25) for an `e2el_ms` objective, and 0.7107 (506/712) for combined `ttft_ms` and `tpot_ms`, matching to four decimal places.
- Mutation testing over the objective mapping, the attainment denominator and the configuration wiring; each mutation is killed by a test.
- A report written before these fields existed still validates and renders without the new columns.

## Related Issues

Groundwork for #197.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit 1de51b70f2cb5e505cd70f19e63e2b8ab38a5e79
Author: QHarshil <harshil_c@hotmail.com>
Date:   Fri Sep 4 00:51:55 2026 -0700

    Add goodput measurement against per-request latency objectives
    
    The SLO guide documents targets such as "TTFT under 200ms for 99% of
    requests" across eight use cases, but GuideLLM had no way to measure a
    run against them.
    
    Add GoodputSLO, a set of per-request latency thresholds named after
    vLLM's benchmark_serving (ttft_ms, tpot_ms, e2el_ms) so objectives carry
    between the two tools. Compile two metrics from it: SLO attainment, the
    share of requests meeting every objective, and request goodput, the rate
    of those requests. Both are None when no objectives are configured.
    
    Errored requests count as non-conforming, since a request that failed did
    not deliver a response within its objective. Requests cancelled when a run
    hits its duration limit are excluded, since the run ended them rather than
    the server. Requests whose objectives cannot be evaluated, such as time to
    first token on a non-streaming backend, are excluded from both numerator
    and denominator so the metric reads as inapplicable rather than as zero.
    
    Objectives are set through --metrics and surface in the console and CSV
    outputs only when configured.
    
    Assisted-by: Claude Code claude-opus-5
    Signed-off-by: QHarshil <harshil_c@hotmail.com>

---------

Assisted-by: Claude Code claude-opus-5
Signed-off-by: QHarshil <harshil_c@hotmail.com>
