### PR TITLE
Improve Determinism for Integration Tests

### DIFF
--- a/src/guidellm/scheduler/constraints/request.py
+++ b/src/guidellm/scheduler/constraints/request.py
@@ -137,6 +137,16 @@ class MaxDurationConstraint(PydanticConstraintInitializer):
 
         return cast("Constraint", self.model_copy())
 
+    def resolved_seconds(self) -> float:
+        """Return the active duration limit in seconds.
+
+        :return: Scalar ``args.seconds``, or the list entry for ``current_index``
+        """
+        current_index = max(0, self.current_index)
+        if isinstance(self.args.seconds, int | float):
+            return float(self.args.seconds)
+        return float(self.args.seconds[min(current_index, len(self.args.seconds) - 1)])
+
     def __call__(
         self, state: SchedulerState, request_info: RequestInfo | None
     ) -> SchedulerUpdateAction:
@@ -148,14 +158,9 @@ class MaxDurationConstraint(PydanticConstraintInitializer):
         :return: Action indicating whether to continue or stop operations
         """
         _ = request_info  # Unused parameters
-        current_index = max(0, self.current_index)
-        max_duration = (
-            self.args.seconds
-            if isinstance(self.args.seconds, int | float)
-            else self.args.seconds[min(current_index, len(self.args.seconds) - 1)]
-        )
+        max_duration = self.resolved_seconds()
 
-        start_time = state.start_requests_time or state.start_time
+        start_time = state.start_time
         current_time = time.time()
         elapsed = current_time - start_time
         duration_exceeded = elapsed >= max_duration

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -128,10 +128,6 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         self.backend_started = False
         self.messaging_started = False
         self.turns_queue: list[DAGExecutionState[RequestT, ResponseT]] = []
-        # In-flight ``_process_next_graph_node`` tasks. These are created with
-        # ``asyncio.create_task`` and are not cancelled merely by cancelling
-        # ``_process_requests_loop``; the stop-event handler must cancel them.
-        self._pending_request_tasks: set[asyncio.Task[None]] = set()
 
     def run(self):
         """
@@ -242,13 +238,7 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 self.constraint_reached_event,
                 poll_interval=self.messaging.poll_interval,
             )
-            # Request tasks are create_task children of the loop, so they keep
-            # running (including asyncio.sleep on a replay target) until they
-            # are cancelled. Cancel them here, when the stop event is observed,
-            # rather than waiting for the loop's CancelledError handler.
             processing_task.cancel()
-            for task in list(self._pending_request_tasks):
-                task.cancel()
             # Let in-flight nodes finish reporting their own terminal update
             # before the sweep below, so a node is never reported twice.
             with contextlib.suppress(asyncio.CancelledError):
