### PR TITLE
fix(schemas): redact media payloads from persisted request args

### DIFF
--- a/src/guidellm/backends/openai/request_handlers.py
+++ b/src/guidellm/backends/openai/request_handlers.py
@@ -427,7 +427,7 @@ def _compile_streaming_response(
 
     return GenerationResponse(
         request_id=request.request_id,
-        request_args=arguments.model_dump_json(),
+        request_args=arguments.model_dump_persistence_json(),
         response_id=streaming_response_id,
         text=text,
         reasoning_text=reasoning_text,
@@ -592,7 +592,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             response_id=response.get("id"),  # use vLLM ID if available
             text=text,
             input_metrics=input_metrics,
@@ -642,7 +642,7 @@ class TextCompletionsRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             response_id=self.streaming_response_id,  # use vLLM ID if available
             text=text,
             input_metrics=input_metrics,
@@ -1160,7 +1160,7 @@ class ChatCompletionsRequestHandler(TextCompletionsRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             response_id=response.get("id"),  # use vLLM ID if available
             text=text,
             reasoning_text=reasoning_text,
@@ -1373,7 +1373,7 @@ class AudioRequestHandler(ChatCompletionsRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             response_id=response.get("id"),
             text=text,
             input_metrics=input_metrics,
@@ -1566,7 +1566,7 @@ class RealtimeTranscriptionWSRequestHandler(OpenAIWSRequestHandler):
         request_args = arguments.model_copy(update={"body": body or None})
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=request_args.model_dump_json(),
+            request_args=request_args.model_dump_persistence_json(),
             text=full_text,
             input_metrics=inp,
             output_metrics=outp,
@@ -1955,7 +1955,7 @@ class ResponsesRequestHandler(OpenAIRequestHandler):
 
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             response_id=response.get("id"),
             text=text,
             reasoning_text=reasoning_text,
@@ -2405,7 +2405,7 @@ class EmbeddingsRequestHandler(OpenAIRequestHandler):
         # Build response (no text output for embeddings)
         return GenerationResponse(
             request_id=request.request_id,
-            request_args=arguments.model_dump_json(),
+            request_args=arguments.model_dump_persistence_json(),
             text="",  # Embeddings don't generate text
             input_metrics=UsageMetrics(
                 text_tokens=usage.get("prompt_tokens", 0),

--- a/src/guidellm/schemas/base/request.py
+++ b/src/guidellm/schemas/base/request.py
@@ -9,10 +9,13 @@ consistent interaction with various AI generation APIs.
 
 from __future__ import annotations
 
+import re
 import uuid
+from collections.abc import Mapping
 from typing import Any, Literal
 
-from pydantic import Field, computed_field
+from pydantic import Field, ValidationError, computed_field
+from pydantic_core import to_json
 
 from guidellm.schemas.base.base import StandardBaseDict, StandardBaseModel
 from guidellm.utils.dict import deep_update
@@ -30,6 +33,115 @@ __all__ = [
     "TurnType",
     "UsageMetrics",
 ]
+
+_DEFAULT_BINARY_MIME_TYPE = "application/octet-stream"
+_MULTIPART_PAYLOAD_INDEX = 1
+_MULTIPART_MIME_INDEX = 2
+_BINARY_TYPES = (bytes, bytearray, memoryview)
+_MAX_BASE64_PADDING = 2
+_BASE64_BODY_PATTERN = re.compile(r"[A-Za-z0-9+/]*")
+
+
+def _binary_metadata(
+    value: bytes | bytearray | memoryview,
+    filename: str | None = None,
+    mime_type: str | None = None,
+) -> dict[str, int | str | None]:
+    """Describe binary persistence data without retaining its content."""
+    return {
+        "filename": filename,
+        "mime_type": mime_type or _DEFAULT_BINARY_MIME_TYPE,
+        "byte_count": value.nbytes if isinstance(value, memoryview) else len(value),
+    }
+
+
+def _multipart_metadata(value: tuple[Any, ...]) -> dict[str, int | str | None] | None:
+    """Return safe metadata for a standard multipart file tuple."""
+    if (
+        len(value) <= _MULTIPART_PAYLOAD_INDEX
+        or not isinstance(value[0], str)
+        or not isinstance(value[_MULTIPART_PAYLOAD_INDEX], _BINARY_TYPES)
+    ):
+        return None
+    mime_type = (
+        value[_MULTIPART_MIME_INDEX]
+        if len(value) > _MULTIPART_MIME_INDEX
+        and isinstance(value[_MULTIPART_MIME_INDEX], str)
+        else None
+    )
+    return _binary_metadata(value[_MULTIPART_PAYLOAD_INDEX], value[0], mime_type)
+
+
+def _base64_byte_count(value: str, start: int = 0) -> int | None:
+    """Validate Base64 and calculate decoded length without allocating payload bytes."""
+    payload_length = len(value) - start
+    if payload_length <= 0 or payload_length % 4:
+        return None
+    padding = 1 if value[-1] == "=" else 0
+    if payload_length > 1 and value[-2] == "=":
+        padding += 1
+    payload_end = len(value) - padding
+    # Match in place with pos/endpos: no slice of the payload is materialized, and
+    # the scan runs in C rather than as a per-character Python loop.
+    contains_only_base64 = (
+        _BASE64_BODY_PATTERN.fullmatch(value, start, payload_end) is not None
+    )
+    if padding > _MAX_BASE64_PADDING or not contains_only_base64:
+        return None
+    return 3 * (payload_length // 4) - padding
+
+
+def _data_url_metadata(value: str) -> dict[str, int | str | None] | None:
+    """Return safe metadata for a Base64 data URL, if applicable."""
+    if not value.startswith("data:"):
+        return None
+    comma_index = value.find(",")
+    if comma_index < 0:
+        return None
+    header = value[len("data:") : comma_index]
+    header_parts = header.split(";")
+    if not any(part.lower() == "base64" for part in header_parts[1:]):
+        return None
+    mime_type = header_parts[0] or _DEFAULT_BINARY_MIME_TYPE
+    byte_count = _base64_byte_count(value, comma_index + 1)
+    if byte_count is None:
+        return {"filename": None, "mime_type": mime_type, "byte_count": None}
+    return {"filename": None, "mime_type": mime_type, "byte_count": byte_count}
+
+
+def _sanitize_persistence_value(  # noqa: PLR0911
+    value: Any, known_inline_media: bool = False
+) -> Any:
+    """Replace persistence-only binary and inline media values recursively."""
+    if isinstance(value, _BINARY_TYPES):
+        return _binary_metadata(value)
+    if isinstance(value, tuple):
+        return _multipart_metadata(value) or [
+            _sanitize_persistence_value(item, known_inline_media) for item in value
+        ]
+    if isinstance(value, list):
+        return [_sanitize_persistence_value(item, known_inline_media) for item in value]
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): _sanitize_persistence_value(
+                item,
+                known_inline_media=(
+                    item_key == "file_data"
+                    or (item_key == "data" and "format" in value)
+                ),
+            )
+            for item_key, item in value.items()
+        }
+    if isinstance(value, str):
+        if metadata := _data_url_metadata(value):
+            return metadata
+        if known_inline_media and (byte_count := _base64_byte_count(value)) is not None:
+            return {
+                "filename": None,
+                "mime_type": _DEFAULT_BINARY_MIME_TYPE,
+                "byte_count": byte_count,
+            }
+    return value
 
 
 class GenerationRequestArguments(StandardBaseDict):
@@ -108,6 +220,29 @@ class GenerationRequestArguments(StandardBaseDict):
                 setattr(self, combine, current)
 
         return self
+
+    def model_dump_persistence_json(self) -> str:
+        """Serialize request arguments safely for persisted benchmark responses.
+
+        The transport arguments remain untouched. Binary and inline media are
+        replaced only in the persisted representation so result files do not
+        unexpectedly contain request payloads.
+
+        :return: JSON with binary payloads represented by bounded metadata.
+        """
+        sanitized = _sanitize_persistence_value(self.model_dump(mode="python"))
+
+        try:
+            revalidated = GenerationRequestArguments.model_validate(sanitized)
+        except ValidationError:
+            # Sanitizing can replace a string with a metadata mapping, which a
+            # strictly typed field such as `headers: dict[str, str]` rejects.
+            # Serialize the sanitized structure directly rather than raising on
+            # the response-compile path; only the type-preserving round trip is
+            # lost, and the payload stays redacted.
+            return to_json(sanitized, fallback=str).decode()
+
+        return revalidated.model_dump_json()
 
 
 class UsageMetrics(StandardBaseDict):

--- a/tests/unit/backends/openai/test_request_handlers.py
+++ b/tests/unit/backends/openai/test_request_handlers.py
@@ -2359,6 +2359,24 @@ class TestAudioRequestHandler:
         assert file_tuple[2] == "audio/wav"
 
     @pytest.mark.regression
+    def test_compile_non_streaming_persists_bounded_audio_metadata(
+        self, valid_instances
+    ):
+        """Persist audio upload metadata without its bytes. ## WRITTEN BY AI ##"""
+        request = GenerationRequest(columns={"audio_column": [{"audio": b"secret"}]})
+        arguments = valid_instances.format(request)
+
+        response = valid_instances.compile_non_streaming(
+            request,
+            arguments,
+            {"text": "transcript"},
+        )
+
+        assert "secret" not in response.request_args
+        assert '"byte_count":6' in response.request_args
+        assert '"filename":"audio_input"' in response.request_args
+
+    @pytest.mark.regression
     @pytest.mark.parametrize("file_name", [None, ""], ids=["missing", "empty"])
     def test_format_file_upload_defaults_nonempty_file_name(
         self,

--- a/tests/unit/schemas/test_request.py
+++ b/tests/unit/schemas/test_request.py
@@ -4,6 +4,7 @@ Unit tests for GenerationRequest, GenerationRequestArguments, and UsageMetrics.
 
 from __future__ import annotations
 
+import json
 import uuid
 
 import pytest
@@ -20,6 +21,67 @@ from guidellm.schemas import (
 
 class TestGenerationRequestArguments:
     """Test cases for GenerationRequestArguments model."""
+
+    @pytest.mark.regression
+    def test_persistence_serialization_redacts_inline_payloads(self):
+        """Persist request metadata, not media bytes. ## WRITTEN BY AI ##"""
+        arguments = GenerationRequestArguments(
+            params={
+                "remote": "https://example.test/file.wav",
+                "ordinary": "value",
+                "identifier": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            },
+            files={"upload": ("sample.wav", b"abc", "audio/wav")},
+            body={
+                "image": "data:image/png;charset=utf-8;base64,YWJj",
+                "audio": "YWJj",
+                "input_audio": {"format": "wav", "data": "YWJj"},
+                "raw": b"abc",
+            },
+        )
+
+        persisted = json.loads(arguments.model_dump_persistence_json())
+
+        assert persisted["params"] == {
+            "remote": "https://example.test/file.wav",
+            "ordinary": "value",
+            "identifier": "12345678-1234-5678-1234-567812345678",
+        }
+        assert persisted["files"]["upload"] == {
+            "filename": "sample.wav",
+            "mime_type": "audio/wav",
+            "byte_count": 3,
+        }
+        assert persisted["body"]["image"] == {
+            "filename": None,
+            "mime_type": "image/png",
+            "byte_count": 3,
+        }
+        assert persisted["body"]["audio"] == "YWJj"
+        assert persisted["body"]["input_audio"]["data"]["byte_count"] == 3
+        assert persisted["body"]["raw"]["byte_count"] == 3
+
+    @pytest.mark.regression
+    def test_persistence_serialization_survives_strictly_typed_fields(self):
+        """Redacting a strictly typed field must not raise. ## WRITTEN BY AI ##"""
+        arguments = GenerationRequestArguments(
+            headers={"X-Inline-Image": "data:image/png;base64,YWJj"},
+            body={"prompt": "hello"},
+        )
+
+        serialized = arguments.model_dump_persistence_json()
+        persisted = json.loads(serialized)
+
+        # `headers` is typed `dict[str, str]`, so a redacted header value cannot
+        # be revalidated through the model. Serialization must still succeed,
+        # must still redact, and must leave everything else intact.
+        assert persisted["headers"]["X-Inline-Image"] == {
+            "filename": None,
+            "mime_type": "image/png",
+            "byte_count": 3,
+        }
+        assert "YWJj" not in serialized
+        assert persisted["body"] == {"prompt": "hello"}
 
     @pytest.fixture(
         params=[


### PR DESCRIPTION
## Summary

Benchmark result files embed the raw request payload. If you run an audio or vision benchmark, the JSON and HTML reports GuideLLM writes contain a full copy of every image, audio clip and uploaded file you sent — Base64-encoded, verbatim, once per request. A short media benchmark can therefore produce a report far larger than the run it describes, and that report carries a copy of the input media, which is a problem the moment the report is shared, attached to an issue, or checked into a repo.

Root cause, verified in the source. `GenerationResponse.request_args` is a *persistence* field, but it was being filled from the same dump used for *transport*. Every one of the eight construction sites in the OpenAI backend called `arguments.model_dump_json()` — `src/guidellm/backends/openai/request_handlers.py` lines 430, 595, 645, 1163, 1376, 1569, 1958 and 2408. Nothing in the pipeline distinguished "send this to the server" from "write this to disk", so `bytes`/`bytearray`/`memoryview` values, multipart file tuples, Base64 `data:` URLs and provider inline-media fields all went to disk exactly as they went over the wire.

Those shapes are what the code actually produces: `src/guidellm/utils/vision.py:120` and `:269` emit `data:image/jpeg;base64,…` and `data:video/…;base64,…`, and `request_handlers.py:825-826` and `:1649` emit bare Base64 under `input_audio.data` (with a sibling `format`) and under `file_data`.

Measured on this branch, on one chat request carrying a 15360-byte inline JPEG `data:` URL and an 8192-byte inline `input_audio` clip: the serialized `request_args` value goes from **31727 bytes to 431 bytes**, with neither payload present in the output.

## Details

- [x] Add a persistence-only sanitizer to the request schema module (`src/guidellm/schemas/base/request.py:45-144`) and a `model_dump_persistence_json()` method on `GenerationRequestArguments` (`request.py:224-245`) that uses it. Transport arguments are untouched; only the persisted representation changes.
- [x] Replace binary and inline-media values with bounded metadata — `{filename, mime_type, byte_count}`. The sanitizer recognises standard multipart tuples `(name, payload, mime)`, `data:` URLs including ones with extra header parameters (`data:image/png;charset=utf-8;base64,…`), and the provider inline-media keys `file_data` and `data`-paired-with-`format`. Coverage of the last two is limited to standard, correctly-padded Base64 — see the trade-offs below.
- [x] Compute Base64 length arithmetically from the encoded string (`request.py:75-91`) rather than decoding, so a large payload is never materialised in memory just to be measured. The alphabet check is a compiled-regex `fullmatch` bounded by `pos`/`endpos`, so it scans in C and takes no slice of the payload.
- [x] Revalidate the sanitized structure through Pydantic before serializing, so non-media values keep their types and an ordinary string that merely *looks* Base64-ish outside a known media field is left alone.
- [x] Guard that revalidation (`request.py:235-243`). See the trade-off below.
- [x] Point all eight persistence call sites at the new serializer. `grep -n 'model_dump_json()' src/guidellm/backends/openai/request_handlers.py` now returns nothing.
- [x] Add three regression tests.

The diff is 4 files, 224 insertions and 9 deletions (`git diff --stat d469d0e..HEAD`).

## Trade-offs a reviewer should weigh

**1. The guarded revalidation changes JSON shape in one narrow case.** Redacting a value replaces a `str` with a mapping, and a strictly typed field rejects that. Concretely, `headers` is declared `dict[str, str]` (`request.py:164`), so a header whose value is a `data:` URL fails revalidation. Before the guard, that raised on the response-compile path:

```
ValidationError: 1 validation error for GenerationRequestArguments
headers.X-Inline-Image  Input should be a valid string
```

Rather than raise while compiling a response, the sanitized structure is then serialized directly with `pydantic_core.to_json(..., fallback=str)`. Redaction still holds — this does **not** fall back to the fat transport dump. What is lost on that path is the type-preserving round trip: field ordering and any model-level serializers are bypassed. A `data:`-URL header value is implausible in practice, which is why the guard is a safety net rather than the main path, but a maintainer may prefer a different design — e.g. skipping sanitization for `headers` entirely. That is a reasonable review comment and I will take it.

**2. `request_args` changes shape for media requests.** Affected values become metadata objects instead of raw strings. Anything downstream that parses media back out of a report will now see metadata. Text-only benchmarks are unaffected: I compared `model_dump_json()` against `model_dump_persistence_json()` across text completions, chat text, headers+params, empty arguments, and a deliberately Base64-looking prompt — byte-identical in all five.

**3. Redaction under the two bare inline-media keys is not exhaustive.** Under `file_data`, and under `data` paired with a sibling `format`, a value is redacted only if it parses as standard-alphabet, correctly-padded Base64. A URL-safe Base64 payload (using `-` and `_`), or the newline-wrapped output of `base64.encodebytes`, fails that check and is persisted verbatim. I confirmed both leak. GuideLLM's own encoders (`request_handlers.py:825-826`, `:1649`, `utils/vision.py`, `utils/audio.py`) all use standard `b64encode`, so this is not reachable through the paths this PR is written for — only through user-supplied body content. It is a real gap in the guarantee, not a hypothetical one, and I would rather state it than let the word "recognises" imply more than it delivers. Tightening it means redacting those keys unconditionally, which trades a leak for a false-positive risk on non-media values; that is the maintainer's call, and I will implement whichever you prefer.

**4. Persistence serialization costs more CPU than the transport dump**, because it walks and revalidates the arguments. This is a load-generation tool, so the number belongs in the PR body rather than in a footnote — and it needs to be measured on the media path this PR exists for, not only on text.

Measured on this branch as CPU time per call (`time.process_time`, so a busy machine does not inflate it), each figure the minimum of 7 timing repeats, and the range taken over 5 such runs:

```
perf  2 KB text body        transport  0.0013-0.0015 ms -> persisted  0.0058-0.0065 ms  (3.95-4.78x)
perf  15 KiB inline image   transport  0.0080-0.0091 ms -> persisted  0.0190-0.0226 ms  (2.33-2.71x)
perf  100 KiB inline image  transport  0.0456-0.0519 ms -> persisted  0.0812-0.0986 ms  (1.75-2.03x)
perf  1 MiB inline image    transport  0.4472-0.5127 ms -> persisted  0.7773-0.8589 ms  (1.62-1.79x)
```

The multiplier *falls* as the payload grows, because the transport dump's own Base64 copying comes to dominate. In absolute terms the added cost is a few microseconds on a text request and about **0.3 ms on a 1 MiB inline image**.

Two things a reviewer should know about where that cost lands:

- It is **synchronous inside the request coroutine** (`src/guidellm/backends/openai/http.py:313`, immediately after `request_end` is stamped), so it occupies the event loop rather than running off it. It falls outside the reported request latency, which is `request_end - request_start` (`src/guidellm/schemas/base/request_stats.py:103-114`) and is already stamped by then. It is inside the scheduler's `resolve_end` (`src/guidellm/scheduler/worker.py:497`, in `_finalize_node`), and it delays other coroutines resident on the same loop.
- It is **wasted when `sample_size <= 0`**, because `request_args` is cleared immediately afterwards (`src/guidellm/benchmark/schemas/accumulator.py:685-687`, `:715-716`). That was already true of the transport dump this replaces; this change makes the discarded work more expensive.

Getting this number honest mattered. The obvious implementation of the Base64 length check — a per-character Python loop over the encoded string — costs about **40 ms** on a 1 MiB payload on this machine, against about **0.75 ms** for the compiled-regex `fullmatch` used here. With the loop in place, the persisted dump of a 1 MiB inline image measured 37.6 ms against 0.43 ms for the transport dump, about **87×** — a serious regression on exactly the media requests this PR exists for, and one that a text-only benchmark would never have shown. The table above is what the shipped version costs.

## Test Plan

All commands run on this branch in a local venv. `tox` is not installed in this environment, so the two CI environments were run as their underlying commands, taken verbatim from `tox.ini:51-58` (`lint-check`) and `tox.ini:71-75` (`type-check`).

**New tests** — `tests/unit/schemas/test_request.py:26` and `:65`, `tests/unit/backends/openai/test_request_handlers.py:2362`.

```
$ .venv/bin/python -m pytest tests/unit/schemas/test_request.py tests/unit/backends/openai/test_request_handlers.py -q
326 passed in 2.43s

$ .venv/bin/python -m pytest tests/unit/schemas tests/unit/backends -q
1043 passed, 8 skipped in 4.26s
```

The first test covers `bytes`, a multipart upload tuple, a `data:` URL carrying an extra header parameter, the `input_audio {data, format}` shape, a remote URL, an ordinary string and a UUID. The second covers the guarded revalidation path. The third drives the real `AudioRequestHandler` format-then-compile path and asserts the raw payload is absent from the persisted arguments while `filename` and `byte_count` survive.

**Full unit suite**

```
$ .venv/bin/python -m pytest tests/unit -q
3023 passed, 31 skipped, 163 xfailed, 1 warning in 115.50s (0:01:55)
```

**Lint / format / imports / docs (`tox -e lint-check` equivalents)**

```
$ .venv/bin/ruff format --check --diff
372 files already formatted

$ .venv/bin/ruff check
All checks passed!

$ .venv/bin/lint-imports
Contracts: 4 kept, 0 broken.

$ .venv/bin/python -m mdformat --check README.md DEVELOPING.md CONTRIBUTING.md CODE_OF_CONDUCT.md docs/ src/ tests/
(no output, exit 0)
```

`lint-imports` passing confirms the new `from pydantic_core import to_json` breaks no import contract.

**Types (`tox -e type-check` equivalent)**

```
$ .venv/bin/mypy --check-untyped-defs
Success: no issues found in 221 source files

$ git diff --check d469d0e09581cf5582def8be96b0d279674476e9
(no output, exit 0)
```

**Reproducing the size figure.** The construction is deterministic, so the 31727 → 431 number can be checked directly:

```python
import base64
from guidellm.schemas.base.request import GenerationRequestArguments

image = bytes(range(256)) * 60  # 15360 bytes
audio = bytes(range(256)) * 32  # 8192 bytes
args = GenerationRequestArguments(method="POST", body={"model": "demo", "messages": [{"role": "user", "content": [
    {"type": "text", "text": "describe this"},
    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64," + base64.b64encode(image).decode()}},
    {"type": "input_audio", "input_audio": {"data": base64.b64encode(audio).decode(), "format": "wav"}},
]}]})
print(len(args.model_dump_json()), len(args.model_dump_persistence_json()))
```

```
31727 431
```

The persisted value in full, with both payloads replaced by bounded metadata:

```json
{"method":"POST","stream":null,"headers":null,"params":null,"body":{"model":"demo","messages":[{"role":"user","content":[{"type":"text","text":"describe this"},{"type":"image_url","image_url":{"url":{"filename":null,"mime_type":"image/jpeg","byte_count":15360}}},{"type":"input_audio","input_audio":{"data":{"filename":null,"mime_type":"application/octet-stream","byte_count":8192},"format":"wav"}}]}]},"files":null,"content":null}
```

The timing table above comes from the same two objects plus 15 KiB / 100 KiB / 1 MiB image-only variants, timed with `timeit.repeat(..., repeat=7)` under `timeit.default_timer = time.process_time`.

### Negative controls — the tests fail without the fix

Reverting the file outright only produces `AttributeError: 'GenerationRequestArguments' object has no attribute 'model_dump_persistence_json'`, which proves nothing about whether the tests exercise the redaction. So both controls keep the method and revert only the behaviour.

**Control 1 — the serializer body replaced with `return self.model_dump_json()`**, i.e. the exact pre-fix serialization with the API intact:

```
FAILED ...::test_persistence_serialization_redacts_inline_payloads - AssertionError: assert ['sample.wav', 'YWJj', 'audio/wav'] == {'filename': 'sample.wav', 'mime_type': 'audio/wav', 'byte_count': 3}
FAILED ...::test_persistence_serialization_survives_strictly_typed_fields - AssertionError: assert 'data:image/png;base64,YWJj' == {'filename': None, 'mime_type': 'image/png', 'byte_count': 3}
FAILED ...::test_compile_non_streaming_persists_bounded_audio_metadata - assert '"byte_count":6' in '{"method":null,"stream":null,"headers":null,"params":null,"body":{},"files":{"file":["audio_input","c2VjcmV0",null]},"content":null}'
3 failed, 323 passed in 5.00s
```

Note the third failure output: the raw payload `c2VjcmV0` sitting in the persisted `request_args`. That is precisely the defect this PR fixes, reproduced.

**Control 2 — only the `try`/`except` guard removed**, leaving a bare `GenerationRequestArguments.model_validate(sanitized).model_dump_json()`:

```
FAILED ...::test_persistence_serialization_survives_strictly_typed_fields - pydantic_core._pydantic_core.ValidationError: 1 validation error for GenerationRequestArguments
1 failed, 325 passed in 2.96s
```

So the guard is pinned by a test, not only described in prose.

The source tree was restored after each control; the final state re-runs at 326 passed.

## What was not verified

Stated plainly.

- **No live model server, no vLLM instance, no GPU.** All evidence is unit-level and deterministic.
- **No integration or e2e run.** Only `tests/unit` was executed.
- **The 31727 → 431 byte figure is one serialized `request_args` value that I constructed and measured**, not a before/after comparison of a real report file from a real audio or vision benchmark run. The direction and mechanism are certain; the end-to-end report-size saving on a real run was not measured.
- **The timing table is a single-machine microbenchmark on one laptop**, measuring the cost of one serializer call in isolation. It is not a measurement of scheduler throughput under load, and it does not prove the load generator is unaffected at high request rates or high concurrency. The machine was running other work during the measurement, which is why the figures are CPU time, minimum-of-repeats, and reported as ranges rather than single values.
- **`tox` itself was not run** — it is not installed here. I ran the exact commands its `lint-check` and `type-check` environments invoke, from the project venv. CI remains the authoritative check.
- **Only the OpenAI backend's persistence call sites were changed.** Other backends were not audited for the same pattern in this PR.

## Related Issues

- No linked issue.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

Noted below: this change was produced with AI assistance.

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Code and tests were substantially modified with Claude Code; the commit includes an `Assisted-by` trailer, and each AI-written test docstring carries the `## WRITTEN BY AI ##` marker required by `AGENTS.md`.

<!-- begin:squash-data -->

---

# git log

commit 4c77621a3dbed36ff3f6c0bd4207c9f37afc22a1
Author: breken-ai <312387581+breken-ai@users.noreply.github.com>
Date:   Thu Sep 10 10:15:36 2026 +0530

    fix(schemas): redact media payloads from persisted request args
    
    Problem
    -------
    Benchmark result artifacts embedded the raw request payload. Every
    `GenerationResponse.request_args` was produced by the same
    `model_dump_json()` used for transport, so multipart audio/image
    uploads, `bytes`/`bytearray`/`memoryview` values, Base64 `data:` URLs
    and provider inline-media fields were written verbatim into the JSON and
    HTML reports. A short audio or vision benchmark could produce a report
    far larger than the run itself, and that report carried a copy of the
    input media -- a problem when the reports are shared or attached to
    issues.
    
    Root cause
    ----------
    `request_args` is a persistence field, but it was serialized with the
    same dump used for transport, so nothing distinguished "send this to the
    server" from "write this to disk".
    
    Approach
    --------
    - Added a persistence-only sanitizer in the request schema module and a
      new persistence serializer on `GenerationRequestArguments` that uses
      it. Transport arguments are left untouched; only the persisted
      representation changes.
    - Binary and media values are replaced by bounded metadata --
      `filename`, `mime_type`, `byte_count`. The sanitizer recognises
      standard multipart tuples `(name, payload, mime)`, `data:` URLs with
      header parameters, and the provider inline-media keys `file_data` and
      `data` when paired with `format`.
    - Base64 length is computed arithmetically from the encoded string, so a
      large payload is never decoded into memory just to measure it. The
      alphabet check is a compiled-regex `fullmatch` bounded by `pos`/
      `endpos`, so it runs in C and materializes no slice of the payload; a
      per-character Python loop over the same 1 MiB payload costs about
      40 ms on this machine, against 0.75 ms for the regex.
    - Sanitized data is revalidated through Pydantic before serialization,
      so non-media values keep their types and ordinary strings that merely
      look Base64-ish outside a known media field are left alone.
    - Revalidation is guarded. Redacting a value replaces a string with a
      mapping, which a strictly typed field such as `headers: dict[str, str]`
      rejects. Rather than raising on the response-compile path, the
      sanitized structure is then serialized directly; the payload still
      stays redacted, only the type-preserving round trip is skipped.
    - All eight persistence call sites in the OpenAI backend request
      handlers now use the safe serializer.
    
    Files touched
    -------------
      src/guidellm/schemas/base/request.py
      src/guidellm/backends/openai/request_handlers.py
      tests/unit/schemas/test_request.py
      tests/unit/backends/openai/test_request_handlers.py
    
    Verification
    ------------
    Three regression tests, named in full:
    
      TestGenerationRequestArguments::test_persistence_serialization_redacts_inline_payloads
      TestGenerationRequestArguments::test_persistence_serialization_survives_strictly_typed_fields
      TestAudioRequestHandler::test_compile_non_streaming_persists_bounded_audio_metadata
    
    The first covers bytes, multipart uploads, `data:` URLs with header
    parameters, inline audio shapes, remote URLs, ordinary strings and
    UUIDs. The second covers the guarded revalidation path above. The third
    drives a real handler format-then-compile path and asserts the raw
    payload is absent from the persisted arguments while filename and byte
    count survive.
    
    Negative controls were run. With the sanitizer neutered so the
    persistence serializer returns the transport dump, all three fail. With
    only the revalidation guard removed, the strictly-typed-field test fails
    with a `ValidationError`.
    
    Also run on this branch: the full unit suite (3023 passed, 31 skipped,
    163 xfailed), repo-wide `ruff format --check --diff` (372 files already
    formatted), repo-wide `ruff check` (All checks passed!),
    `import-linter lint` (Contracts: 4 kept, 0 broken),
    `mdformat --check` (silent), and `mypy --check-untyped-defs`
    (Success: no issues found in 221 source files).
    
    Impact
    ------
    Reports no longer contain request media. Measured on this branch, on one
    chat request carrying a 15360-byte inline JPEG `data:` URL and an
    8192-byte inline `input_audio` clip, the serialized `request_args` goes
    from 31727 bytes to 431 bytes, with neither payload present in the
    output.
    
    Cost. Persistence serialization walks and revalidates the arguments, so
    it costs more CPU than the transport dump it replaces. Measured on this
    branch as CPU time per call (`time.process_time`), each figure the
    minimum of 7 timing repeats and the range taken over 5 such runs:
    
      2 KB text body        0.0013-0.0015 ms -> 0.0058-0.0065 ms  (3.95-4.78x)
      15 KiB inline image   0.0080-0.0091 ms -> 0.0190-0.0226 ms  (2.33-2.71x)
      100 KiB inline image  0.0456-0.0519 ms -> 0.0812-0.0986 ms  (1.75-2.03x)
      1 MiB inline image    0.4472-0.5127 ms -> 0.7773-0.8589 ms  (1.62-1.79x)
    
    The multiplier falls as the payload grows, because the transport dump's
    own Base64 copying comes to dominate. In absolute terms the added cost
    is a few microseconds on a text request and about 0.3 ms on a 1 MiB
    inline image. This work runs synchronously inside the request coroutine
    (`src/guidellm/backends/openai/http.py:313`, immediately after
    `request_end` is stamped), so it occupies the event loop rather than
    running off it. This is a load-generation tool, so that is stated
    plainly rather than left in a footnote.
    
    The added work is also wasted when `sample_size <= 0`, since
    `request_args` is cleared immediately afterwards
    (`src/guidellm/benchmark/schemas/accumulator.py:685-687` and
    `:715-716`). That was already true of the transport dump this replaces;
    this change makes the discarded work more expensive.
    
    This changes the shape of `request_args` for media requests: the
    affected values become metadata objects instead of raw strings. Anything
    downstream that parses media out of a report will see metadata instead.
    Text-only benchmarks produce byte-identical output.
    
    Known limitation: under the inline-media keys, a payload that is not
    standard-alphabet, correctly-padded Base64 -- URL-safe Base64, or the
    newline-wrapped output of `base64.encodebytes` -- fails the length check
    and is persisted verbatim. GuideLLM's own encoders always emit standard
    Base64, so this is reachable only through user-supplied body content.
    
    Assisted-by: Claude Code
    Signed-off-by: breken-ai <312387581+breken-ai@users.noreply.github.com>

---------

Assisted-by: Claude Code
Signed-off-by: breken-ai <312387581+breken-ai@users.noreply.github.com>
