### PR TITLE
fix(metrics): exclude missing values from timed distributions

### DIFF
--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -295,10 +295,12 @@ class GenerativeMetricsSummary(StandardBaseDict):
                 status: [
                     (  # type: ignore[misc]
                         metric[_TIMED_METRIC_END_TIME_INDEX],
-                        float(metric[value_index] or 0.0),
+                        float(val),
                     )
                     for metric in metrics
                     if metric is not None
+                    for val in [metric[value_index]]
+                    if val is not None
                 ]
                 for status, metrics in metrics_by_status.items()
             }
@@ -313,10 +315,12 @@ class GenerativeMetricsSummary(StandardBaseDict):
                     (  # type: ignore[misc]
                         metric[_TIMED_METRIC_START_TIME_INDEX],
                         metric[_TIMED_METRIC_END_TIME_INDEX],
-                        float(metric[value_index] or 0.0),
+                        float(val),
                     )
                     for metric in metrics
                     if metric is not None
+                    for val in [metric[value_index]]
+                    if val is not None
                 ]
                 for status, metrics in metrics_by_status.items()
             }

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -173,6 +173,36 @@ class TestToolCallMetricsAllErrored:
         assert summary.mixed_tokens.output is None
 
 
+@pytest.mark.regression
+def test_timed_metrics_exclude_missing_values_from_rates_and_concurrency():
+    """
+    Missing optional values do not become zero-valued rate or concurrency events.
+
+    Mixed workloads can contain requests where a modality-specific metric does not
+    apply. Those requests must be excluded consistently from every distribution for
+    that metric, while real zero values remain valid observations.
+
+    ## WRITTEN BY AI ##
+    """
+    summary = GenerativeMetricsSummary.compile_timed_metrics(
+        successful=[
+            (1.0, 2.0, None, 8),
+            (2.0, 3.0, None, None),
+            (5.0, 6.0, None, 8),
+        ],
+        incomplete=[],
+        errored=[],
+    )
+
+    assert summary is not None
+    assert summary.output is not None
+    assert summary.output_per_second is not None
+    assert summary.output_concurrency is not None
+    assert summary.output.successful.count == 2
+    assert summary.output_per_second.successful.median == pytest.approx(4.0)
+    assert summary.output_concurrency.successful.count == 2
+
+
 @pytest.mark.sanity
 def test_round_trip_metrics_compile():
     """


### PR DESCRIPTION
## Summary

Keep optional metric values that do not apply out of rate and concurrency distributions. Mixed-modality benchmarks previously excluded `None` from the value distribution but recorded the same request as a zero-valued rate and concurrency event, which distorted reported medians and sample counts.

The change filters missing values consistently before building value, per-second, and concurrency inputs while preserving real zero observations.

## Test Plan

- Base regression: the new mixed `None`/zero test fails because the rate median is `0.0` instead of `4.0`.
- Metrics unit file: 12 passed.
- Ruff lint/import checks, Markdown formatting, mypy across 222 files, and `git diff --check` pass.

The full unit suite also passes: `uv run tox -e test-unit` reported 3,030 passed, 31 skipped, 163 expected failures, and one existing Pydantic warning. The focused tests use the real metric summary implementation.

No linked issue or competing open/closed-unmerged PR was found; warmup accounting issue #1078 is a separate scope.

## AI Disclosure

This patch and its regression test were generated with Codex GPT-5 and have not yet been reviewed by a human. The commit includes `Generated-by: Codex GPT-5` and `Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>`.

<!-- begin:squash-data -->

---

# git log

commit 58eb61a82ad6c359499edd7317a9dec8b783755e
Author: Divyam Talwar <divyamtalwar0@gmail.com>
Date:   Tue Sep 8 14:10:53 2026 +0530

    Fix missing timed metric accounting
    
    Exclude optional values that do not apply from rate and concurrency distributions while preserving real zero observations.
    
    Generated-by: Codex GPT-5
    Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>

---------

Generated-by: Codex GPT-5
Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>