@@ -300,12 +290,13 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         Schedules and processes requests according to the timing strategy while
         maintaining the configured concurrency limit through semaphore coordination.
         """
+        pending_tasks: set[asyncio.Task] = set()
         try:
             # Run request processing
             async_semaphore = asyncio.Semaphore(self.async_limit)
 
-            def _task_done(task: asyncio.Task[None]):
-                self._pending_request_tasks.discard(task)
+            def _task_done(task: asyncio.Task):
+                pending_tasks.discard(task)
                 async_semaphore.release()
 
                 if not task.cancelled() and (exception := task.exception()):
@@ -326,13 +317,12 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 request_task = asyncio.create_task(
                     self._process_next_graph_node(target_start=request_time)
                 )
-                self._pending_request_tasks.add(request_task)
+                pending_tasks.add(request_task)
                 request_task.add_done_callback(_task_done)
         except asyncio.CancelledError as err:
-            in_flight = list(self._pending_request_tasks)
-            for task in in_flight:
+            for task in pending_tasks:
                 task.cancel()
-            await asyncio.gather(*in_flight, return_exceptions=True)
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
 
             raise err
 
@@ -566,8 +556,8 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         self, request: RequestT, request_info: RequestInfo, target_start: float
     ):
         request_info.timings.scheduled_at = request_info.timings.dequeued
-        if target_start > time.time():
-            await asyncio.sleep(target_start - time.time())
+        if target_start > (current_time := time.time()):
+            await asyncio.sleep(target_start - current_time)
             # Adapt delay so that scheduled at reflects the sleep time
             request_info.timings.scheduled_at = target_start
 

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -309,10 +309,10 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                     worker_index=self.worker_index
                 )
 
-                if (
-                    time_until := request_time - time.time()
-                ) >= self.fut_scheduling_time_limit:
-                    await asyncio.sleep(time_until - self.fut_scheduling_time_limit)
+                if request_time - time.time() >= self.fut_scheduling_time_limit:
+                    await self._sleep_until_target(
+                        request_time - self.fut_scheduling_time_limit
+                    )
 
                 request_task = asyncio.create_task(
                     self._process_next_graph_node(target_start=request_time)
@@ -552,12 +552,36 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         if state in self.turns_queue:
             self.turns_queue.remove(state)
 
+    async def _sleep_until_target(self, target_time: float) -> None:
+        """Sleep until ``target_time``, aborting if the worker should stop.
+
+        A single ``asyncio.sleep`` for a far-future replay timestamp is only
+        interrupted if the parent task is cancelled. Under multiprocessing that
+        cancel can lag ``max_duration``, so poll stop events on the same
+        interval used elsewhere in the worker.
+
+        :param target_time: Unix timestamp to wait until
+        :raises asyncio.CancelledError: If a constraint, shutdown, or error
+            event is set before ``target_time``
+        """
+        while True:
+            if (
+                self.constraint_reached_event.is_set()
+                or self.shutdown_event.is_set()
+                or self.error_event.is_set()
+            ):
+                raise asyncio.CancelledError
+            remaining = target_time - time.time()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(remaining, self.messaging.poll_interval))
+
     async def _schedule_request(
         self, request: RequestT, request_info: RequestInfo, target_start: float
     ):
         request_info.timings.scheduled_at = request_info.timings.dequeued
-        if target_start > (current_time := time.time()):
-            await asyncio.sleep(target_start - current_time)
+        if target_start > time.time():
+            await self._sleep_until_target(target_start)
             # Adapt delay so that scheduled at reflects the sleep time
             request_info.timings.scheduled_at = target_start
 

--- a/src/guidellm/scheduler/worker.py
+++ b/src/guidellm/scheduler/worker.py
@@ -128,6 +128,10 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         self.backend_started = False
         self.messaging_started = False
         self.turns_queue: list[DAGExecutionState[RequestT, ResponseT]] = []
+        # In-flight ``_process_next_graph_node`` tasks. These are created with
+        # ``asyncio.create_task`` and are not cancelled merely by cancelling
+        # ``_process_requests_loop``; the stop-event handler must cancel them.
+        self._pending_request_tasks: set[asyncio.Task[None]] = set()
 
     def run(self):
         """
@@ -238,7 +242,13 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                 self.constraint_reached_event,
                 poll_interval=self.messaging.poll_interval,
             )
+            # Request tasks are create_task children of the loop, so they keep
+            # running (including asyncio.sleep on a replay target) until they
+            # are cancelled. Cancel them here, when the stop event is observed,
+            # rather than waiting for the loop's CancelledError handler.
             processing_task.cancel()
+            for task in list(self._pending_request_tasks):
+                task.cancel()
             # Let in-flight nodes finish reporting their own terminal update
             # before the sweep below, so a node is never reported twice.
             with contextlib.suppress(asyncio.CancelledError):
