### PR TITLE
fix: replay flat trace rows as independent conversations

### DIFF
--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -62,10 +62,12 @@ These are passed through the `--data` argument like below:
 guidellm run \
     --backend kind=openai_http,target=http://localhost:8000 \
     --profile kind=replay \
-    --data "kind=trace_synthetic,source.kind=json_file,source.path=replay.jsonl,timestamp_column=ts,prompt_tokens_column=input_tokens,output_tokens_column=generated_tokens,time_scale=1.0,max_wait=30"
+    --data "kind=trace_synthetic,source.kind=json_file,source.path=replay.jsonl,timestamp_column=ts,prompt_tokens_column=input_tokens,output_tokens_column=generated_tokens,time_scale=1.0,max_session_wait=30"
 ```
 
 `trace_synthetic` can be thought of as the format-agnostic option, only looking for the timestamp, prompt token count and output token count columns and ignoring all other features contained in a dataset. While primarily used for testing, `trace_synthetic` may be used as a fallback for trace formats not currently supported by GuideLLM.
+
+`trace_synthetic` and `mooncake` replay each row as an independent, single-request conversation. Rows are sorted by timestamp and keep their offsets from the first request in the trace. Prompts are generated as rows are consumed, and Mooncake hash IDs remain shared across rows. Use `max_session_wait` to cap gaps between these independent requests; `max_wait` only caps gaps within multi-request conversations, such as WEKA sessions.
 
 ## Format-Specific Data Arguments
 

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -188,6 +188,41 @@ class TraceFormatBase(Protocol):
         return ConversationGraphData(turns=turns)
 
 
+class SingleTurnTraceFormat(TraceFormatBase):
+    """Replay each trace row as an independent conversation on a shared timeline."""
+
+    dataset: Dataset
+    _trace_start_timestamp: float
+
+    def __iter__(self) -> Iterable[Dataset]:
+        """Yield one timestamp-sorted row at a time for lazy prompt generation."""
+        ordered = self.dataset.sort(self.config.timestamp_column)
+        if not len(ordered):
+            return
+        self._trace_start_timestamp = ordered[0][self.config.timestamp_column]
+        for index in range(len(ordered)):
+            yield ordered.select([index])
+
+    def build_conversation_graph(
+        self,
+        conversation: Dataset,
+        processor: PreTrainedTokenizerBase,
+        faker: Faker,
+    ) -> ConversationGraphData:
+        """Build a single root turn with its offset from the start of the trace.
+
+        :param conversation: One trace row returned by iteration
+        :param processor: Tokenizer for generating the synthetic prompt
+        :param faker: Seeded synthetic text generator
+        :return: An independent conversation preserving its trace arrival time
+        """
+        graph = super().build_conversation_graph(conversation, processor, faker)
+        graph.turns[0].columns["relative_timestamp_column"] = [
+            conversation[0][self.config.timestamp_column] - self._trace_start_timestamp
+        ]
+        return graph
+
+
 class TraceFormatRegistry(RegistryMixin[type[TraceFormatBase]]):
     @classmethod
     def dispatch(cls, config: TraceDataArgs, dataset: Dataset) -> TraceFormatBase:

--- a/src/guidellm/data/deserializers/trace_minimal.py
+++ b/src/guidellm/data/deserializers/trace_minimal.py
@@ -9,14 +9,12 @@ line with a synthetic prompt matching the requested input_length for replay benc
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 from datasets import Dataset, Features
 from faker import Faker
 from transformers import PreTrainedTokenizerBase
 
 from guidellm.data.deserializers.trace_common import (
-    TraceFormatBase,
+    SingleTurnTraceFormat,
     TraceFormatRegistry,
     decode_prompt,
     generate_token_ids,
@@ -28,13 +26,10 @@ __all__ = ["MinimalTraceFormat"]
 
 
 @TraceFormatRegistry.register("trace_synthetic")
-class MinimalTraceFormat(TraceFormatBase):
+class MinimalTraceFormat(SingleTurnTraceFormat):
     def __init__(self, config: MinimalTraceFormatArgs, dataset: Dataset) -> None:
         self.config = config
         self.dataset = dataset
-
-    def __iter__(self) -> Iterable[Dataset]:
-        yield self.dataset.sort(self.config.timestamp_column)
 
     def required_columns(self) -> Features:
         return {}

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -10,7 +10,6 @@ same previous hash ID.
 from __future__ import annotations
 
 import math
-from collections.abc import Iterable
 from typing import Any
 
 from datasets import Dataset, Features, List, Value
@@ -21,8 +20,8 @@ from guidellm.data.deserializers.deserializer import (
     DatasetDeserializerFactory,
 )
 from guidellm.data.deserializers.trace_common import (
+    SingleTurnTraceFormat,
     TraceDatasetDeserializer,
-    TraceFormatBase,
     TraceFormatRegistry,
     create_distinct_token_block,
     create_prompt_from_hash_ids,
@@ -50,7 +49,7 @@ DatasetDeserializerFactory.register_decorator(TraceDatasetDeserializer, "mooncak
 
 
 @TraceFormatRegistry.register("mooncake")
-class MooncakeTraceFormat(TraceFormatBase):
+class MooncakeTraceFormat(SingleTurnTraceFormat):
     """Mooncake trace format requires a column for timestamps, prompt token counts,
     ouput token counts and lists of hash IDs.
 
@@ -70,9 +69,6 @@ class MooncakeTraceFormat(TraceFormatBase):
 
         self.hash_id_table: dict[int, tuple[int, ...]] = {}
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
-
-    def __iter__(self) -> Iterable[Dataset]:
-        yield self.dataset.sort(self.config.timestamp_column)
 
     def required_columns(self) -> Features:
         return Features({self.config.hash_ids_column: List(Value("int32"))})

--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -29,7 +29,6 @@ from guidellm.scheduler import (
 )
 from guidellm.scheduler.schemas import (
     ConversationGraph,
-    ConversationNode,
     HistoryContext,
 )
 from guidellm.scheduler.schemas.conversation_graph import (
@@ -115,32 +114,19 @@ def _requests_from_trace(
     finalizer = GenerativeRequestFinalizer(GenerativeRequestFinalizerArgs())
 
     relative_timestamps: list[float] = []
-    conv = next(iter(dataset))
-    mapped = mapper([{"dataset": conv}])
-    graph = finalizer(mapped)
-    assert isinstance(graph, GenerativeConversationGraph)
-    assert len(graph.nodes) == 10
-
     graphs: list[ConversationGraph[GenerationRequest]] = []
-    for idx, node in enumerate(graph.nodes.values()):
+    for idx, conversation in enumerate(dataset):
+        mapped = mapper([{"dataset": conversation}])
+        graph = finalizer(mapped)
+        assert isinstance(graph, GenerativeConversationGraph)
+        assert len(graph.nodes) == 1
+        assert not graph.edges
+        node = next(iter(graph.nodes.values()))
         node.request.request_id = f"req_{idx}"
         offset = node.settings.relative_timestamp
         assert offset is not None
         relative_timestamps.append(offset)
-        graphs.append(
-            ConversationGraph(
-                graph_id=f"graph_req_{idx}",
-                nodes={
-                    node.node_id: ConversationNode(
-                        node_id=node.node_id,
-                        agent_id=node.agent_id,
-                        request=node.request,
-                        settings=node.settings,
-                    )
-                },
-                edges=[],
-            )
-        )
+        graphs.append(graph)
 
     return graphs, relative_timestamps
 

--- a/tests/unit/data/deserializers/test_trace_common.py
+++ b/tests/unit/data/deserializers/test_trace_common.py
@@ -202,7 +202,7 @@ class TestTraceDatasetDeserializer:
             suffix=suffix,
         )
         ds = self.deserialize(deserializer, trace)
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         for i, turn in enumerate(conv):
             assert turn.columns["relative_timestamp_column"][0] == i
             assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
@@ -216,7 +216,7 @@ class TestTraceDatasetDeserializer:
             suffix=".csv",
         )
         ds = self.deserialize(deserializer, trace)
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         for i, turn in enumerate(conv):
             assert turn.columns["relative_timestamp_column"][0] == i
             assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
@@ -240,13 +240,14 @@ class TestTraceDatasetDeserializer:
         )
         ds = self.deserialize(deserializer, trace)
         assert isinstance(ds, IterableDataset)
-        conv = load_graph(next(iter(ds)))
+        conversations = [load_graph(row) for row in ds]
         proc = mock_processor()
-        assert len(conv.turns) == n_rows
-        for i, turn in enumerate(conv.turns):
-            assert turn.node_id == f"main_{i}"
-            if i > 0:
-                assert turn.parents[0].parent_node_id == f"main_{i - 1}"
+        assert len(conversations) == n_rows
+        for i, conversation in enumerate(conversations):
+            assert len(conversation.turns) == 1
+            turn = conversation.turns[0]
+            assert turn.node_id == "main_0"
+            assert not turn.parents
             n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == i + 1
             assert turn.columns["output_tokens_count_column"][0] == (i + 1) * 10
@@ -269,13 +270,15 @@ class TestTraceDatasetDeserializer:
             ),
         )
         ds = self.deserialize(deserializer, trace)
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         for i, turn in enumerate(conv):
             assert turn.columns["relative_timestamp_column"][0] == i
 
     @pytest.mark.smoke
-    def test_max_wait_rewrites_emitted_timestamps(self, tmp_path: Path, deserializer):
-        """max_wait compresses intra-session gaps on emitted graphs.
+    def test_max_session_wait_rewrites_emitted_timestamps(
+        self, tmp_path: Path, deserializer
+    ):
+        """max_session_wait compresses gaps between independent trace rows.
 
         ## WRITTEN BY AI ##
         """
@@ -285,8 +288,8 @@ class TestTraceDatasetDeserializer:
             '{"timestamp": 10, "input_length": 10, "output_length": 1}\n'
             '{"timestamp": 1450, "input_length": 10, "output_length": 1}\n',
         )
-        ds = self.deserialize(deserializer, trace, max_wait=30.0)
-        conv = load_graph_turns(next(iter(ds)))
+        ds = self.deserialize(deserializer, trace, max_session_wait=30.0)
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         timestamps = [turn.columns["relative_timestamp_column"][0] for turn in conv]
         assert timestamps == pytest.approx([0.0, 10.0, 40.0])
 
@@ -302,8 +305,10 @@ class TestTraceDatasetDeserializer:
             '{"timestamp": 10, "input_length": 10, "output_length": 1}\n'
             '{"timestamp": 1450, "input_length": 10, "output_length": 1}\n',
         )
-        ds = self.deserialize(deserializer, trace, max_wait=30.0, time_scale=2.0)
-        conv = load_graph_turns(next(iter(ds)))
+        ds = self.deserialize(
+            deserializer, trace, max_session_wait=30.0, time_scale=2.0
+        )
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         timestamps = [turn.columns["relative_timestamp_column"][0] for turn in conv]
         assert timestamps == pytest.approx([0.0, 20.0, 80.0])
 
@@ -326,7 +331,7 @@ class TestTraceDatasetDeserializer:
             '"model": "a", "type": "n", "api_time": 2.87}\n',
         )
         ds = self.deserialize(deserializer, trace)
-        turns = load_graph_turns(next(iter(ds)))
+        turns = [turn for row in ds for turn in load_graph_turns(row)]
         assert len(turns) == 2
         for i, turn in enumerate(turns):
             assert turn.columns["prompt_tokens_count_column"][0] == (i + 1) * 10
@@ -350,7 +355,7 @@ class TestTraceDatasetDeserializer:
             '{"timestamp": 2, "input_length": 20, "output_length": 2, "stop": null}\n',
         )
         ds = self.deserialize(deserializer, trace)
-        turns = load_graph_turns(next(iter(ds)))
+        turns = [turn for row in ds for turn in load_graph_turns(row)]
         assert len(turns) == 2
 
     @pytest.mark.smoke

--- a/tests/unit/data/deserializers/test_trace_minimal.py
+++ b/tests/unit/data/deserializers/test_trace_minimal.py
@@ -16,7 +16,7 @@ from guidellm.data.schemas.conversation_graph_data import (
     ConversationGraphData,
     ConversationTurnData,
 )
-from guidellm.schemas.data import MinimalTraceFormatArgs
+from guidellm.schemas.data import MinimalTraceFormatArgs, MooncakeTraceFormatArgs
 from tests.unit.data.deserializers.trace_test_utils import trace_file_source
 
 
@@ -109,7 +109,7 @@ class TestMinimalTraceFormat:
             prompt_tokens_column="input_tokens",
             output_tokens_column="generated_tokens",
         )
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
 
         prompt_counts = [2, 4]
         output_counts = [20, 40]
@@ -145,7 +145,7 @@ class TestMinimalTraceFormat:
             processor_factory=lambda: processor,
             random_seed=42,
         )
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
 
         assert processor.encode.call_count <= len(prompt_lengths) + 4
         for i, turn in enumerate(conv):
@@ -156,3 +156,47 @@ class TestMinimalTraceFormat:
             actual_length = len(processor.encode(turn.columns["text_column"][0]))
             if actual_length != n_in:
                 pytest.fail(f"{actual_length} != {n_in}")
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("kind", ["trace_synthetic", "mooncake"])
+def test_trace_rows_are_independent_conversations(tmp_path: Path, kind: str) -> None:
+    """Emit independent requests lazily while retaining sorted arrival offsets.
+
+    ## WRITTEN BY AI ##
+    """
+    trace = write_trace(
+        tmp_path,
+        "\n".join(
+            json.dumps(
+                {
+                    "timestamp": timestamp,
+                    "input_length": 4,
+                    "output_length": 2,
+                    "hash_ids": [1],
+                }
+            )
+            for timestamp in [15, 10, 12]
+        ),
+    )
+    config = (
+        MooncakeTraceFormatArgs(source=trace_file_source(trace), hash_id_block_size=4)
+        if kind == "mooncake"
+        else MinimalTraceFormatArgs(source=trace_file_source(trace), max_wait=1.0)
+    )
+    processor = mock_processor()
+    dataset = DatasetDeserializerFactory.deserialize(
+        config=config, processor_factory=lambda: processor, random_seed=42
+    )
+    iterator = iter(dataset)
+    first = load_graph_turns(next(iterator))
+    assert len(first) == 1
+    assert processor.decode.call_count == 1
+    conversations = [first, *(load_graph_turns(row) for row in iterator)]
+    assert len(conversations) == 3
+    assert all(len(turns) == 1 and not turns[0].parents for turns in conversations)
+    assert [
+        turns[0].columns["relative_timestamp_column"][0] for turns in conversations
+    ] == [0, 2, 5]
+    if kind == "mooncake":
+        assert len({turns[0].columns["text_column"][0] for turns in conversations}) == 1

--- a/tests/unit/data/deserializers/test_trace_mooncake.py
+++ b/tests/unit/data/deserializers/test_trace_mooncake.py
@@ -223,7 +223,7 @@ class TestMooncakeTraceFormat:
         )
         processor = ascending_processor()
         ds = self.deserialize(deserializer, trace)
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         for i, turn in enumerate(conv):
             n_in = turn.columns["prompt_tokens_count_column"][0]
             assert n_in == prompt_lengths[i]
@@ -258,7 +258,7 @@ class TestMooncakeTraceFormat:
             processor_factory=lambda: processor,
             random_seed=42,
         )
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         for turn in conv:
             in_cnt = turn.columns["prompt_tokens_count_column"][0]
             actual_length = len(processor.encode(turn.columns["text_column"][0]))
@@ -318,7 +318,7 @@ class TestMooncakeTraceFormat:
             random_seed=42,
         )
         with pytest.raises(ValueError, match="generate distinct"):
-            load_graph_turns(next(iter(ds)))
+            list(ds)
 
     @pytest.mark.smoke
     def test_token_block_distinctness(self, tmp_path: Path, deserializer):
@@ -341,7 +341,7 @@ class TestMooncakeTraceFormat:
             processor_factory=compatible_processor,
             random_seed=42,
         )
-        conv = load_graph_turns(next(iter(ds)))
+        conv = [turn for row in ds for turn in load_graph_turns(row)]
         root_blocks, sibling_blocks = zip(
             *[
                 (


### PR DESCRIPTION
## Summary

Mooncake and `trace_synthetic` currently turn the entire timestamp-sorted dataset into one conversation, eagerly generating every prompt and assigning independent requests to one worker. Emit each row as an independent single-turn conversation with its prompt generated on demand.

## Details

- Preserve arrival offsets relative to the complete trace and the global Mooncake hash mapping.
- Consume conversation graphs directly in the replay integration test instead of manually splitting one graph into requests.
- Use `max_session_wait` to cap gaps between independent rows; retain `max_wait` for gaps within multi-request sessions, and document the distinction.

## Test Plan

Validation already completed for the code in this PR:

- Reproduced through `DatasetDeserializerFactory` with JSONL and a locally cached Qwen3-0.6B tokenizer: upstream emits one three-turn conversation; fixed code emits three single-turn conversations and preserves offsets `[0, 2, 5]`.
- Regression tests verify lazy first-prompt decoding and shared Mooncake hashes; both new cases fail on upstream.
- All deserializer tests: 242 passed, 1 skipped.
- Focused Mooncake/generic tests and multiprocess replay integration: 15 passed, including timing and dispatch across workers.
- `tox -e lint-check` and `tox -e type-check`: passed.
- The disclosure-only commit-message update preserves the exact source tree.

## Related Issues

- Fixes #1113.

---

- [ ] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Codex generated or substantially modified the implementation, tests, and documentation. The commit includes `Generated-by: Codex`. The personal certification above is left for the contributor to attest.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 76603d0e49b36c6ccdb928958d75a9f52d10157b
Author: git-jxj <65210887+git-jxj@users.noreply.github.com>
Date:   Thu Sep 10 10:06:26 2026 +0800

    fix: replay flat trace rows as independent conversations
    
    Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
    Generated-by: Codex

---------

Generated-by: Codex
Signed-off-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
