### PR TITLE
Fix more flaky tests by reducing reliance on time-only blocking

### DIFF
--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -290,13 +290,18 @@ def _linear_replay_graph(
 async def test_max_duration_cancels_long_replay_sleep():
     """max_duration stops workers sleeping on a future relative_timestamp.
 
+    Use two independent graphs so the delayed request is sleeping from t=0.
+    A linear parent-child graph only starts that sleep after the first request
+    finishes, which on a loaded runner can let both complete before cancel.
+
     ## WRITTEN BY AI ##
     """
-    graph = _linear_replay_graph([0.0, 5.0])
+    immediate = _linear_replay_graph([0.0], graph_id="immediate", request_prefix="imm")
+    delayed = _linear_replay_graph([5.0], graph_id="delayed", request_prefix="del")
     strategy = TraceReplayStrategy(time_scale=1.0)
     group = WorkerProcessGroup(
         backend=FastMockBackend(resolve_delay=RESOLVE_DELAY),
-        requests=[graph],
+        requests=[immediate, delayed],
         strategy=strategy,
         max_duration=MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=0.4)),
     )
@@ -307,11 +312,7 @@ async def test_max_duration_cancels_long_replay_sleep():
         run_started = time.time()
         async for _, _, request_info, _state in group.request_updates():
             statuses.add(request_info.status)
-            if (
-                request_info.status in ("cancelled", "completed", "errored")
-                and _state.end_processing_time is not None
-                and _state.processed_requests >= _state.created_requests
-            ):
+            if "cancelled" in statuses:
                 break
         elapsed = time.time() - run_started
     finally:

--- a/tests/unit/backends/openai/test_realtime_ws.py
+++ b/tests/unit/backends/openai/test_realtime_ws.py
@@ -19,6 +19,7 @@ from guidellm.backends.backend import Backend
 from guidellm.backends.openai.websocket import OpenAIWebSocketBackend
 from guidellm.schemas import GenerationRequest, RequestInfo, RequestTimings
 from guidellm.schemas.backends import OpenAIWebSocketBackendArgs
+from tests.unit.testing_utils import wait_until
 
 
 @pytest.fixture(autouse=True)
@@ -440,7 +441,7 @@ async def test_resolve_cancelled_after_delta_yields_partial_then_reraises() -> N
 
         task = asyncio.create_task(collect())
         await asyncio.wait_for(delta_seen.wait(), timeout=5.0)
-        await asyncio.sleep(0.05)
+        await wait_until(lambda: len(results) >= 1, timeout=5.0)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -27,7 +27,7 @@ from guidellm.scheduler.schemas import (
 )
 from guidellm.schemas import RequestInfo, RequestSettings, RequestTimings
 from guidellm.utils.messaging import InterProcessMessagingQueue
-from tests.unit.testing_utils import async_timeout
+from tests.unit.testing_utils import async_timeout, wait_until
 
 STANDARD_NUM_REQUESTS: int = 200
 
@@ -672,11 +672,13 @@ class TestWorkerProcess:
         """
         instance, _main_messaging, _constructor_args = valid_instances
         events: list[str] = []
+        loop_started = asyncio.Event()
 
         async def fake_processing_startup():
             events.append("startup")
 
         async def fake_process_requests_loop():
+            loop_started.set()
             try:
                 await asyncio.sleep(1000)
             except asyncio.CancelledError:
@@ -699,11 +701,11 @@ class TestWorkerProcess:
         instance._processing_shutdown = fake_processing_shutdown
 
         process_requests_task = asyncio.create_task(instance._process_requests())
-        # Give the inner processing loop task a chance to actually start and
-        # suspend on its (mocked) long-running work before triggering the
-        # constraint, so cancellation exercises its except-CancelledError
-        # handling rather than short-circuiting a task that never ran.
-        await asyncio.sleep(0.01)
+        # Wait until the inner loop is actually suspended on its mock work
+        # before triggering the constraint, so cancellation exercises its
+        # except-CancelledError handling rather than cancelling a task that
+        # never ran.
+        await asyncio.wait_for(loop_started.wait(), timeout=2.0)
         instance.constraint_reached_event.set()
         await process_requests_task
 
@@ -885,7 +887,7 @@ class TestWorkerProcessMultiturn:
         assert nxt[1] > time.time()
 
         cancel_task = asyncio.create_task(worker_instance._cancel_requests_loop())
-        await asyncio.sleep(0.05)
+        await wait_until(lambda: not worker_instance.turns_queue)
         cancel_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await cancel_task
@@ -954,7 +956,7 @@ class TestWorkerProcessMultiturn:
             worker._process_next_graph_node(target_start=time.time())
         )
         await backend.entered_resolve.wait()
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0)
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
@@ -1119,7 +1121,12 @@ class TestWorkerProcessMultiturn:
         # Cancel path for graphs still queued on the worker
         worker.turns_queue.append(state)
         cancel_task = asyncio.create_task(worker._cancel_requests_loop())
-        await asyncio.sleep(0.05)
+        await wait_until(
+            lambda: any(
+                info.status == "cancelled"
+                for _, _, info in worker.messaging._sent_items
+            )
+        )
         cancel_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await cancel_task

--- a/tests/unit/testing_utils.py
+++ b/tests/unit/testing_utils.py
@@ -13,6 +13,29 @@ import pytest
 F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
 
 
+async def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 2.0,
+    poll_interval: float = 0.0,
+) -> None:
+    """Poll ``predicate`` until it is true.
+
+    Used instead of a fixed sleep so tests do not race the event loop under CI load.
+
+    :param predicate: Called until it returns True
+    :param timeout: Seconds to wait before failing
+    :param poll_interval: Delay between polls; 0 yields to the event loop only
+    :raises AssertionError: If ``timeout`` elapses before ``predicate`` is true
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError(f"timed out after {timeout}s waiting for condition")
+        await asyncio.sleep(poll_interval)
+
+
 def async_timeout(delay: float = 10.0, hard_fail: bool = False) -> Callable[[F], F]:
     """
     Decorator to add timeout to async test functions.


### PR DESCRIPTION
## Summary

I instructed the AI to locate and fix more flaky tests. It mainly did so by adding checks before proceeding rather than relying solely on sleep statements.

## Test Plan

- Review the code
- Confirm it passes CI

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 1e7ae9f6137518dedace96474471ba92d62e6186
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Fri Sep 4 16:21:18 2026 -0400

    Fix more flaky tests by reducing reliance on time-only blocking
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
