### PR TITLE
Fix CI by making replay test deterministic

### DIFF
--- a/tests/integration/scheduler/test_trace_replay_multiprocess.py
+++ b/tests/integration/scheduler/test_trace_replay_multiprocess.py
@@ -148,12 +148,17 @@ def _requests_from_trace(
 class FastMockBackend(BackendInterface):
     """Backend with short resolve delay to exercise multiprocess dequeue."""
 
-    def __init__(self, resolve_delay: float = RESOLVE_DELAY):
+    def __init__(
+        self,
+        resolve_delay: float = RESOLVE_DELAY,
+        processes_limit: int | None = None,
+    ):
         self._resolve_delay = resolve_delay
+        self._processes_limit = processes_limit
 
     @property
     def processes_limit(self) -> int | None:
-        return None
+        return self._processes_limit
 
     @property
     def requests_limit(self) -> int | None:
@@ -320,34 +325,71 @@ def _linear_replay_graph(
 async def test_max_duration_cancels_long_replay_sleep():
     """max_duration stops workers sleeping on a future relative_timestamp.
 
-    Use two independent graphs so the delayed request is sleeping from t=0.
-    A linear parent-child graph only starts that sleep after the first request
-    finishes, which on a loaded runner can let both complete before cancel.
+    Arm duration only after the delayed request is ``pending`` (sleep started)
+    so cancel is sequenced from that event, not by racing two wall-clocks.
+    The timestamp is far enough that the request cannot complete first.
 
     ## WRITTEN BY AI ##
     """
-    immediate = _linear_replay_graph([0.0], graph_id="immediate", request_prefix="imm")
-    delayed = _linear_replay_graph([5.0], graph_id="delayed", request_prefix="del")
+    delayed_id = "del_0"
+    delayed = _linear_replay_graph(
+        [1_000_000.0], graph_id="delayed", request_prefix="del"
+    )
     strategy = TraceReplayStrategy(time_scale=1.0)
     group = WorkerProcessGroup(
-        backend=FastMockBackend(resolve_delay=RESOLVE_DELAY),
-        requests=[immediate, delayed],
+        backend=FastMockBackend(resolve_delay=RESOLVE_DELAY, processes_limit=1),
+        requests=[delayed],
         strategy=strategy,
-        max_duration=MaxDurationConstraint(args=MaxDurationConstraintArgs(seconds=0.4)),
     )
-    statuses: set[str] = set()
+    statuses_by_request: dict[str, list[str]] = {}
+    duration_armed = False
+    cancelled_count = 0
     try:
         await group.create_processes()
-        await group.start(time.time() + 0.05)
-        run_started = time.time()
+        await group.start(time.time())
         async for _, _, request_info, _state in group.request_updates():
-            statuses.add(request_info.status)
-            if "cancelled" in statuses:
+            statuses_by_request.setdefault(request_info.request_id, []).append(
+                request_info.status
+            )
+            if (
+                not duration_armed
+                and request_info.request_id == delayed_id
+                and request_info.status == "pending"
+            ):
+                # Sleep is in flight. Attach an already-elapsed duration and
+                # signal workers the same way the coordinator poll loop would.
+                duration_armed = True
+                assert group.state is not None
+                state_update = group.state.update_state(
+                    add_constraints={
+                        "max_duration": MaxDurationConstraint(
+                            args=MaxDurationConstraintArgs(seconds=1e-9)
+                        )
+                    }
+                )
+                if (
+                    state_update.stop_processing
+                    and group.constraint_reached_event is not None
+                ):
+                    group.constraint_reached_event.set()
+            if request_info.status == "cancelled":
                 break
-        elapsed = time.time() - run_started
+        if group.state is not None:
+            # received_callback may record cancel before this iterator yields it
+            cancelled_count = group.state.update_state().state.cancelled_requests
     finally:
         exceptions = await group.shutdown()
         assert exceptions == []
 
-    assert "cancelled" in statuses
-    assert elapsed < 2.5
+    delayed_statuses = statuses_by_request.get(delayed_id, [])
+    assert duration_armed, (
+        f"delayed request never reached pending; statuses={statuses_by_request}"
+    )
+    assert "cancelled" in delayed_statuses or cancelled_count >= 1, (
+        f"expected cancelled for {delayed_id}; statuses={statuses_by_request} "
+        f"cancelled_requests={cancelled_count}"
+    )
+    assert "completed" not in delayed_statuses, (
+        f"delayed request completed instead of cancelling; "
+        f"statuses={statuses_by_request}"
+    )


### PR DESCRIPTION
## Summary

Makes the test less time dependent. I was able to confirm that the original test failed locally when I fully deprioritized the process.

It also makes it run as one worker to also help make it be more deterministic.

This prioritizes just making the test more tolerant of slow machines rather than making the scheduler more quick to cancel on slow machines, which is basically how #1103 worked. Now the _test_ polls.

## Test Plan

Review the code and see if it passes CI.

## Related Issues

- Closes #1103 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit fce0ad5d34d2648bd9fb0e98b01b69c7947dd929
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Sep 10 12:51:13 2026 -0400

    Make replay test deterministic
    
    The new design does not rely as much on timing assumptions.
    
    Generated-by: Cursor AI Grok 4.6
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
