### PR TITLE
fix(openai): accept SSE DONE markers without a space

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -660,13 +660,12 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
         :param line: Raw line from the streaming response
         :return: Parsed JSON data as dictionary, or None if line indicates completion
         """
-        if line == "data: [DONE]":
-            return None
-
         if not line or not (line := line.strip()) or not line.startswith("data:"):
             return {}
 
         line = line[len("data:") :].strip()
+        if line == "[DONE]":
+            return None
 
         data = json.loads(line)
         _check_streaming_error(data)
@@ -1996,10 +1995,11 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
         if not line or not line.startswith("data:"):
             return {}
 
-        if line == "data: [DONE]":
+        line = line[len("data:") :].strip()
+        if line == "[DONE]":
             return None
 
-        data = json.loads(line[len("data:") :].strip())
+        data = json.loads(line)
         _check_streaming_error(data)
         return data
 

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -725,6 +725,7 @@ class TestTextCompletionsRequestHandler:
         [
             ('data: {"choices": [{"text": "Test"}]}', {"choices": [{"text": "Test"}]}),
             ("data: [DONE]", None),
+            ("data:[DONE]", None),
             ("", {}),
             ("invalid line", {}),
             ('data: {"test": "value"}', {"test": "value"}),
@@ -3531,6 +3532,7 @@ class TestResponsesRequestHandler:
                 {"type": "response.output_text.delta", "delta": "Hi"},
             ),
             ("data: [DONE]", None),
+            ("data:[DONE]", None),
             ("", {}),
             ("event: response.created", {}),
             ("event: response.output_text.delta", {}),


### PR DESCRIPTION
## Summary

A streaming server can return valid generated text followed by `data:[DONE]`, but GuideLLM attempts to JSON-decode the terminator and raises `JSONDecodeError`. The [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#interpreting-an-event-stream) makes the space after the colon optional, so this should behave like `data: [DONE]`.

## Details

- [x] Recognize `[DONE]` after the existing data-prefix removal and whitespace normalization in the text completions and Responses handlers. Chat completions inherits the text handler's parser.
- [x] Extend both parser test matrices with the no-space terminator, retaining the existing spaced terminator and ordinary JSON/control-line cases.

## Test Plan

- Before the fix, the two new cases failed with `JSONDecodeError`; the other 15 selected cases passed.
- `tox -e tests -- tests/unit/backends/openai`: 326 passed.
- Full `tox -e tests`: 3,061 passed, 31 skipped, 188 xfailed; 14 audio-test failures and one realtime-WebSocket setup error because this environment cannot load `libtorchcodec`/FFmpeg shared libraries. Both affected test files reproduce the same 14 failures and one error with unmodified main sources.
- `tox -e lint-check`: passed.
- `tox -e type-check`: passed, 222 source files.
- `uv run --no-project --python .tox/tests/bin/python pre-commit run --files src/guidellm/backends/openai/request_handlers.py tests/unit/backends/openai/test_request_handlers.py`: passed.
- Manual localhost HTTP verification through `OpenAIHTTPBackend.process_startup()` and `backend.resolve()`: `/v1/completions`, `/v1/chat/completions`, and `/v1/responses` each return `Hello` for both DONE spellings (six cases).

## Related Issues

- No linked issue.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Code and tests were generated with OpenAI Codex; the commit includes a `Generated-by` trailer.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit f2b4aca857b9055873bec726f9f37aa40872d042
Author: git-jxj <65210887+git-jxj@users.noreply.github.com>
Date:   Wed Sep 9 15:30:28 2026 +0800

    fix(openai): accept SSE DONE markers without a space
    
    Recognize the terminator after extracting the data value in both streaming parsers.
    
    Generated-by: OpenAI Codex
    Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>

---------

Generated-by: OpenAI Codex
Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