@@ -290,13 +300,12 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         Schedules and processes requests according to the timing strategy while
         maintaining the configured concurrency limit through semaphore coordination.
         """
-        pending_tasks: set[asyncio.Task] = set()
         try:
             # Run request processing
             async_semaphore = asyncio.Semaphore(self.async_limit)
 
-            def _task_done(task: asyncio.Task):
-                pending_tasks.discard(task)
+            def _task_done(task: asyncio.Task[None]):
+                self._pending_request_tasks.discard(task)
                 async_semaphore.release()
 
                 if not task.cancelled() and (exception := task.exception()):
@@ -309,20 +318,21 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
                     worker_index=self.worker_index
                 )
 
-                if request_time - time.time() >= self.fut_scheduling_time_limit:
-                    await self._sleep_until_target(
-                        request_time - self.fut_scheduling_time_limit
-                    )
+                if (
+                    time_until := request_time - time.time()
+                ) >= self.fut_scheduling_time_limit:
+                    await asyncio.sleep(time_until - self.fut_scheduling_time_limit)
 
                 request_task = asyncio.create_task(
                     self._process_next_graph_node(target_start=request_time)
                 )
-                pending_tasks.add(request_task)
+                self._pending_request_tasks.add(request_task)
                 request_task.add_done_callback(_task_done)
         except asyncio.CancelledError as err:
-            for task in pending_tasks:
+            in_flight = list(self._pending_request_tasks)
+            for task in in_flight:
                 task.cancel()
-            await asyncio.gather(*pending_tasks, return_exceptions=True)
+            await asyncio.gather(*in_flight, return_exceptions=True)
 
             raise err
 
@@ -552,36 +562,12 @@ class WorkerProcess(Generic[RequestT, ResponseT]):
         if state in self.turns_queue:
             self.turns_queue.remove(state)
 
-    async def _sleep_until_target(self, target_time: float) -> None:
-        """Sleep until ``target_time``, aborting if the worker should stop.
-
-        A single ``asyncio.sleep`` for a far-future replay timestamp is only
-        interrupted if the parent task is cancelled. Under multiprocessing that
-        cancel can lag ``max_duration``, so poll stop events on the same
-        interval used elsewhere in the worker.
-
-        :param target_time: Unix timestamp to wait until
-        :raises asyncio.CancelledError: If a constraint, shutdown, or error
-            event is set before ``target_time``
-        """
-        while True:
-            if (
-                self.constraint_reached_event.is_set()
-                or self.shutdown_event.is_set()
-                or self.error_event.is_set()
-            ):
-                raise asyncio.CancelledError
-            remaining = target_time - time.time()
-            if remaining <= 0:
-                return
-            await asyncio.sleep(min(remaining, self.messaging.poll_interval))
-
     async def _schedule_request(
         self, request: RequestT, request_info: RequestInfo, target_start: float
     ):
         request_info.timings.scheduled_at = request_info.timings.dequeued
         if target_start > time.time():
-            await self._sleep_until_target(target_start)
+            await asyncio.sleep(target_start - time.time())
             # Adapt delay so that scheduled at reflects the sleep time
             request_info.timings.scheduled_at = target_start
 

--- a/src/guidellm/scheduler/worker_group.py
+++ b/src/guidellm/scheduler/worker_group.py
@@ -26,7 +26,11 @@ from typing import Generic, NamedTuple
 from typing_extensions import TypeAliasType
 
 from guidellm.logger import logger
-from guidellm.scheduler.constraints import Constraint, RequestsExhaustedConstraint
+from guidellm.scheduler.constraints import (
+    Constraint,
+    MaxDurationConstraint,
+    RequestsExhaustedConstraint,
+)
 from guidellm.scheduler.dag import DAGExecutionState
 from guidellm.scheduler.schemas import (
     BackendInterface,
@@ -134,6 +138,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         # Background health monitor, created in create_processes
         self._health_monitor_task: asyncio.Task | None = None
         self._worker_error_details: str | None = None
+        self._max_duration_deadline_task: asyncio.Task | None = None
 
         # Scheduler and messaging state, created in start
         self.state: WorkerGroupState[RequestT, ResponseT] | None = None
@@ -354,6 +359,11 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
             receive_stop_criteria=[self.shutdown_event],
         )
 
+        if self._max_duration_constraint() is not None:
+            self._max_duration_deadline_task = asyncio.create_task(
+                self._run_max_duration_deadline()
+            )
+
         if (wait_time := start_time - time.time()) > 0:
             await asyncio.sleep(wait_time)
         if self.error_event.is_set():
@@ -362,6 +372,36 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
                 or "an error occurred in one of the worker processes"
             )
             raise RuntimeError(f"error_event is set in WorkerProcessGroup: {detail}")
+
+    def _max_duration_constraint(self) -> MaxDurationConstraint | None:
+        for constraint in self.constraints.values():
+            if isinstance(constraint, MaxDurationConstraint):
+                return constraint
+        return None
+
+    def _apply_time_constraint_update(self) -> None:
+        if self.state is None:
+            return
+        state_update = self.state.update_state()
+        if state_update.stop_processing and self.constraint_reached_event is not None:
+            self.constraint_reached_event.set()
+        if state_update.stop_queueing:
+            self.state.stop_send_requests_event.set()
+
+    async def _run_max_duration_deadline(self) -> None:
+        """Wait until the max_duration deadline, then signal workers to stop.
+
+        One ``asyncio.sleep`` until ``start_time + seconds``, not a poll loop.
+
+        :raises asyncio.CancelledError: If shutdown cancels this wait
+        """
+        constraint = self._max_duration_constraint()
+        if constraint is None or self.state is None:
+            return
+        remaining = self.state.start_time + constraint.resolved_seconds() - time.time()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        self._apply_time_constraint_update()
 
     async def request_updates(
         self,
@@ -411,15 +451,7 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
                 # Time-based constraints (max_duration) must be evaluated even when
                 # workers are sleeping until a future target start, because no
                 # request updates arrive during that wait.
-                if self.state is not None:
-                    state_update = self.state.update_state()
-                    if (
-                        state_update.stop_processing
-                        and self.constraint_reached_event is not None
-                    ):
-                        self.constraint_reached_event.set()
-                    if state_update.stop_queueing:
-                        self.state.stop_send_requests_event.set()
+                self._apply_time_constraint_update()
 
     async def shutdown(self) -> list[Exception]:
         """
