### PR TITLE
Fix shared mutable fill values in argument parsing

### DIFF
--- a/src/guidellm/utils/arg_string.py
+++ b/src/guidellm/utils/arg_string.py
@@ -67,12 +67,16 @@ class ArgStringParser:
 
         :param skip_invalid: If True, skips invalid key=value pairs rather than raising
         :param fill_value: Callable that returns fill value for sparse lists.
-            Defaults to lambda: None.
+            Called separately for each fill position. Defaults to lambda: None.
         :param allow_overwrite: If True, allows overwriting existing values.
             Defaults to False, which raises an error on overwrites.
         """
         self.skip_invalid = skip_invalid
-        self.fill_value = fill_value() if fill_value is not None else None
+        self._fill_value_factory = (
+            fill_value if fill_value is not None else lambda: None
+        )
+        # Keep a separate reference value for the existing overwrite checks.
+        self.fill_value = self._fill_value_factory()
         self.allow_overwrite = allow_overwrite
         self.key_delimiter = key_delimiter
         self.split_delimiter = split_delimiter
@@ -250,7 +254,7 @@ class ArgStringParser:
         :param index: The minimum index that must be accessible
         """
         while len(lst) <= index:
-            lst.append(self.fill_value)
+            lst.append(self._fill_value_factory())
 
     def _list_set_value(
         self,

--- a/tests/unit/utils/test_arg_string.py
+++ b/tests/unit/utils/test_arg_string.py
@@ -43,6 +43,49 @@ class TestArgStringParser:
         result = parser.decode("items[5]=value")
         assert result == {"items": [0, 0, 0, 0, 0, "value"]}
 
+    @pytest.mark.regression
+    @pytest.mark.parametrize("fill_factory", [list, dict])
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_mutable_fill_values_are_independent(self, fill_factory, nested):
+        """
+        Mutating a fill value must not affect other positions or later decodes.
+
+        ## WRITTEN BY AI ##
+        """
+        parser = arg_string.ArgStringParser(fill_value=fill_factory)
+        expression = "items[2].name=value" if nested else "items[2]=value"
+        result = parser.decode(expression)
+        other = parser.decode("other[1]=value")
+
+        if fill_factory is list:
+            result["items"][0].append("changed")
+        else:
+            result["items"][0]["changed"] = True
+
+        assert result["items"][1] == fill_factory()
+        assert other["other"][0] == fill_factory()
+        assert parser.decode(expression)["items"][0] == fill_factory()
+
+    @pytest.mark.regression
+    def test_set_mutable_fill_values_are_independent(self):
+        """
+        Sparse list fills created by successive set calls must be independent.
+
+        ## WRITTEN BY AI ##
+        """
+        parser = arg_string.ArgStringParser(fill_value=list)
+        result = {}
+        parser.set(result, "items[2]", "value")
+        result["items"][0].append("changed")
+        parser.set(result, "items[4]", "later")
+
+        assert result == {"items": [["changed"], [], "value", [], "later"]}
+        parser.set(result, "items[1].name", "nested")
+        parser.set(result, "items[3]", "filled")
+        assert result == {
+            "items": [["changed"], {"name": "nested"}, "value", "filled", "later"]
+        }
+
 
 class TestArgStringLoads:
     """Test cases for arg_string.loads function."""


### PR DESCRIPTION
ArgStringParser evaluated the fill-value factory once during construction and reused that object for every sparse list position. With fill_value=list or dict, mutating one placeholder changed other positions and results from subsequent decodes using the same parser.

Retain the factory and invoke it separately for every added list position. Keep a separate reference value for the existing overwrite checks. Add regression coverage for mutable list and dictionary fills, nested paths, repeated decode calls, and successive set calls.

Assisted-by: Codex

## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [ ]

## Test Plan

<!--
List the steps needed to test this PR.
-->
-

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 2153ab1a17a2a77058db58775000d1759ef59ba1
Author: tangming1996 <ming.tang@daocloud.io>
Date:   Mon Sep 7 17:17:02 2026 +0800

    Fix shared mutable fill values in argument parsing
    
    ArgStringParser evaluated the fill-value factory once during construction
    and reused that object for every sparse list position. With fill_value=list
    or dict, mutating one placeholder changed other positions and results from
    subsequent decodes using the same parser.
    
    Retain the factory and invoke it separately for every added list position.
    Keep a separate reference value for the existing overwrite checks. Add
    regression coverage for mutable list and dictionary fills, nested paths,
    repeated decode calls, and successive set calls.
    
    Assisted-by: Codex
    Signed-off-by: tangming1996 <ming.tang@daocloud.io>

---------

Assisted-by: Codex
Signed-off-by: tangming1996 <ming.tang@daocloud.io>
