### PR TITLE
fix: allow data loader workers with no assigned rows

### DIFF
--- a/src/guidellm/data/loaders/torch.py
+++ b/src/guidellm/data/loaders/torch.py
@@ -75,6 +75,7 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
         epoch: int = 0,
     ) -> Iterator[DataT]:
         gen_count = 0
+        processed_count = 0
         yield_count = 0
         error_count = 0
 
@@ -102,6 +103,7 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
                         continue
 
                     # Apply preprocessors in sequence
+                    processed_count += 1
                     for preprocessor in self.preprocessors:
                         row = preprocessor(row)
 
@@ -123,10 +125,10 @@ class DatasetsIterator(TorchIterableDataset[DataT]):
                     )
                     gen_count -= 1
 
-        if gen_count > 0 and yield_count == 0:
+        if processed_count > 0 and yield_count == 0:
             raise ValueError(
-                f"Dataset iterator processed {gen_count} rows but yielded "
-                f"zero results ({error_count} errors; {gen_count - error_count} "
+                f"Dataset iterator processed {processed_count} rows but yielded "
+                f"zero results ({error_count} errors; {processed_count - error_count} "
                 f"empty). Check your data and data arguments."
             )
 

--- a/tests/unit/data/loaders/test_torch.py
+++ b/tests/unit/data/loaders/test_torch.py
@@ -7,10 +7,46 @@ Unit tests for guidellm.data.loaders.torch module.
 from __future__ import annotations
 
 import pytest
+from datasets import Dataset
 
 from guidellm.data.loaders.loader import DataLoaderRegistry
 from guidellm.data.loaders.torch import TorchDataLoader
 from guidellm.schemas.data import TorchDataLoaderArgs
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("num_workers", [0, 1, 2])
+@pytest.mark.parametrize("samples", [-1, 0, 1])
+def test_loader_allows_workers_without_assigned_rows(num_workers, samples):
+    """A small dataset must load even when some workers receive no rows.
+
+    ## WRITTEN BY AI ##
+    """
+    loader = TorchDataLoader(
+        config=TorchDataLoaderArgs(samples=samples, num_workers=num_workers),
+        datasets=[Dataset.from_dict({"text": ["hello"]})],
+        preprocessors=[],
+        finalizer=list,
+    )
+
+    assert list(loader) == [[{"dataset": {"text": "hello"}}]]
+
+
+@pytest.mark.regression
+def test_loader_rejects_rows_with_only_empty_results():
+    """Rows assigned to a worker must still produce usable results.
+
+    ## WRITTEN BY AI ##
+    """
+    loader = TorchDataLoader(
+        config=TorchDataLoaderArgs(samples=0, num_workers=0),
+        datasets=[Dataset.from_dict({"text": ["hello"]})],
+        preprocessors=[],
+        finalizer=lambda _: [],
+    )
+
+    with pytest.raises(ValueError, match="processed 1 rows but yielded zero results"):
+        list(loader)
 
 
 class TestTorchDataLoaderArgs:


### PR DESCRIPTION
## Summary

Loading a one-row dataset with two workers fails when samples are not precached. The worker assigned no rows incorrectly reports that the dataset produced no usable results because the check counts rows assigned to other workers.

## Details

Count rows actually processed by the current worker when checking for empty results. Empty shards can finish normally, while workers whose rows produce no usable results still report an error.

Add real HuggingFace Dataset and PyTorch multiprocessing coverage for cached and uncached loading with zero, one, and two workers, plus a regression retaining empty-result validation.

## Test Plan

- Two uncached multiworker cases fail on upstream and pass with the fix.
- All 10 new regression cases pass; the complete loader test file passes (17 tests).
- Full lint and type checks passed.
- Full unit suite: 3,025 passed, 31 skipped, 163 xfailed, 14 failed. The same 14 audio failures reproduce on unmodified upstream because FFmpeg shared libraries required by torchcodec are unavailable in this environment.

## Related Issues

None.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> `Generated-by: Codex` and DCO trailers are retained in the commit and the generated squash data below.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 61fb74fcb372a701755ba6791bc309df3c7e6e2d
Author: xinjun.jiang <xinjun.jiang@daocloud.io>
Date:   Sat Sep 5 21:06:31 2026 +0800

    fix: allow data loader workers with no assigned rows
    
    Generated-by: Codex
    Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>

---------

Generated-by: Codex
Signed-off-by: xinjun.jiang <xinjun.jiang@daocloud.io>
