### PR TITLE
fix: load SQLite dataset files through a database connection

### DIFF
--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -27,6 +27,8 @@ In addition, you can specify additional arguments to the dataset loading with th
 
 - load_kwargs: Additional arguments to the dataset loading. For example, dataset splits can be specified with `--data '{"kind":"huggingface","source":"my/dataset","load_kwargs":{"split":"test"}}'`.
 
+For SQLite `.db` files, provide the query through `load_kwargs.sql`, for example `--data '{"kind":"db_file","path":"prompts.db","load_kwargs":{"sql":"SELECT text FROM samples"}}'`.
+
 ### Data Loader
 
 You can specify the data loader with `--data-loader` and a configuration string. The only current type is `pytorch`:

--- a/src/guidellm/data/deserializers/file.py
+++ b/src/guidellm/data/deserializers/file.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Callable
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
@@ -200,7 +202,8 @@ class DBFileDatasetDeserializer(DatasetDeserializer):
                 f"expected str or Path to a local .db file, got {path}"
             )
 
-        return Dataset.from_sql(con=str(path), **config.load_kwargs)
+        with closing(sqlite3.connect(path)) as connection:
+            return Dataset.from_sql(con=connection, **config.load_kwargs)
 
 
 @DatasetDeserializerFactory.register("tar_file")

--- a/tests/unit/data/deserializers/test_file.py
+++ b/tests/unit/data/deserializers/test_file.py
@@ -345,10 +345,10 @@ def test_hdf5_file_deserializer_success(tmp_path):
 
 
 @pytest.mark.sanity
-def test_db_file_deserializer_success(monkeypatch, tmp_path):
+def test_db_file_deserializer_success(tmp_path):
     """DBFileDatasetDeserializer reads .db file into Dataset.
 
-    ### WRITTEN BY AI ###
+    ## WRITTEN BY AI ##
     """
 
     def create_sqlite_db(path: Path):
@@ -362,15 +362,6 @@ def test_db_file_deserializer_success(monkeypatch, tmp_path):
 
     db_path = tmp_path / "sample.db"
     create_sqlite_db(db_path)
-
-    mocked_ds = Dataset.from_dict({"text": ["hello", "world"]})
-
-    def mock_from_sql(sql, con, **kwargs):
-        assert sql == "SELECT * FROM samples"
-        assert con == (str(db_path))
-        return mocked_ds
-
-    monkeypatch.setattr("datasets.Dataset.from_sql", mock_from_sql)
 
     deserializer = DBFileDatasetDeserializer()
     config = FileDataArgs(


### PR DESCRIPTION
## Summary

Loading a local SQLite dataset with `kind=db_file` fails because its filesystem path is passed to `Dataset.from_sql` as a database URI. The existing success test mocks the database read and hides the failure.

## Details

Open the file using a SQLite connection and close it after loading. Replace the mocked read with a real SQLite query, and document how to supply that query through `load_kwargs.sql`.

## Test Plan

- The real SQLite regression fails before the fix and passes afterward.
- 407 data-module tests passed; 1 optional HDF5 test skipped.
- Independently loaded a database whose filename contains spaces and `#`, and verified SQL filtering returns the expected row.
- `tox -e lint-check,type-check` passed.
- Full unit suite: 3,015 passed, 31 skipped, 163 xfailed, 14 failed. The 14 failures are audio tests unable to load FFmpeg shared libraries through torchcodec. The same 14 test nodes fail with the unmodified upstream source in the same environment.

## Related Issues

None.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> `Generated-by: Codex` and DCO trailers are retained in the commit and the generated squash data below.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 6c3c6d5a1c1335b95dfbd346fce31e03adc87453
Author: xinjun.jiang <xinjun.jiang@daocloud.io>
Date:   Sat Sep 5 20:30:02 2026 +0800

    fix: load SQLite dataset files through a database connection
    
    Generated-by: Codex
    Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>

---------

Generated-by: Codex
Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>
