### PR TITLE
fix(metrics): preserve all cancellations in final scheduler counts

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -17,6 +17,11 @@ These metrics provide a breakdown of the overall request statuses, helping users
 - **Definition**: The total number of requests made during a benchmark run, broken down by status (successful, incomplete, error).
 - **Use Case**: Helps gauge the workload handled by the system and identify the proportion of requests that were successful versus those that failed or were incomplete.
 
+Exported results distinguish two sets of counts:
+
+- `scheduler_metrics.requests_made` counts all scheduler outcomes across the run, including requests cancelled before dispatch. Its `incomplete` field stores the cancellation count because it reuses the shared status breakdown schema.
+- `metrics.request_totals` counts requests retained in the measurement window after filtering. Requests cancelled before resolving begins are excluded; cancellations after resolving begins count as incomplete.
+
 ## Token Metrics
 
 ### Prompt Tokens and Counts

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -139,7 +139,16 @@ class SchedulerMetrics(StandardBaseDict):
             request_end_time=accumulator.timings.finalized_request_end,
             end_time=scheduler_state.end_time or -1.0,
             # Request details tracked by the scheduler
-            requests_made=accumulator.scheduler_metrics.requests_made,
+            requests_made=StatusBreakdown(
+                successful=len(accumulator.completed.requests_stats),
+                incomplete=len(accumulator.incomplete.requests_stats),
+                errored=len(accumulator.errored.requests_stats),
+                total=(
+                    len(accumulator.completed.requests_stats)
+                    + len(accumulator.incomplete.requests_stats)
+                    + len(accumulator.errored.requests_stats)
+                ),
+            ),
             # Scheduler internal performance timings
             queued_time_avg=accumulator.scheduler_metrics.queued_time.mean or -1.0,
             resolve_start_delay_avg=(

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -84,7 +84,10 @@ class SchedulerMetrics(StandardBaseDict):
 
     # Request details tracked by the scheduler
     requests_made: StatusBreakdown[int, int, int, int] = Field(
-        description="Request counts by status: successful, incomplete, errored, total"
+        description=(
+            "Scheduler request counts: successful, cancelled (stored as incomplete), "
+            "errored, total. Includes requests cancelled before dispatch."
+        )
     )
 
     # Scheduler internal performance timings
@@ -138,15 +141,16 @@ class SchedulerMetrics(StandardBaseDict):
             measure_end_time=accumulator.timings.finalized_measure_end,
             request_end_time=accumulator.timings.finalized_request_end,
             end_time=scheduler_state.end_time or -1.0,
-            # Request details tracked by the scheduler
+            # A queued cancellation skips request accumulation, so cached scheduler
+            # counts may lag the final state when the last request never started.
             requests_made=StatusBreakdown(
-                successful=len(accumulator.completed.requests_stats),
-                incomplete=len(accumulator.incomplete.requests_stats),
-                errored=len(accumulator.errored.requests_stats),
+                successful=scheduler_state.successful_requests,
+                incomplete=scheduler_state.cancelled_requests,
+                errored=scheduler_state.errored_requests,
                 total=(
-                    len(accumulator.completed.requests_stats)
-                    + len(accumulator.incomplete.requests_stats)
-                    + len(accumulator.errored.requests_stats)
+                    scheduler_state.successful_requests
+                    + scheduler_state.cancelled_requests
+                    + scheduler_state.errored_requests
                 ),
             ),
             # Scheduler internal performance timings

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -13,13 +13,17 @@ from guidellm.benchmark.schemas.metrics import (
     GenerativeMetrics,
     GenerativeMetricsSummary,
     GenerativeToolCallMetricsSummary,
+    SchedulerMetrics,
 )
 from guidellm.scheduler import (
     AsyncConstantStrategy,
+    SchedulerState,
     SchedulingStrategy,
     ThroughputStrategy,
 )
 from guidellm.schemas import (
+    GenerationRequest,
+    GenerationResponse,
     GenerativeRequestStats,
     RequestInfo,
     RequestTimings,
@@ -277,6 +281,76 @@ def _make_accumulator(
     accumulator.completed.requests_stats = list(successful)
 
     return accumulator
+
+
+@pytest.mark.regression
+def test_scheduler_metrics_exclude_requests_cancelled_before_dispatch():
+    """
+    Compiled scheduler counts exclude requests cancelled while still queued.
+
+    ## WRITTEN BY AI ##
+    """
+    accumulator = _make_accumulator([], SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 1.0)
+    cancelled_state = SchedulerState(
+        start_time=SCHEDULE_BASE_TIME,
+        end_time=SCHEDULE_BASE_TIME + 1.0,
+        start_requests_time=SCHEDULE_BASE_TIME,
+        end_processing_time=SCHEDULE_BASE_TIME + 1.0,
+        created_requests=1,
+        queued_requests=1,
+        processed_requests=1,
+        cancelled_requests=1,
+    )
+    info = RequestInfo(
+        request_id="cancelled-queued",
+        status="cancelled",
+        timings=RequestTimings(
+            queued=SCHEDULE_BASE_TIME,
+            dequeued=SCHEDULE_BASE_TIME + 0.5,
+            resolve_end=SCHEDULE_BASE_TIME + 1.0,
+            finalized=SCHEDULE_BASE_TIME + 1.0,
+        ),
+    )
+
+    accumulator.update_estimate(
+        response=None,
+        request=GenerationRequest(request_id=info.request_id),
+        info=info,
+        scheduler_state=cancelled_state,
+    )
+    completed_request = GenerationRequest(request_id="completed")
+    completed_info = RequestInfo(
+        request_id=completed_request.request_id,
+        status="completed",
+        timings=RequestTimings(
+            queued=SCHEDULE_BASE_TIME,
+            dequeued=SCHEDULE_BASE_TIME + 0.1,
+            resolve_start=SCHEDULE_BASE_TIME + 0.2,
+            request_start=SCHEDULE_BASE_TIME + 0.2,
+            request_end=SCHEDULE_BASE_TIME + 0.8,
+            resolve_end=SCHEDULE_BASE_TIME + 0.9,
+            finalized=SCHEDULE_BASE_TIME + 1.0,
+        ),
+    )
+    final_state = cancelled_state.model_copy(
+        update={"successful_requests": 1, "cancelled_requests": 1}
+    )
+    accumulator.update_estimate(
+        response=GenerationResponse(
+            request_id=completed_request.request_id,
+            request_args=None,
+        ),
+        request=completed_request,
+        info=completed_info,
+        scheduler_state=final_state,
+    )
+
+    metrics = SchedulerMetrics.compile(accumulator, final_state)
+
+    assert metrics.requests_made.successful == 1
+    assert metrics.requests_made.errored == 0
+    assert metrics.requests_made.incomplete == 0
+    assert metrics.requests_made.total == 1
 
 
 class TestScheduleRelativeMetrics:

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -5,6 +5,9 @@ tables appear when all expected tool call requests errored.
 
 from __future__ import annotations
 
+from itertools import permutations
+from typing import Literal
+
 import pytest
 
 from guidellm.benchmark.schemas.accumulator import GenerativeBenchmarkAccumulator
@@ -23,10 +26,10 @@ from guidellm.scheduler import (
 )
 from guidellm.schemas import (
     GenerationRequest,
-    GenerationResponse,
     GenerativeRequestStats,
     RequestInfo,
     RequestTimings,
+    StatusBreakdown,
     StatusDistributionSummary,
     UsageMetrics,
 )
@@ -284,73 +287,90 @@ def _make_accumulator(
 
 
 @pytest.mark.regression
-def test_scheduler_metrics_exclude_requests_cancelled_before_dispatch():
-    """
-    Compiled scheduler counts exclude requests cancelled while still queued.
+@pytest.mark.parametrize("order", list(permutations(("terminal", "started", "queued"))))
+@pytest.mark.parametrize("terminal_status", ["completed", "errored"])
+def test_scheduler_counts_all_cancellations_independent_of_event_order(
+    order: tuple[str, ...], terminal_status: Literal["completed", "errored"]
+):
+    """Keep all scheduler outcomes while filtering unstarted benchmark requests.
 
     ## WRITTEN BY AI ##
     """
     accumulator = _make_accumulator([], SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 1.0)
-    cancelled_state = SchedulerState(
+    state = SchedulerState(
+        start_time=SCHEDULE_BASE_TIME,
+        start_requests_time=SCHEDULE_BASE_TIME,
+        created_requests=3,
+        queued_requests=3,
+    )
+    for event in order:
+        status = terminal_status if event == "terminal" else "cancelled"
+        timings = RequestTimings(
+            queued=SCHEDULE_BASE_TIME,
+            dequeued=SCHEDULE_BASE_TIME + 0.1,
+            resolve_start=None if event == "queued" else SCHEDULE_BASE_TIME + 0.2,
+            request_start=None if event == "queued" else SCHEDULE_BASE_TIME + 0.3,
+            request_end=None if event == "queued" else SCHEDULE_BASE_TIME + 0.8,
+            resolve_end=SCHEDULE_BASE_TIME + 0.9,
+            finalized=SCHEDULE_BASE_TIME + 1.0,
+        )
+        state.processed_requests += 1
+        if status == "completed":
+            state.successful_requests += 1
+        elif status == "errored":
+            state.errored_requests += 1
+        else:
+            state.cancelled_requests += 1
+        accumulator.update_estimate(
+            response=None,
+            request=GenerationRequest(request_id=event),
+            info=RequestInfo(request_id=event, status=status, timings=timings),
+            scheduler_state=state,
+        )
+    state.end_processing_time = SCHEDULE_BASE_TIME + 1.0
+    state.end_time = SCHEDULE_BASE_TIME + 1.0
+
+    scheduler_metrics = SchedulerMetrics.compile(accumulator, state)
+    metrics = GenerativeMetrics.compile(accumulator)
+    successful = int(terminal_status == "completed")
+    errored = int(terminal_status == "errored")
+
+    assert scheduler_metrics.requests_made == StatusBreakdown(
+        successful=successful, incomplete=2, errored=errored, total=3
+    )
+    assert metrics.request_totals == StatusBreakdown(
+        successful=successful, incomplete=1, errored=errored, total=2
+    )
+
+
+@pytest.mark.regression
+def test_scheduler_counts_requests_when_all_are_cancelled_before_dispatch():
+    """Count scheduler cancellations even when no request statistics exist.
+
+    ## WRITTEN BY AI ##
+    """
+    accumulator = _make_accumulator([], SCHEDULE_BASE_TIME, SCHEDULE_BASE_TIME + 1.0)
+    state = SchedulerState(
         start_time=SCHEDULE_BASE_TIME,
         end_time=SCHEDULE_BASE_TIME + 1.0,
-        start_requests_time=SCHEDULE_BASE_TIME,
-        end_processing_time=SCHEDULE_BASE_TIME + 1.0,
         created_requests=1,
         queued_requests=1,
         processed_requests=1,
         cancelled_requests=1,
     )
-    info = RequestInfo(
-        request_id="cancelled-queued",
-        status="cancelled",
-        timings=RequestTimings(
-            queued=SCHEDULE_BASE_TIME,
-            dequeued=SCHEDULE_BASE_TIME + 0.5,
-            resolve_end=SCHEDULE_BASE_TIME + 1.0,
-            finalized=SCHEDULE_BASE_TIME + 1.0,
-        ),
-    )
-
     accumulator.update_estimate(
         response=None,
-        request=GenerationRequest(request_id=info.request_id),
-        info=info,
-        scheduler_state=cancelled_state,
-    )
-    completed_request = GenerationRequest(request_id="completed")
-    completed_info = RequestInfo(
-        request_id=completed_request.request_id,
-        status="completed",
-        timings=RequestTimings(
-            queued=SCHEDULE_BASE_TIME,
-            dequeued=SCHEDULE_BASE_TIME + 0.1,
-            resolve_start=SCHEDULE_BASE_TIME + 0.2,
-            request_start=SCHEDULE_BASE_TIME + 0.2,
-            request_end=SCHEDULE_BASE_TIME + 0.8,
-            resolve_end=SCHEDULE_BASE_TIME + 0.9,
-            finalized=SCHEDULE_BASE_TIME + 1.0,
-        ),
-    )
-    final_state = cancelled_state.model_copy(
-        update={"successful_requests": 1, "cancelled_requests": 1}
-    )
-    accumulator.update_estimate(
-        response=GenerationResponse(
-            request_id=completed_request.request_id,
-            request_args=None,
-        ),
-        request=completed_request,
-        info=completed_info,
-        scheduler_state=final_state,
+        request=GenerationRequest(request_id="queued"),
+        info=RequestInfo(request_id="queued", status="cancelled"),
+        scheduler_state=state,
     )
 
-    metrics = SchedulerMetrics.compile(accumulator, final_state)
+    metrics = SchedulerMetrics.compile(accumulator, state)
 
-    assert metrics.requests_made.successful == 1
-    assert metrics.requests_made.errored == 0
-    assert metrics.requests_made.incomplete == 0
-    assert metrics.requests_made.total == 1
+    assert metrics.requests_made == StatusBreakdown(
+        successful=0, incomplete=1, errored=0, total=1
+    )
+    assert accumulator.incomplete.requests_stats == []
 
 
 class TestScheduleRelativeMetrics:


### PR DESCRIPTION
## Summary

Scheduler request counts must include all cancellations, including requests cancelled before dispatch. The `incomplete` field represents cancelled requests because the scheduler reuses `StatusBreakdown`; filtered benchmark totals belong in `metrics.request_totals`.

This revision addresses the review by preserving those semantics and fixing the remaining event-order bug: a queued cancellation returns before updating the cached scheduler metrics, so a final queued cancellation can be missing from the exported scheduler counts. Compile those counts from the final `SchedulerState`, and document the distinction between scheduler outcomes and filtered measurement-window totals.

## Review follow-up

The original change incorrectly derived scheduler counts from the filtered request accumulators. That implementation has been replaced in commit `db6ec4ee7d7b78ed7f1029c5977f2cd17492b842`. Serialized field names remain compatible.

## Validation

- With the original cached-count implementation restored, the new tests produced 5 failures: four cases where queued cancellation was processed last, plus the case where every request was cancelled before dispatch.
- All six terminal-event orderings are tested for both completion and error, alongside started and queued cancellations. The tests check both scheduler counts and filtered benchmark totals.
- `uv run --frozen tox -e tests -- tests/unit/benchmark tests/unit/scheduler/test_worker.py -k 'not run_async_lifecycle and not run_with_timings' --tb=short`: 153 passed, 12 deselected.
- `uv run --frozen tox -e lint-check,type-check`: passed; mypy checked 222 source files.
- Broader benchmark/scheduler suite: 700 passed, 16 xfailed, 5 failed during `multiprocessing.Manager` startup. A representative failure was reproduced with the original metrics implementation: the sandbox rejects socket creation with `PermissionError`, followed by `EOFError`. This is not a clean full-suite result.
- `git diff --check`: passed.

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Implementation, tests, and documentation were assisted by OpenAI Codex and remain subject to maintainer review. The follow-up commit includes `Generated-by: OpenAI Codex` and the author's sign-off.

<!-- begin:squash-data -->

---

# git log

commit 7c2d3ed629b79ad3cb1e23d6f772ab2b45521525
Author: Divyam Talwar <divyamtalwar0@gmail.com>
Date:   Tue Sep 8 14:35:51 2026 +0530

    fix(metrics): exclude queued cancellations from requests made
    
    Compile request outcome counts from the request accumulators so cancellations that never reached dispatch do not leak into report totals after a later terminal update.
    
    Generated-by: OpenAI Codex
    
    Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>

commit db6ec4ee7d7b78ed7f1029c5977f2cd17492b842
Author: Divyam Talwar <divyamtalwar0@gmail.com>
Date:   Wed Sep 9 03:02:43 2026 +0530

    fix(metrics): preserve all cancellations in final scheduler counts
    
    Address PR #1102 review feedback: scheduler requests_made includes every
    cancellation, with the shared incomplete field representing cancelled.
    Filtered measurement-window counts remain in metrics.request_totals.
    
    Compile scheduler outcomes from the final SchedulerState. The cached
    accumulator can be stale when the last event is a queued cancellation,
    because that event returns before updating scheduler metric counts.
    Document the distinction without changing the serialized field names.
    
    Regression evidence: restoring the original cached-count implementation
    produced 5 failures (four trailing-cancellation permutations and the
    all-queued-cancelled case). The corrected path passes all permutations
    of queued cancellation, started cancellation, and completion/error.
    
    Validation:
    - tox focused benchmark and worker checks: 153 passed, 12 deselected.
    - tox lint-check and type-check: passed (222 source files).
    - Broader benchmark/scheduler run: 700 passed, 16 xfailed, 5 failed.
      The five failures occur at multiprocessing.Manager startup in this
      sandbox. A representative case also fails with the original metrics
      implementation: PermissionError creating a socket, followed by EOFError.
    - git diff --check: passed.
    
    Generated-by: OpenAI Codex
    
    Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>

---------

Signed-off-by: Divyam Talwar <divyamtalwar0@gmail.com>
