### PR TITLE
fix(openai): surface nested Responses streaming errors

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -2193,6 +2193,8 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
             # with optional usage data. Returning None signals the streaming
             # loop in http.py to break out of the stream.
             resp = data.get("response") or {}
+            if event_type == "response.failed":
+                _check_streaming_error(resp)
             usage = resp.get("usage")
             if usage:
                 self.streaming_usage = usage

--- a/tests/unit/backends/openai/test_http.py
+++ b/tests/unit/backends/openai/test_http.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import nullcontext
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
@@ -1068,3 +1069,83 @@ class TestCheckToolCallExpectations:
         # Verify token counts
         assert final_info.timings.token_iterations > 0
         assert final_response.output_metrics.text_tokens == 10
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "error", "include_delta", "expect_error"),
+    [
+        (
+            "response.failed",
+            {"code": "server_error", "message": "Generation failed"},
+            True,
+            True,
+        ),
+        (
+            "response.failed",
+            {"code": "server_error", "message": "Generation failed"},
+            False,
+            True,
+        ),
+        ("response.failed", None, True, False),
+        ("response.failed", {}, True, False),
+        ("response.completed", None, True, False),
+        ("response.incomplete", None, True, False),
+    ],
+)
+async def test_resolve_responses_terminal_error(
+    httpx_mock: HTTPXMock, event_type, error, include_delta, expect_error
+):
+    """Propagate explicit Responses failures even after receiving partial text.
+
+    ## WRITTEN BY AI ##
+    """
+    events = []
+    if include_delta:
+        events.append({"type": "response.output_text.delta", "delta": "Partial answer"})
+    events.append(
+        {
+            "type": event_type,
+            "response": {
+                "id": "resp-1",
+                "status": event_type.removeprefix("response."),
+                "error": error,
+            },
+        }
+    )
+    httpx_mock.add_response(
+        url="http://test/v1/responses",
+        headers={"Content-Type": "text/event-stream"},
+        stream=IteratorStream(
+            [("data: " + json.dumps(event) + "\n\n").encode() for event in events]
+        ),
+    )
+    backend = _make_backend(
+        target="http://test",
+        model="test-model",
+        stream=True,
+        request_format="/v1/responses",
+    )
+    request = GenerationRequest(columns={"text_column": ["Hello"]})
+    request_info = RequestInfo(request_id=request.request_id)
+    await backend.process_startup()
+    try:
+        expected = (
+            pytest.raises(
+                ValueError,
+                match="Streaming response returned an error: Generation failed",
+            )
+            if expect_error
+            else nullcontext()
+        )
+        with expected:
+            responses = [
+                response
+                async for response, _ in backend.resolve(request, request_info)
+                if response is not None
+            ]
+            if not expect_error:
+                assert responses[-1].text == "Partial answer"
+    finally:
+        await backend.process_shutdown()


### PR DESCRIPTION
## Summary

When a Responses API stream emits partial text followed by `response.failed` containing a non-empty `response.error`, GuideLLM returns the partial text as a normal `GenerationResponse`. If no text arrived, it instead raises the generic `UNUSABLE_BACKEND_RESPONSE` error, losing the server's failure message. The [documented failure event](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.failed) carries its error inside `response`, which the existing top-level SSE error check does not inspect.

## Details

- [x] Apply the existing `_check_streaming_error` helper to the nested response of a `response.failed` event, surfacing its error as `ValueError` through the normal request-failure path.
- [x] Add six parametrized `backend.resolve()` cases using the real Responses handler and mocked HTTP transport: explicit failures with and without partial text, failed events with null/empty errors, and completed/incomplete controls.

The terminal-event tests introduced in #655 intentionally preserve partial output for failed events without an error payload. Those cases still pass. This change only raises for an explicit non-empty nested error on `response.failed`; it preserves the existing incomplete-event behavior.

## Test Plan

- Before the fix: two new regression cases failed and four controls passed. After partial text, the expected exception was absent; without partial text, the wrong generic error was raised.
- `tox -e tests -- tests/unit/backends/openai`: 330 passed, including existing failed/incomplete terminal-event tests.
- Full `tox -e tests`: 3,065 passed, 31 skipped, 188 xfailed; 14 audio-test failures and one realtime-WebSocket setup error because this environment cannot load `libtorchcodec`/FFmpeg shared libraries. Re-running both affected test files with unmodified main sources in the same tox environment reproduces all 14 failures and the setup error.
- `tox -e lint-check` and `tox -e type-check`: passed (222 source files for type checking).
- `uv run --no-project --python .tox/tests/bin/python pre-commit run --files src/guidellm/backends/openai/request_handlers.py tests/unit/backends/openai/test_http.py`: passed.
- Independent localhost HTTP verification through `process_startup()` and `backend.resolve()`: both explicit-failure cases now raise `ValueError` containing the server message; failed events without an error or with a null error, completed events, and incomplete events all retain partial text. The partial-text failure was reproduced before applying the fix.

## Related Issues

- Related: #743 and #795 established propagation of top-level streaming errors; this addresses the nested error carried by the Responses terminal event.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Code and tests were generated with OpenAI Codex; the commit includes a `Generated-by` trailer.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 4077f207d9abf26a293a07f58d22948473c350cc
Author: git-jxj <65210887+git-jxj@users.noreply.github.com>
Date:   Wed Sep 9 15:40:50 2026 +0800

    fix(openai): surface nested Responses streaming errors
    
    Propagate explicit response.failed errors while retaining terminal events without an error payload.
    
    Generated-by: OpenAI Codex
    Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>

---------

Generated-by: OpenAI Codex
Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