@@ -434,6 +466,12 @@ class WorkerProcessGroup(Generic[RequestT, ResponseT]):
         :return: List of exceptions encountered during shutdown; empty if no errors
         """
         exceptions: list[Exception] = []
+
+        if self._max_duration_deadline_task is not None:
+            self._max_duration_deadline_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._max_duration_deadline_task
+            self._max_duration_deadline_task = None
 
         if self._health_monitor_task is not None:
             self._health_monitor_task.cancel()

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -123,11 +123,11 @@ class FastMockBackend(BackendInterface):
 
     @property
     def processes_limit(self) -> int | None:
-        return None
+        return 2
 
     @property
     def requests_limit(self) -> int | None:
-        return None
+        return 4
 
     def info(self) -> dict[str, Any]:
         return {"type": "fast_mock_trace_replay", "delay": self._resolve_delay}
@@ -306,13 +306,15 @@ async def test_max_duration_cancels_long_replay_sleep():
         max_duration=MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=0.4)),
     )
     statuses: set[str] = set()
+    cancelled_ids: set[str] = set()
     try:
         await group.create_processes()
         await group.start(time.time() + 0.05)
         run_started = time.time()
         async for _, _, request_info, _state in group.request_updates():
             statuses.add(request_info.status)
-            if "cancelled" in statuses:
+            if request_info.status == "cancelled":
+                cancelled_ids.add(request_info.request_id)
                 break
         elapsed = time.time() - run_started
     finally:
@@ -320,4 +322,5 @@ async def test_max_duration_cancels_long_replay_sleep():
         assert exceptions == []
 
     assert "cancelled" in statuses
+    assert any(request_id.startswith("del_") for request_id in cancelled_ids)
     assert elapsed < 2.5

--- a/tests/unit/scheduler/test_constraints.py
+++ b/tests/unit/scheduler/test_constraints.py
@@ -1261,6 +1261,28 @@ class TestConstraintNoneRequest:
         assert action.request_queuing == "stop"
         assert action.request_processing == "stop_local"
 
+    @pytest.mark.regression
+    def test_max_duration_uses_scheduler_start_not_first_request(self):
+        """Replay waits count toward max_duration from scheduler start.
+
+        ``start_requests_time`` is first backend ``request_start``, which is
+        after a trace-replay sleep. Duration must use ``start_time``.
+
+        ## WRITTEN BY AI ##
+        """
+        constraint = MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=1.0))
+        now = time.time()
+        state = SchedulerState(
+            node_id=0,
+            num_processes=1,
+            start_time=now - 5.0,
+            start_requests_time=now + 30.0,
+        )
+        action = constraint(state, None)
+        assert action.request_queuing == "stop"
+        assert action.request_processing == "stop_local"
+        assert action.metadata["start_time"] == pytest.approx(now - 5.0)
+
     @pytest.mark.smoke
     def test_max_requests_accepts_none_request(self):
         """max_requests evaluates counts with request=None.

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -898,6 +898,33 @@ class TestWorkerProcessMultiturn:
 
     @pytest.mark.regression
     @pytest.mark.asyncio
+    @async_timeout(5.0)
+    async def test_schedule_request_aborts_sleep_on_constraint(self, worker_instance):
+        """Replay target waits must stop when max_duration fires.
+
+        ## WRITTEN BY AI ##
+        """
+        request_info = RequestInfo(request_id="delayed")
+        request_info.timings.dequeued = time.time()
+        target_start = time.time() + 5.0
+
+        async def trip_constraint() -> None:
+            await asyncio.sleep(0.05)
+            worker_instance.constraint_reached_event.set()
+
+        trip_task = asyncio.create_task(trip_constraint())
+        started = time.time()
+        with pytest.raises(asyncio.CancelledError):
+            await worker_instance._schedule_request("r0", request_info, target_start)
+        await trip_task
+        assert time.time() - started < 2.0
+        assert not any(
+            item[2].status == "in_progress"
+            for item in worker_instance.messaging._sent_items
+        )
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
     async def test_cancel_preserves_partial_backend_response(self):
         """Cancelled node update keeps the final partial response from the backend.
 

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -900,11 +900,11 @@ class TestWorkerProcessMultiturn:
     @pytest.mark.asyncio
     @async_timeout(5.0)
     async def test_constraint_cancels_in_flight_schedule_sleep(self, worker_instance):
-        """constraint_reached must cancel in-flight replay ``asyncio.sleep``.
+        """constraint_reached cancels the processing loop, which aborts replay sleeps.
 
-        ``_process_next_graph_node`` runs as a ``create_task`` child. The stop
-        event is observed by ``_process_requests``, which has to cancel those
-        children; cancelling only the processing loop leaves the sleep running.
+        Setting the stop event must cancel ``_process_requests_loop``. That
+        handler cancels in-flight ``create_task`` children, so a 5s
+        ``_schedule_request`` sleep ends well before it completes.
 
         ## WRITTEN BY AI ##
         """

