### PR TITLE
Fix inconsistent dataset split resolving

### DIFF
--- a/src/guidellm/data/deserializers/deserializer.py
+++ b/src/guidellm/data/deserializers/deserializer.py
@@ -5,7 +5,8 @@ from typing import Protocol, runtime_checkable
 
 from transformers import PreTrainedTokenizerBase
 
-from guidellm.data.schemas import DataNotSupportedError, DatasetType
+from guidellm.data.schemas import DataNotSupportedError, DatasetDictType, DatasetType
+from guidellm.data.utils import resolve_dataset_split
 from guidellm.schemas.data import DataArgs
 from guidellm.utils.registry import RegistryMixin
 
@@ -22,7 +23,7 @@ class DatasetDeserializer(Protocol):
         config,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> DatasetType: ...
+    ) -> DatasetDictType: ...
 
 
 class DatasetDeserializerFactory(RegistryMixin["type[DatasetDeserializer]"]):
@@ -40,10 +41,10 @@ class DatasetDeserializerFactory(RegistryMixin["type[DatasetDeserializer]"]):
             )
 
         deserializer_fn = deserializer_from_type()
-        dataset: DatasetType = deserializer_fn(
+        raw_dataset: DatasetDictType = deserializer_fn(
             config=config,
             processor_factory=processor_factory,
             random_seed=random_seed,
         )
 
-        return dataset
+        return resolve_dataset_split(raw_dataset)

--- a/src/guidellm/data/deserializers/file.py
+++ b/src/guidellm/data/deserializers/file.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from datasets import Dataset, IterableDataset, load_dataset
+from datasets import Dataset, load_dataset
 from transformers import PreTrainedTokenizerBase
 
 from guidellm.data.deserializers.deserializer import (
@@ -13,7 +13,7 @@ from guidellm.data.deserializers.deserializer import (
     DatasetDeserializer,
     DatasetDeserializerFactory,
 )
-from guidellm.data.utils import resolve_dataset_split
+from guidellm.data.schemas import DatasetDictType
 from guidellm.schemas.data.deserializers import FileDataArgs
 
 __all__ = [
@@ -28,9 +28,7 @@ __all__ = [
 ]
 
 
-def _load_file_dataset(
-    loader: str, path: Path, **load_kwargs: Any
-) -> Dataset | IterableDataset:
+def _load_file_dataset(loader: str, path: Path, **load_kwargs: Any) -> DatasetDictType:
     """
     Load a local data file and return a single dataset split.
 
@@ -41,10 +39,9 @@ def _load_file_dataset(
     :param loader: The ``datasets`` loader name (e.g. ``"json"``, ``"csv"``).
     :param path: Path to the local data file.
     :param load_kwargs: Additional keyword arguments forwarded to ``load_dataset``.
-    :return: The resolved dataset split.
+    :return: The resolved dataset.
     """
-    dataset = load_dataset(loader, data_files=str(path), **load_kwargs)
-    return resolve_dataset_split(dataset)
+    return load_dataset(loader, data_files=str(path), **load_kwargs)
 
 
 @DatasetDeserializerFactory.register("text_file")
@@ -54,7 +51,7 @@ class TextFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)  # Ignore unused args format errors
 
         if (
@@ -80,7 +77,7 @@ class CSVFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset | IterableDataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
 
         if (
@@ -103,7 +100,7 @@ class JSONFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset | IterableDataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -125,7 +122,7 @@ class ParquetFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset | IterableDataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -147,7 +144,7 @@ class ArrowFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset | IterableDataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -169,7 +166,7 @@ class HDF5FileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -191,7 +188,7 @@ class DBFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> dict[str, list]:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()
@@ -213,7 +210,7 @@ class TarFileDatasetDeserializer(DatasetDeserializer):
         config: FileDataArgs,
         processor_factory: Callable[[], PreTrainedTokenizerBase],
         random_seed: int,
-    ) -> Dataset | IterableDataset:
+    ) -> DatasetDictType:
         _ = (processor_factory, random_seed)
         if (
             not (path := config.path).exists()

--- a/src/guidellm/data/schemas/__init__.py
+++ b/src/guidellm/data/schemas/__init__.py
@@ -1,5 +1,6 @@
 from .base import (
     DataNotSupportedError,
+    DatasetDictType,
     DatasetType,
     GenerativeDatasetColumnType,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "ConversationParentRef",
     "ConversationTurnData",
     "DataNotSupportedError",
+    "DatasetDictType",
     "DatasetType",
     "GenerativeDatasetColumnType",
 ]

--- a/src/guidellm/data/schemas/base.py
+++ b/src/guidellm/data/schemas/base.py
@@ -6,6 +6,7 @@ from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
 
 __all__ = [
     "DataNotSupportedError",
+    "DatasetDictType",
     "DatasetType",
     "GenerativeDatasetColumnType",
 ]
@@ -27,7 +28,10 @@ GenerativeDatasetColumnType = Literal[
     "conversation_turns_column",
 ]
 
-DatasetType: TypeAlias = Dataset | DatasetDict | IterableDataset | IterableDatasetDict
+DatasetType: TypeAlias = Dataset | IterableDataset
+
+
+DatasetDictType: TypeAlias = DatasetType | DatasetDict | IterableDatasetDict
 
 
 class DataNotSupportedError(Exception):

--- a/src/guidellm/data/utils/dataset.py
+++ b/src/guidellm/data/utils/dataset.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
 
+from guidellm.data.schemas import DatasetDictType, DatasetType
+
 __all__ = ["DEFAULT_SPLITS", "resolve_dataset_split"]
 
 
@@ -70,9 +72,12 @@ DEFAULT_SPLITS: dict[Literal["train", "calib", "val", "test"], list[str]] = {
 
 
 def resolve_dataset_split(
-    dataset: Dataset | IterableDataset | DatasetDict | IterableDatasetDict,
+    dataset: DatasetDictType,
     split: str | None = None,
-) -> Dataset | IterableDataset:
+) -> DatasetType:
+    """
+    Filter dataset to a specific split or return the first available split.
+    """
     if split is not None and isinstance(dataset, DatasetDict | IterableDatasetDict):
         if split in dataset:
             return dataset[split]

--- a/tests/unit/data/deserializers/test_file.py
+++ b/tests/unit/data/deserializers/test_file.py
@@ -51,7 +51,9 @@ def test_text_file_deserializer_success(tmp_path):
     file_path.write_text("".join(file_content))
 
     deserializer = TextFileDatasetDeserializer()
-    config = FileDataArgs(kind="text_file", path=file_path)
+    config = FileDataArgs(
+        kind="text_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=123
@@ -69,7 +71,9 @@ def test_text_file_deserializer_file_not_exists(tmp_path):
     ### WRITTEN BY AI ###
     """
     deserializer = TextFileDatasetDeserializer()
-    config = FileDataArgs(kind="text_file", path=tmp_path / "missing.txt")
+    config = FileDataArgs(
+        kind="text_file", path=tmp_path / "missing.txt", load_kwargs={"split": "train"}
+    )
 
     with pytest.raises(DataNotSupportedError):
         deserializer(
@@ -86,7 +90,9 @@ def test_text_file_deserializer_not_a_file(tmp_path):
     directory = tmp_path / "folder"
     directory.mkdir()
     deserializer = TextFileDatasetDeserializer()
-    config = FileDataArgs(kind="text_file", path=directory)
+    config = FileDataArgs(
+        kind="text_file", path=directory, load_kwargs={"split": "train"}
+    )
 
     with pytest.raises(DataNotSupportedError):
         deserializer(
@@ -103,7 +109,9 @@ def test_text_file_deserializer_invalid_file_extension(tmp_path):
     file_path = tmp_path / "data.ttl"
     file_path.write_text("hello")
     deserializer = TextFileDatasetDeserializer()
-    config = FileDataArgs(kind="text_file", path=file_path)
+    config = FileDataArgs(
+        kind="text_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     with pytest.raises(DataNotSupportedError):
         deserializer(
@@ -131,7 +139,9 @@ def test_parquet_file_deserializer_success(tmp_path):
     create_parquet_file(file_path)
 
     deserializer = ParquetFileDatasetDeserializer()
-    config = FileDataArgs(kind="parquet_file", path=file_path)
+    config = FileDataArgs(
+        kind="parquet_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=42
@@ -150,7 +160,11 @@ def test_parquet_file_deserializer_file_not_exists(tmp_path):
     ### WRITTEN BY AI ###
     """
     deserializer = ParquetFileDatasetDeserializer()
-    config = FileDataArgs(kind="parquet_file", path=tmp_path / "missing.parquet")
+    config = FileDataArgs(
+        kind="parquet_file",
+        path=tmp_path / "missing.parquet",
+        load_kwargs={"split": "train"},
+    )
 
     with pytest.raises(DataNotSupportedError):
         deserializer(
@@ -182,7 +196,11 @@ def test_csv_file_deserializer_success(tmp_path):
     create_csv_file(file_path)
 
     deserializer = CSVFileDatasetDeserializer()
-    config = FileDataArgs(kind="csv_file", path=file_path)
+    config = FileDataArgs(
+        kind="csv_file",
+        path=file_path,
+        load_kwargs={"split": "train"},
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=43
@@ -209,7 +227,11 @@ def test_json_file_deserializer_success(tmp_path):
     file_path.write_text("".join(file_content))
 
     deserializer = JSONFileDatasetDeserializer()
-    config = FileDataArgs(kind="json_file", path=file_path)
+    config = FileDataArgs(
+        kind="json_file",
+        path=file_path,
+        load_kwargs={"split": "train"},
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=123
@@ -241,7 +263,7 @@ def test_file_deserializers_return_dataset_with_info(tmp_path, kind, suffix, con
         "json_file": JSONFileDatasetDeserializer,
         "csv_file": CSVFileDatasetDeserializer,
     }[kind]
-    config = FileDataArgs(kind=kind, path=file_path)
+    config = FileDataArgs(kind=kind, path=file_path, load_kwargs={"split": "train"})
 
     dataset = deserializer_cls()(
         config=config, processor_factory=processor_factory(), random_seed=7
@@ -273,7 +295,9 @@ def test_arrow_file_deserializer_success(monkeypatch, tmp_path):
         writer.write_table(table)
 
     deserializer = ArrowFileDatasetDeserializer()
-    config = FileDataArgs(kind="arrow_file", path=file_path)
+    config = FileDataArgs(
+        kind="arrow_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=42
@@ -302,7 +326,9 @@ def test_hdf5_file_deserializer_success(tmp_path):
     df_sample.to_hdf(str(file_path), key="data", mode="w", format="fixed")
 
     deserializer = HDF5FileDatasetDeserializer()
-    config = FileDataArgs(kind="hdf5_file", path=file_path)
+    config = FileDataArgs(
+        kind="hdf5_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=1
@@ -386,7 +412,9 @@ def test_tar_file_deserializer_success(tmp_path):
     create_simple_tar(str(file_path))
 
     deserializer = TarFileDatasetDeserializer()
-    config = FileDataArgs(kind="tar_file", path=file_path)
+    config = FileDataArgs(
+        kind="tar_file", path=file_path, load_kwargs={"split": "train"}
+    )
 
     dataset = deserializer(
         config=config, processor_factory=processor_factory(), random_seed=43


### PR DESCRIPTION
## Summary

Thought we fixed this at some point but apparently not.

## Details

If a dataset has multiple splits (train, test, etc) the dataset object is of type DatasetDict or IterableDatasetDict. Each deserializer handled split datasets differently, file based handlers would automatically detect a split dataset and atempt to determine the default split. Other deserializers would pass the dataset as-is and fail later when iteration was attempted.

To solve this issue, the DatasetDeserializerFactory now uses the resolve_dataset_split function on all deserialized datasets. A user can still manually select a split using load args.

## Test Plan

Run with any dataset which is split. Pretty much any huggingface loaded dataset will do.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit c5c14d78900f689b3a844dc95c23fb34071e6c0b
Author: Samuel Monson <smonson@redhat.com>
Date:   Fri Sep 4 14:24:04 2026 -0400

    Fix inconsistent dataset split resolving
    
    If a dataset has multiple splits (train, test, etc) the dataset object
    is of type DatasetDict or IterableDatasetDict. Each deserializer handled
    split datasets differently, file based handlers would automatically
    detect a split dataset and atempt to determine the default split. Other
    deserializers would pass the dataset as-is and fail later when iteration
    was attempted.
    
    To solve this issue, the DatasetDeserializerFactory now uses the
    resolve_dataset_split function on all deserialized datasets. A user can
    still manually select a split using load args.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
