### PR TITLE
fix: respect WEKA trace hash ID scopes

### DIFF
--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -259,11 +259,12 @@ class WEKATraceFormat(TraceFormatBase):
             requests = [dict(item) for item in row[self.requests_col]]
             index = len(self._conversation_queue)
             self._conversation_queue.append((conv_id, requests))
-            yield Dataset.from_dict({"_weka_index": [index]})
-
-    def reset(self) -> None:
-        self.hash_id_table = {}
-        self.sibling_token_blocks = {}
+            yield Dataset.from_dict(
+                {
+                    "_weka_index": [index],
+                    "hash_id_scope": [row.get("hash_id_scope")],
+                }
+            )
 
     def required_columns(self) -> Features:
         return Features(
@@ -302,14 +303,33 @@ class WEKATraceFormat(TraceFormatBase):
             )
 
     def create_prompt(
-        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
+        self,
+        row: dict,
+        processor: PreTrainedTokenizerBase,
+        faker: Faker,
+        hash_id_table: dict[int, tuple[int, ...]] | None = None,
+        sibling_token_blocks: dict[Any, set[tuple[int, ...]]] | None = None,
     ) -> str:
         """Before generating the prompt, this first generates a block of tokens for
         each hash ID that has not already been seen.
 
         Hash IDs that are partially filled are discarded to match the specification.
         Remainder of the prompt is created after the creation via hash IDs token
-        blocks."""
+        blocks.
+
+        :param row: API request containing hash IDs and the prompt length
+        :param processor: Tokenizer used to generate and decode token blocks
+        :param faker: Seeded synthetic text generator
+        :param hash_id_table: Conversation-local mapping, or the global mapping
+            when omitted
+        :param sibling_token_blocks: Sibling blocks in the same hash scope, or
+            the global sibling blocks when omitted
+        :return: Synthetic prompt preserving the hash relationships
+        """
+        if hash_id_table is None:
+            hash_id_table = self.hash_id_table
+        if sibling_token_blocks is None:
+            sibling_token_blocks = self.sibling_token_blocks
         ids = row[self.config.hash_ids_column]
         n_in = row[self.config.prompt_tokens_column]
         block_size = self.config.hash_id_block_size
@@ -317,17 +337,17 @@ class WEKATraceFormat(TraceFormatBase):
         if math.floor(expected) != len(ids) and math.ceil(expected) == len(ids):
             ids.pop()
         for idx, hash_id in enumerate(ids):
-            if hash_id not in self.hash_id_table:
+            if hash_id not in hash_id_table:
                 prev_id = None if idx == 0 else ids[idx - 1]
-                self.sibling_token_blocks.setdefault(prev_id, set())
-                self.hash_id_table[hash_id] = create_distinct_token_block(
+                sibling_token_blocks.setdefault(prev_id, set())
+                hash_id_table[hash_id] = create_distinct_token_block(
                     block_size,
-                    self.sibling_token_blocks[prev_id],
+                    sibling_token_blocks[prev_id],
                     processor,
                     faker,
                 )
-                self.sibling_token_blocks[prev_id].add(self.hash_id_table[hash_id])
-        prompt = create_prompt_from_hash_ids(ids, self.hash_id_table, processor)
+                sibling_token_blocks[prev_id].add(hash_id_table[hash_id])
+        prompt = create_prompt_from_hash_ids(ids, hash_id_table, processor)
         remainder = _generate_remaining_prompt(n_in % block_size, processor, faker)
         if not prompt:
             return remainder
@@ -358,9 +378,16 @@ class WEKATraceFormat(TraceFormatBase):
             )
         min_t = min(spec.absolute_t for spec in specs)
         turns: list[ConversationTurnData] = []
+        # Local hashes are shared by all turns in this conversation, including
+        # subagents, without replacing the dataset's global hash mapping.
+        local_scope = conversation[0].get("hash_id_scope") == "local"
+        hash_id_table = {} if local_scope else self.hash_id_table
+        sibling_token_blocks = {} if local_scope else self.sibling_token_blocks
         for spec in specs:
             _validate_api_row(spec.row, self.config, self.validate_row)
-            prompt = self.create_prompt(spec.row, processor, faker)
+            prompt = self.create_prompt(
+                spec.row, processor, faker, hash_id_table, sibling_token_blocks
+            )
             columns: dict[str, Any] = {
                 "text_column": [prompt],
                 "prompt_tokens_count_column": [

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -552,6 +552,10 @@ class TestWEKATraceFormat:
     def test_multi_conversation_resets_hash_id_state(
         self, tmp_path: Path, deserializer, default_block_size
     ):
+        """Local hash IDs do not share generated tokens across conversations.
+
+        ## WRITTEN BY AI ##
+        """
         n_rows = 2
         n_virtual_rows = 2
         n_in = default_block_size * 2
@@ -560,7 +564,10 @@ class TestWEKATraceFormat:
             generate_weka_trace(
                 n_rows,
                 n_virtual_rows,
-                [TraceColumnGenerator("id", lambda i: f'"conv{i}"')],
+                [
+                    TraceColumnGenerator("id", lambda i: f'"conv{i}"'),
+                    TraceColumnGenerator("hash_id_scope", lambda _: '"local"'),
+                ],
                 [
                     TraceColumnGenerator("t", lambda i: i),
                     TraceColumnGenerator("in", lambda _: n_in),
@@ -580,6 +587,41 @@ class TestWEKATraceFormat:
         prompts1 = [turn.columns["text_column"][0] for turn in conv1]
         prompts2 = [turn.columns["text_column"][0] for turn in conv2]
         assert prompts1[0] != prompts2[0]
+
+    @pytest.mark.regression
+    def test_mixed_hash_id_scopes(self, tmp_path: Path) -> None:
+        """Global hashes survive local rows, whose turns share only local hashes.
+
+        ## WRITTEN BY AI ##
+        """
+        rows = []
+        for index, scope in enumerate(["global", "local", None, "local", "global"]):
+            row = {
+                "id": f"conv{index}",
+                "requests": [
+                    {"t": turn, "in": 4, "out": 2, "hash_ids": [1]} for turn in range(2)
+                ],
+            }
+            if scope is not None:
+                row["hash_id_scope"] = scope
+            rows.append(row)
+        trace = write_trace(tmp_path, "\n".join(json.dumps(row) for row in rows))
+        dataset = DatasetDeserializerFactory.deserialize(
+            config=WEKATraceFormatArgs(
+                source=trace_file_source(trace), hash_id_block_size=4
+            ),
+            processor_factory=compatible_processor,
+            random_seed=42,
+        )
+        prompts = [
+            [turn.columns["text_column"][0] for turn in load_graph_turns(row)]
+            for row in dataset
+        ]
+        assert all(first == second for first, second in prompts)
+        assert prompts[0] == prompts[2] == prompts[4]
+        assert prompts[1] != prompts[0]
+        assert prompts[3] != prompts[0]
+        assert prompts[1] != prompts[3]
 
     @pytest.mark.sanity
     def test_zero_prompt_tokens_empty_hash_ids(self, tmp_path: Path, deserializer):


### PR DESCRIPTION
WEKA traces currently reset their hash-to-token mapping after every conversation and ignore `hash_id_scope`. Consequently, the same global hash produces different prompts in successive rows, changing the prefix-cache reuse represented by the trace.

Preserve the global mapping for `global` and omitted scopes, and use temporary mappings shared by all turns in a `local` conversation. Local rows neither reuse nor clear global mappings. Add coverage for interleaved global, local, and omitted scopes and retain the existing local isolation test.

Fixes #1114.

Validation:
- Reproduced the regression with a five-row JSONL through `DatasetDeserializerFactory`, both with the unit-test tokenizer and a locally cached Qwen3-0.6B tokenizer. Global prompt equality fails on upstream and passes after the fix; local prompts remain isolated.
- WEKA and Mooncake deserializer tests: 53 passed.
- Full unit suite: 3009 passed, 31 skipped, 163 xfailed; 14 audio failures were caused by missing FFmpeg libraries. After installing FFmpeg, the entire audio module passes (28 passed).
- `tox -e lint-check` and `tox -e type-check`: passed.

<!-- begin:squash-data -->

---

# git log

commit 0a2de3976f7d5ce68933bd1432b16f692e8a55de
Author: git-jxj <65210887+git-jxj@users.noreply.github.com>
Date:   Thu Sep 10 10:03:24 2026 +0800

    fix: respect WEKA trace hash ID scopes
    
    Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>

---------

Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