--- a/tests/unit/scheduler/test_worker.py
+++ b/tests/unit/scheduler/test_worker.py
@@ -899,24 +899,55 @@ class TestWorkerProcessMultiturn:
     @pytest.mark.regression
     @pytest.mark.asyncio
     @async_timeout(5.0)
-    async def test_schedule_request_aborts_sleep_on_constraint(self, worker_instance):
-        """Replay target waits must stop when max_duration fires.
+    async def test_constraint_cancels_in_flight_schedule_sleep(self, worker_instance):
+        """constraint_reached must cancel in-flight replay ``asyncio.sleep``.
+
+        ``_process_next_graph_node`` runs as a ``create_task`` child. The stop
+        event is observed by ``_process_requests``, which has to cancel those
+        children; cancelling only the processing loop leaves the sleep running.
 
         ## WRITTEN BY AI ##
         """
-        request_info = RequestInfo(request_id="delayed")
-        request_info.timings.dequeued = time.time()
-        target_start = time.time() + 5.0
+        entered_sleep = asyncio.Event()
 
-        async def trip_constraint() -> None:
-            await asyncio.sleep(0.05)
-            worker_instance.constraint_reached_event.set()
+        async def fake_startup() -> None:
+            return None
 
-        trip_task = asyncio.create_task(trip_constraint())
+        async def fake_cancel_loop() -> None:
+            return None
+
+        async def fake_shutdown() -> None:
+            return None
+
+        async def sleeping_node(target_start: float) -> None:
+            _ = target_start
+            request_info = RequestInfo(request_id="delayed")
+            request_info.timings.dequeued = time.time()
+            entered_sleep.set()
+            await worker_instance._schedule_request(
+                "r0", request_info, time.time() + 5.0
+            )
+
+        class ImmediateStartStrategy:
+            async def next_request_time(self, worker_index: int) -> float:
+                _ = worker_index
+                return time.time()
+
+            def request_completed(self, request_info: RequestInfo) -> None:
+                _ = request_info
+
+        worker_instance._processing_startup = fake_startup
+        worker_instance._cancel_requests_loop = fake_cancel_loop
+        worker_instance._processing_shutdown = fake_shutdown
+        worker_instance._process_next_graph_node = sleeping_node
+        worker_instance.strategy = ImmediateStartStrategy()
+        worker_instance.fut_scheduling_time_limit = 0.0
+
         started = time.time()
-        with pytest.raises(asyncio.CancelledError):
-            await worker_instance._schedule_request("r0", request_info, target_start)
-        await trip_task
+        process_task = asyncio.create_task(worker_instance._process_requests())
+        await asyncio.wait_for(entered_sleep.wait(), timeout=2.0)
+        worker_instance.constraint_reached_event.set()
+        await process_task
         assert time.time() - started < 2.0
         assert not any(
             item[2].status == "in_progress"


### PR DESCRIPTION
## Summary

This ensures that cross-worker cancellations work.

In #1080 it was changed to properly stop on cancellation. This goes further to poll because it wasn't propagated to other workers.

This should theoretically make it handle cancellation better, and it should satisfy the failing test.

## Test Plan

This should mainly apply to trace formats with long gaps, just like in #1080 

## Related Issues

- Follow up to #1080 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 3c40e11ed9c2e17f65b694b12854aa5e645aa2d2
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Tue Sep 8 11:43:09 2026 -0400

    Ensure workers poll for cancellation
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 7375e275c889025545989bd1308192020c5c2883
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Tue Sep 8 14:04:48 2026 -0400

    Revert polling, and improve cancellation process
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

commit 356d15a753e270915214fc68215462e09515807a
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Tue Sep 8 15:54:20 2026 -0400

    Pre-determine cancellation time to improve determism.
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
