### PR TITLE
fix(benchmark): clear rejected reservoir request data

### DIFF
--- a/src/guidellm/benchmark/schemas/accumulator.py
+++ b/src/guidellm/benchmark/schemas/accumulator.py
@@ -705,6 +705,8 @@ class GenerativeRequestsAccumulator(StandardBaseModel):
             replace_index = random.randrange(len(self.samples))
             self.clear_stats_data(self.samples[replace_index])
             self.samples[replace_index] = current_index
+        else:
+            self.clear_stats_data(stats)
 
         return stats
 

--- a/tests/unit/benchmark/schemas/test_accumulator.py
+++ b/tests/unit/benchmark/schemas/test_accumulator.py
@@ -5,7 +5,13 @@ import pytest
 from guidellm.benchmark.schemas.accumulator import (
     GenerativeRequestsAccumulator,
 )
-from guidellm.schemas import GenerativeRequestStats, RequestInfo, UsageMetrics
+from guidellm.schemas import (
+    GenerationRequest,
+    GenerationResponse,
+    GenerativeRequestStats,
+    RequestInfo,
+    UsageMetrics,
+)
 
 
 def _make_stats(
@@ -85,6 +91,62 @@ class TestClearStatsData:
         assert stats.request_args is None
         assert stats.output == "answer"
         assert stats.reasoning_output == "thinking..."
+
+
+class TestReservoirSampling:
+    """Tests for bounded request-data retention during reservoir sampling."""
+
+    @pytest.mark.regression
+    def test_clears_request_data_when_new_request_is_not_sampled(self, monkeypatch):
+        """A rejected reservoir candidate must not retain heavyweight data.
+
+        ## WRITTEN BY AI ##
+        """
+        accumulator = GenerativeRequestsAccumulator(sample_size=1)
+
+        first_request = GenerationRequest(request_id="req-1")
+        first_response = GenerationResponse(
+            request_id="req-1",
+            request_args="args-1",
+            text="output-1",
+            reasoning_text="reasoning-1",
+        )
+        first_info = RequestInfo(request_id="req-1", status="completed")
+        first_info.timings.request_start = 0.0
+        first_info.timings.request_end = 1.0
+        first_info.timings.resolve_end = 1.0
+        accumulator.update_estimate(
+            first_response,
+            first_request,
+            first_info,
+            prefer_response_metrics=True,
+        )
+
+        monkeypatch.setattr("random.random", lambda: 1.0)
+        second_request = GenerationRequest(request_id="req-2")
+        second_response = GenerationResponse(
+            request_id="req-2",
+            request_args="args-2",
+            text="output-2",
+            reasoning_text="reasoning-2",
+        )
+        second_info = RequestInfo(request_id="req-2", status="completed")
+        second_info.timings.request_start = 1.0
+        second_info.timings.request_end = 2.0
+        second_info.timings.resolve_end = 2.0
+        accumulator.update_estimate(
+            second_response,
+            second_request,
+            second_info,
+            prefer_response_metrics=True,
+        )
+
+        assert accumulator.samples == [0]
+        assert accumulator.requests_stats[0].request_args == "args-1"
+        assert accumulator.requests_stats[0].output == "output-1"
+        assert accumulator.requests_stats[1].request_args is None
+        assert accumulator.requests_stats[1].output is None
+        assert accumulator.requests_stats[1].reasoning_output is None
 
     @pytest.mark.smoke
     def test_clears_both(self):


### PR DESCRIPTION
## Summary

`GenerativeRequestsAccumulator` uses reservoir sampling to retain at most `sample_size` request samples. When a new request is rejected by the reservoir, the accumulator previously left its `request_args`, output, reasoning, and tool-call fields populated in `requests_stats`. Repeated rejected requests could therefore retain unbounded heavy payload data despite the configured sample bound.

The rejection branch now clears those fields while leaving the selected sample and aggregate metrics unchanged.

## Testing

- Base regression: the new rejection test fails because rejected request data remains populated.
- Accumulator unit file: 6 passed.
- Ruff: passed.
- Mypy on the changed source: no issues.
- `git diff --check`: passed.

The full tox environment could not be completed under shared optional dependency download contention; the focused test uses the real accumulator and schema classes without mocking the implementation.

No matching open or closed-unmerged PR was found. The nearby multipart payload report #988 concerns report serialization, not reservoir retention.

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

The code and tests were generated with OpenAI Codex and require human review before submission. The commit includes `Generated-by: OpenAI Codex GPT-5` and `Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>` trailers.

<!-- begin:squash-data -->

---

# git log

commit 1d15f09397d1a5ed8e0363444fb750eea6a72049
Author: Divyam Talwar <divyamtalwar0@gmail.com>
Date:   Tue Sep 8 13:49:32 2026 +0530

    fix(benchmark): clear rejected reservoir request data
    
    Generated-by: OpenAI Codex GPT-5
    Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>

---------

Generated-by: OpenAI Codex GPT-5
Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>
