### PR TITLE
fix: serialize audio translation filename

### DIFF
--- a/src/guidellm/mock_server/server.py
+++ b/src/guidellm/mock_server/server.py
@@ -274,7 +274,7 @@ class MockServer:
                 {
                     "text": decoded_text,
                     "file_size": len(file.body),
-                    "filename": {file.name},
+                    "filename": file.name,
                     "model_used": request.form.get("model", "mock-model"),
                     "mimetype": file.type,
                 }

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -195,6 +195,30 @@ class TestMockServerEndpoints:
             assert model["owned_by"] == "guidellm-mock"
             assert model["id"] == "test-model"
 
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_audio_translations_returns_filename_string(
+        self, mock_server_instance
+    ):
+        """Test audio translations serialize the uploaded filename as a string.
+
+        ## WRITTEN BY AI ##
+        """
+        server_url, config = mock_server_instance
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{server_url}/v1/audio/translations",
+                files={"file": ("audio.wav", b"mock audio", "audio/wav")},
+                data={"model": config.model},
+                timeout=5.0,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["filename"] == "audio.wav"
+        assert isinstance(data["filename"], str)
+
     @pytest.mark.smoke
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
Assisted-by: Codex

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->
The mock audio translation interface returns a 500 error at location: [[server.py (line 277)](https://github.com/vllm-project/guidellm/blob/fc2dbe9edd4f7f1a4e9ccd752f6f43591adbcb73/src/guidellm/mock_server/server.py#L277). `"filename": {file.name}` incorrectly constructs the filename as a set, which triggers a TypeError during JSON serialization. Valid upload requests will also fail.
## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit f9c107d444d0b60f198d746dced533a306e8e5de
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Mon Sep 7 16:32:48 2026 +0800

    fix: serialize audio translation filename
    
    Assisted-by: Codex
    
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

---------

Signed-off-by: tangming1996 <ming.tang@daocloud.io>
