### PR TITLE
fix(benchmark): apply measurement bounds to token events and TTFT

### DIFF
--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -901,6 +901,26 @@ class GenerativeMetrics(StandardBaseDict):
         incomplete = accumulator.incomplete.get_within_range(start_time, end_time)
         errored = accumulator.errored.get_within_range(start_time, end_time)
 
+        def with_first_token_in_measurement(
+            requests: list[GenerativeRequestStats],
+        ) -> list[GenerativeRequestStats]:
+            """Bound TTFT samples by first token rather than by request overlap.
+
+            Requests without a ``first_token_iteration`` (non-streaming paths,
+            embeddings, requests that never emitted a token) are kept so their
+            existing TTFT contribution is unchanged by this filter.
+            """
+            return [
+                request
+                for request in requests
+                if request.first_token_iteration is None
+                or start_time <= request.first_token_iteration <= end_time
+            ]
+
+        ttft_successful = with_first_token_in_measurement(successful)
+        ttft_incomplete = with_first_token_in_measurement(incomplete)
+        ttft_errored = with_first_token_in_measurement(errored)
+
         # Schedule-relative metrics describe lag against an arrival schedule.
         # Closed-loop strategies derive each target from the system's own
         # responses, so a delay measured against them is circular rather than a
@@ -987,9 +1007,9 @@ class GenerativeMetrics(StandardBaseDict):
             ),
             time_to_first_token_ms=StatusDistributionSummary.from_values_function(
                 function=lambda req: req.time_to_first_token_ms or 0.0,
-                successful=successful,
-                incomplete=incomplete,
-                errored=errored,
+                successful=ttft_successful,
+                incomplete=ttft_incomplete,
+                errored=ttft_errored,
             ),
             time_to_last_round_trip_ms=StatusDistributionSummary.from_values_function(
                 function=lambda req: req.time_to_last_round_trip_ms or 0.0,
@@ -1032,18 +1052,24 @@ class GenerativeMetrics(StandardBaseDict):
                 successful=successful,
                 incomplete=incomplete,
                 errored=errored,
+                start_time=start_time,
+                end_time=end_time,
             ),
             output_tokens_per_second=StatusDistributionSummary.rate_distribution_from_timings_function(
                 function=lambda req: req.output_tokens_timings,
                 successful=successful,
                 incomplete=incomplete,
                 errored=errored,
+                start_time=start_time,
+                end_time=end_time,
             ),
             tokens_per_second=StatusDistributionSummary.rate_distribution_from_timings_function(
                 function=lambda req: req.total_tokens_timings,
                 successful=successful,
                 incomplete=incomplete,
                 errored=errored,
+                start_time=start_time,
+                end_time=end_time,
             ),
             output_tokens_per_iteration=StatusDistributionSummary.from_values_function(
                 function=lambda req: [

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -279,6 +279,93 @@ def _make_accumulator(
     return accumulator
 
 
+class TestMeasurementBoundsFiltering:
+    """
+    Verify that the measurement window bounds token events and TTFT samples.
+
+    ## WRITTEN BY AI ##
+    """
+
+    @staticmethod
+    def _completed(
+        request_id: str,
+        request_start: float,
+        request_end: float,
+        first_token: float | None,
+        last_token: float | None,
+        token_iterations: int,
+    ) -> GenerativeRequestStats:
+        """Build a completed request with 2 prompt and 2 output tokens.
+
+        ## WRITTEN BY AI ##
+        """
+        return GenerativeRequestStats(
+            request_id=request_id,
+            info=RequestInfo(
+                request_id=request_id,
+                status="completed",
+                timings=RequestTimings(
+                    resolve_start=request_start,
+                    resolve_end=request_end,
+                    request_start=request_start,
+                    request_end=request_end,
+                    first_token_iteration=first_token,
+                    last_token_iteration=last_token,
+                    token_iterations=token_iterations,
+                ),
+            ),
+            input_metrics=UsageMetrics(text_tokens=2),
+            output_metrics=UsageMetrics(text_tokens=2),
+        )
+
+    @pytest.mark.regression
+    def test_measurement_bounds_filter_token_events_but_not_overlapping_requests(
+        self,
+    ):
+        """Bound token events and select TTFT by first token. ## WRITTEN BY AI ##"""
+        requests = [
+            # First token on the opening bound; both token events inside.
+            self._completed("first-token-in-window", 99.0, 105.0, 100.0, 105.0, 2),
+            # First token during warmup; the 99.0 event is outside the window.
+            self._completed("first-token-before-window", 99.0, 101.0, 99.0, 101.0, 2),
+            # First token exactly on the closing bound; the 106.0 event is outside.
+            self._completed("token-after-window", 104.0, 106.0, 105.0, 106.0, 2),
+            # Non-streaming: no first-token timing at all, wholly inside.
+            self._completed("no-token-iterations", 101.0, 103.0, None, None, 0),
+        ]
+
+        metrics = GenerativeMetrics.compile(_make_accumulator(requests, 100.0, 105.0))
+
+        # Every request overlaps the window, so request totals are untouched.
+        assert metrics.request_totals.successful == 4
+        # 100.0 and 105.0 are on the inclusive bounds and count; 99.0 does not.
+        # The non-streaming request has no first token to bound, so it is kept
+        # and keeps contributing the sample it contributed before this change.
+        assert metrics.time_to_first_token_ms.successful.count == 3
+        # Prompt events land at 100.0, 99.0 (dropped), 105.0 and 103.0.
+        assert metrics.prompt_tokens_per_second.successful.count == 6
+        # Output events land at 100.0/105.0, 99.0 (dropped)/101.0,
+        # 105.0/106.0 (dropped) and 103.0.
+        assert metrics.output_tokens_per_second.successful.count == 6
+        assert metrics.tokens_per_second.successful.count == 12
+
+    @pytest.mark.regression
+    def test_bounds_spanning_the_run_keep_every_token_event(self):
+        """A window covering the whole run drops nothing. ## WRITTEN BY AI ##"""
+        requests = [
+            self._completed("streamed", 99.0, 105.0, 100.0, 105.0, 2),
+            self._completed("non-streaming", 101.0, 103.0, None, None, 0),
+        ]
+
+        metrics = GenerativeMetrics.compile(_make_accumulator(requests, 98.0, 107.0))
+
+        assert metrics.request_totals.successful == 2
+        assert metrics.time_to_first_token_ms.successful.count == 2
+        assert metrics.prompt_tokens_per_second.successful.count == 4
+        assert metrics.output_tokens_per_second.successful.count == 4
+        assert metrics.tokens_per_second.successful.count == 8
+
+
 class TestScheduleRelativeMetrics:
     """
     Verify the schedule-relative distributions added alongside request_latency.


### PR DESCRIPTION
## Summary

When a benchmark is run with `--warmup` and/or `--cooldown`, the reported token-rate and time-to-first-token figures describe a wider span of time than the measurement window the user asked for.

A request that starts during warmup and finishes inside the measurement window is correctly counted as an in-window request, but *all* of its token events are counted too, including the ones it emitted while the run was still warming up. Symmetrically, a request whose first token only arrives after the cooldown boundary still contributes a TTFT sample. So `prompt_tokens_per_second`, `output_tokens_per_second`, `tokens_per_second` and `time_to_first_token_ms` are computed over events that lie outside the window, and the user sees warmup/cooldown behaviour folded into the measured numbers.

Root cause, verified in the source. `GenerativeMetrics.compile` bounds at the *request* level (`src/guidellm/benchmark/schemas/metrics.py:900-902`, unchanged on `main`):

```python
successful = accumulator.completed.get_within_range(start_time, end_time)
incomplete = accumulator.incomplete.get_within_range(start_time, end_time)
errored = accumulator.errored.get_within_range(start_time, end_time)
```

and then hands those request lists straight to the rate summaries at `metrics.py:1050`, `:1058` and `:1066` and to the TTFT summary at `:1008`. Request-level inclusion cannot express "this request is in scope, but only some of the token events it produced are", and TTFT needs a first-token rule rather than a whole-request-overlap rule. `requests_per_second` already forwards the same bounds on `main` (`metrics.py:932-939` at `d469d0e`); the token rates did not.

## Details

- [x] Forward `start_time`/`end_time` from `GenerativeMetrics.compile` into the three token-rate summaries (`prompt_tokens_per_second`, `output_tokens_per_second`, `tokens_per_second`). The helper already accepts and honours those bounds; it was simply not being given them. Events at the inclusive bounds are kept, events outside are dropped.
- [x] Select TTFT samples by whether `first_token_iteration` falls inside `[start_time, end_time]`, via a small local helper at `metrics.py:904-918`, applied at `:920-922`. Requests that have **no** `first_token_iteration` at all are deliberately kept, so their existing TTFT contribution is unchanged by this filter.
- [x] Leave request totals alone. They continue to mean "every completed request that overlaps the window", which is what `get_within_range` already gave.
- [x] Add two regression tests in a new dedicated class `TestMeasurementBoundsFiltering` (`tests/unit/benchmark/schemas/test_metrics.py:282-366`).

The "keep requests with no first token" decision is worth a reviewer's attention. `first_token_iteration` is only ever assigned on streaming paths — `backends/openai/http.py:367`, `backends/openai/websocket.py:86`, `backends/vllm_python/vllm.py:578`, `backends/vllm_python/batch.py:688`. Non-streaming requests, embeddings, and requests that never emitted a token leave it `None`. Making the filter `is not None and start <= fti <= end` would have silently dropped every one of those from the TTFT distribution — a second, unrelated behaviour change. The predicate is therefore `is None or start <= fti <= end`, which touches only the requests the measurement window is actually about.

The diff is 2 files, 116 insertions and 3 deletions (`git diff --stat d469d0e..HEAD`).

## Behaviour changes a reviewer should weigh

**1. Runs with warmup and/or cooldown.** Token-rate event counts and TTFT sample counts now exclude events outside the window. This is the intended fix.

**2. Every run, including runs with no warmup and no cooldown.** This one is a side effect of passing the bounds at all, and it is the main thing I would like a maintainer's opinion on.

`DistributionSummary.rate_distribution_from_timings` does not merely filter when given bounds — it also inserts zero-weight sentinel events at the window edges (`src/guidellm/schemas/base/statistics.py:338-353`):

```python
if start_time is not None:
    # Filter out any times before start, insert start time with 0 weight
    weighted_times = np.insert(
        weighted_times[weighted_times[:, 0] >= start_time], 0, [start_time, 0.0], axis=0,
    )
```

So idle time at the head or tail of the window now enters the rate weighting on *every* run, not just warmup/cooldown runs. Measured in isolation on this branch:

```python
ev = [(101.0, 1), (102.0, 1), (103.0, 1)]
DistributionSummary.rate_distribution_from_timings(ev)
# mean=1.5000 median=1.0000 count=3
DistributionSummary.rate_distribution_from_timings(ev, start_time=100.0, end_time=105.0)
# mean=0.6000 median=0.6667 count=3
```

End to end through `GenerativeMetrics.compile`, on a synthetic three-request timeline over a 10 s window with **no** warmup and **no** cooldown, running the same input against `metrics.py` from `d469d0e` and from this branch. Each request carries 2 prompt and 2 output tokens, built with the `_completed` helper from the new test class:

```python
reqs = [
    _completed("r1", 101.0, 103.0, 102.0, 103.0, 2),
    _completed("r2", 104.0, 106.0, 105.0, 106.0, 2),
    _completed("r3", 107.0, 109.0, 108.0, 109.0, 2),
]
GenerativeMetrics.compile(_make_accumulator(reqs, 100.0, 110.0))
```

| `tokens_per_second.successful` | base `d469d0e` | this branch |
| ------------------------------ | -------------- | ----------- |
| count                          | 12             | 12          |
| mean                           | 1.7143         | 1.2000      |
| median                         | 2.0000         | 1.0000      |

`time_to_first_token_ms.successful` was `count=3 mean=1000.0000` on both, i.e. TTFT is genuinely unchanged when the window spans the run.

No token event is dropped (count stays 12) — the summary statistics move because the weighting now includes the idle head and tail. This is the same weighting `requests_per_second` has always used, so the change makes the token rates *consistent* with it. But it does mean token-rate averages shift on existing benchmark configurations that never used warmup or cooldown, and historical numbers become non-comparable. **If maintainers would rather not take that, I am happy to gate the rate half on warmup/cooldown actually being configured and leave the unbounded path untouched otherwise.** Say the word and I will push that.

**3. TTFT is now bounded by a different rule from the other per-token latency metrics, and its sample count no longer tracks the request count.** This falls straight out of item 1, and it is the thing a maintainer is most likely to ask about, so it is stated here rather than left to be discovered.

`time_to_first_token_ms` now draws from the first-token-filtered lists (`metrics.py:1010-1012`), while `inter_token_latency_ms` (`:1046`) and `time_per_output_token_ms` (`:1037`) still draw from the whole-request-overlap lists, as does `request_totals` (`:947`). On a warmup/cooldown run the same benchmark can therefore report a TTFT distribution built from fewer requests than the ITL and TPOT distributions printed next to it, and `time_to_first_token_ms.successful.count` no longer equals `request_totals.successful`. Measured on the four-request scenario from the new test, window `[100, 105]`:

```
request_totals.successful           = 4
time_to_first_token_ms.successful   = count 3
inter_token_latency_ms.successful   = count 4
time_per_output_token_ms.successful = count 8   (weighted by output tokens, 2 per request)
```

That divergence is asserted by `test_measurement_bounds_filter_token_events_but_not_overlapping_requests`, so it is a pinned decision rather than an accident. I did not extend the first-token rule to ITL and TPOT because neither is a single-event metric: both describe an interval spanning the whole generation, and choosing how to bound them — by first token, by last token, or by clipping the interval to the window — is a separate design question rather than a mechanical extension of this fix. If you want ITL and TPOT bounded too, tell me which rule you want and I will add it on this branch.

## Out of scope, but found while doing this

On `main`, a request with no `first_token_iteration` still contributes a `0.0` TTFT sample: `time_to_first_token_ms` returns `None` (`src/guidellm/schemas/base/request_stats.py:207-216`) and `compile` coalesces with `or 0.0` (`metrics.py:1008-1013`). A fully non-streaming benchmark therefore reports `TTFT count=N, mean≈0.0`. I saw this directly in the negative control below (`count=4, median=0.0, min=0.0`). That is arguably wrong, but changing it is a separate decision about what TTFT means for a non-streaming request, so this PR deliberately leaves it exactly as it is. Happy to follow up if you want it addressed.

## Test Plan

All commands run on this branch in a local venv. `tox` is not installed in this environment, so the two CI environments were run as their underlying commands, taken verbatim from `tox.ini:51-58` (`lint-check`) and `tox.ini:71-75` (`type-check`).

**New tests**

```
$ .venv/bin/python -m pytest tests/unit/benchmark/schemas/test_metrics.py -q
13 passed in 10.41s

$ .venv/bin/python -m pytest tests/unit/benchmark -q
131 passed in 18.48s
```

**Full unit suite**

```
$ .venv/bin/python -m pytest tests/unit -q
3022 passed, 31 skipped, 163 xfailed, 1 warning in 136.89s (0:02:16)
```

**Lint / format / imports / docs (`tox -e lint-check` equivalents)**

```
$ .venv/bin/ruff format --check --diff
372 files already formatted

$ .venv/bin/ruff check
All checks passed!

$ .venv/bin/lint-imports
Contracts: 4 kept, 0 broken.

$ .venv/bin/python -m mdformat --check README.md DEVELOPING.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/ src/ tests/
(no output, exit 0)
```

**Types (`tox -e type-check` equivalent)**

```
$ .venv/bin/mypy --check-untyped-defs
Success: no issues found in 221 source files

$ git diff --check d469d0e09581cf5582def8be96b0d279674476e9
(no output, exit 0)
```

### Negative controls — the tests fail without the fix

**Control 1 — `metrics.py` restored to `d469d0e`, new tests kept.**

```
$ git checkout d469d0e -- src/guidellm/benchmark/schemas/metrics.py
$ .venv/bin/python -m pytest tests/unit/benchmark/schemas/test_metrics.py::TestMeasurementBoundsFiltering -q
PASSED ...::test_bounds_spanning_the_run_keep_every_token_event
FAILED ...::test_measurement_bounds_filter_token_events_but_not_overlapping_requests - assert 4 == 3
1 failed, 1 passed in 2.87s
```

The `4` there is `DistributionSummary(mean=500.0, median=0.0, ..., count=4, min=0.0, max=1000.0)` — the base behaviour, with the out-of-window request still contributing.

`test_bounds_spanning_the_run_keep_every_token_event` **passes** on the base commit, and that is the correct outcome for it. It is not regression proof; it is a guard. What it proves is that no token event and no TTFT sample is dropped when the window spans the whole run — which is exactly why it must pass on both sides. (The token-rate *summary statistics* in that case do change, as documented above; that test asserts counts, not means.)

**Control 2 — the `is None or` narrowing is load-bearing.** Re-tightening only the TTFT predicate to `is not None and start <= fti <= end`:

```
FAILED ...::test_measurement_bounds_filter_token_events_but_not_overlapping_requests - assert 2 == 3
FAILED ...::test_bounds_spanning_the_run_keep_every_token_event - assert 1 == 2
2 failed in 3.14s
```

Both fail, so the "keep requests with no first-token timing" behaviour is pinned by tests, not just asserted in prose.

**Control 3 — the rate half is independently load-bearing.** Reverse-applying only the hunk that adds `start_time=`/`end_time=` to the three rate call sites, leaving the TTFT helper intact:

```
PASSED ...::test_bounds_spanning_the_run_keep_every_token_event
FAILED ...::test_measurement_bounds_filter_token_events_but_not_overlapping_requests - assert 8 == 6
1 failed, 1 passed in 4.23s
```

The TTFT assertion passes and the failure lands on `assert metrics.prompt_tokens_per_second.successful.count == 6` (`test_metrics.py:346`), so the rate bounds are exercised on their own rather than being shadowed by the TTFT assertion.

The source tree was restored after every control, and the final state re-runs at 13 passed / 131 passed as above.

## What was not verified

Stated plainly, because it matters for how much weight to put on the numbers above.

- **No live model server, no vLLM instance, no GPU.** Every result here is unit-level and deterministic, built from synthetic `GenerativeRequestStats` timelines. Nothing was measured against a real backend.
- **No integration or e2e run.** Only `tests/unit` was executed.
- **The 1.7143 → 1.2000 / 2.0000 → 1.0000 figures come from the synthetic three-request timeline shown above**, not from a real benchmark. The direction and the mechanism are certain (sentinel insertion at `statistics.py:338-353`, confirmed in isolation). The *magnitude* on a real run depends on how much idle time sits at the window edges and will differ.
- **`tox` itself was not run** — it is not installed here. I ran the exact commands its `lint-check` and `type-check` environments invoke, from the project venv. CI remains the authoritative check.
- **No before/after comparison of a real benchmark report file** for a warmup/cooldown run.

## Related Issues

- No linked issue.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

Noted below: this change was produced with AI assistance.

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Code and tests were substantially modified with Claude Code; the commit includes an `Assisted-by` trailer, and each AI-written test docstring carries the `## WRITTEN BY AI ##` marker required by `AGENTS.md`.

<!-- begin:squash-data -->

---

# git log

commit 6db436d9eb6355bfbeac6fa0422c168073515edc
Author: breken-ai <312387581+breken-ai@users.noreply.github.com>
Date:   Thu Sep 10 10:15:15 2026 +0530

    fix(benchmark): apply measurement bounds to token events and TTFT
    
    Problem
    -------
    With `--warmup`/`--cooldown` set, per-second token metrics and
    time-to-first-token were computed from whole requests rather than from
    the individual events those requests produced. A request that started
    during warmup and finished inside the measurement window contributed all
    of its token events, including the ones emitted while warming up. A
    request whose first token landed after the measurement window closed
    still contributed a TTFT sample. The reported rates and TTFT therefore
    described a window wider than the one the user asked for.
    
    Root cause
    ----------
    `GenerativeMetrics.compile` filtered at the request level with
    `get_within_range` and then handed the resulting request lists straight
    to the rate and TTFT summaries. Request-level inclusion cannot express
    "this request is in scope, but only some of its token events are", and
    TTFT needs a first-token rule rather than a whole-request overlap rule.
    
    Approach
    --------
    - `prompt_tokens_per_second`, `output_tokens_per_second` and
      `tokens_per_second` now pass `start_time`/`end_time` through to the
      rate summary helper, which already accepts and honours those bounds.
      Token events at the inclusive bounds are counted; events outside are
      excluded. `requests_per_second` already passes the same bounds on
      `main`, so this makes the token rates consistent with it.
    - TTFT samples are selected by `first_token_iteration` falling inside
      `[start_time, end_time]`, via a small local helper. Requests that have
      no `first_token_iteration` at all -- non-streaming paths, embeddings,
      and requests that never emitted a token -- are kept, so their existing
      TTFT contribution is deliberately left unchanged by this filter.
    - Request totals are deliberately unchanged: they continue to represent
      every completed request that overlaps the window.
    
    Impact
    ------
    Three reported-number changes, all intended, all disclosed here.
    
    1. Runs with warmup and/or cooldown. Token-rate event counts and TTFT
       sample counts now exclude events that fall outside the measurement
       window, so those figures change and describe a narrower window.
    
    2. Every run, including runs with no warmup and no cooldown. Supplying
       the bounds also makes `rate_distribution_from_timings` insert
       zero-weight boundary events at the window edges, so idle time at the
       head or tail of the window now participates in the rate weighting.
       Measured over a 10 s window [100, 110] on three requests of 2 prompt
       and 2 output tokens each, starting at 101, 104 and 107 and each
       emitting its first token one second in:
       `tokens_per_second.successful` keeps `count=12`, but `mean` moves
       1.7143 -> 1.2000 and `median` 2.0000 -> 1.0000. This is the weighting
       `requests_per_second` has always used, but it is new for token rates,
       so users will see token-rate averages shift on existing benchmark
       configurations.
    
    3. TTFT is now bounded by a different rule from the other per-token
       latency metrics. `time_to_first_token_ms` draws from the
       first-token-filtered lists, while `inter_token_latency_ms` and
       `time_per_output_token_ms` still draw from the whole-request-overlap
       lists, as does `request_totals`. On a warmup/cooldown run the TTFT
       distribution can therefore be built from fewer requests than the ITL
       and TPOT distributions beside it, and
       `time_to_first_token_ms.successful.count` no longer equals
       `request_totals.successful`. On the four-request scenario in the new
       test, window [100, 105]: request totals 4, TTFT count 3, ITL count 4,
       TPOT count 8 (weighted by output tokens). ITL and TPOT were left
       alone because neither is a single-event metric -- both span the whole
       generation, so how to bound them is a separate design question rather
       than a mechanical extension of this fix.
    
    Verification
    ------------
    Two regression tests were added, in a new dedicated test class:
    
      tests/unit/benchmark/schemas/test_metrics.py
    
    - `test_measurement_bounds_filter_token_events_but_not_overlapping_requests`
      drives a deterministic four-request timeline across both boundaries and
      asserts request totals, TTFT sample count, and prompt/output/combined
      token-event counts, including inclusivity at the exact bounds and the
      retained non-streaming request. With `metrics.py` restored to the base
      commit it fails with `assert 4 == 3`.
    - `test_bounds_spanning_the_run_keep_every_token_event` pins the
      no-warmup/no-cooldown case: a window spanning the whole run drops no
      token event and no TTFT sample. It passes on the base commit by
      design; it fails if the TTFT filter is tightened to drop requests with
      no `first_token_iteration`.
    
    Also run on this branch: the full unit suite (3022 passed, 31 skipped,
    163 xfailed), repo-wide `ruff format --check --diff` (372 files already
    formatted), repo-wide `ruff check` (All checks passed!),
    `import-linter lint` (Contracts: 4 kept, 0 broken),
    `mdformat --check` (silent), and `mypy --check-untyped-defs`
    (Success: no issues found in 221 source files).
    
    Assisted-by: Claude Code
    Signed-off-by: breken-ai <312387581+breken-ai@users.noreply.github.com>

---------

Assisted-by: Claude Code
Signed-off-by: breken-ai <312387581+breken-ai@users.noreply.github.com>
