### PR TITLE
Add logic for global and local hash IDs for trace formats

### DIFF
--- a/docs/guides/trace_replay.md
+++ b/docs/guides/trace_replay.md
@@ -86,7 +86,12 @@ The WEKA format expects a column with conversation UUIDs that is not wrapped wit
 
 Similar to Mooncake, WEKA uses prefix-based cache hash IDs. The original [specification](https://github.com/callanjfox/agentic-coding-analysis/blob/master/docs/TRACE_FORMAT.md) for the trace requires hash IDs to be 1 or greater, and for trailing hash IDs to be dropped if there are not enough input tokens to fill the hash ID block size. To accommodate for datasets which may not follow the specification exactly (ex. [semianalysisai/cc-traces-weka-no-subagents-051226](https://huggingface.co/datasets/semianalysisai/cc-traces-weka-no-subagents-051226)), GuideLLM will accept any non-negative integer as a valid hash ID, and will drop partially filled hash IDs if they exist.
 
-GuideLLM will generate prompts starting from the first conversation. When the conversation ends, the next conversation will be used. Hash IDs and relative timestamps are local to the conversation. After a conversation ends, the hash ID tree is reset and the relative timestamp returns to 0.0.
+GuideLLM will generate prompts starting from the first conversation. When the conversation ends, the next conversation will be used. Relative timestamps are local to the conversation and return to 0.0 after each conversation ends.
+
+Hash IDs follow the per-row `hash_id_scope` field:
+
+- `"global"` or omitted: hash IDs share one token-block table across conversations, matching Mooncake. The same hash ID in a later conversation reuses the earlier token block so prefix-cache hit rate stays close to the original trace.
+- `"local"`: hash IDs apply only within that conversation. The table is discarded after the conversation is emitted.
 
 Declared `type: "subagent"` entries become isolated child chains. Each child spawns from the preceding parent API turn with a fresh history (`history_context="new"`) and the following parent turn waits for every sibling spawned since that turn (`history_context="last"`). Multiple subagents listed between the same parent turns therefore run in parallel; the parent resumes only after all of them complete. Request-list order is preserved at every nesting level (it is the spawn/join topology) and is not sorted by timestamp.
 

--- a/src/guidellm/data/deserializers/__init__.py
+++ b/src/guidellm/data/deserializers/__init__.py
@@ -40,6 +40,7 @@ from .trace_common import (
     create_distinct_token_block,
     create_prompt_from_hash_ids,
     decode_prompt,
+    fill_hash_id_table,
     generate_token_ids,
     get_missing_columns,
 )
@@ -79,6 +80,7 @@ __all__ = [
     "create_distinct_token_block",
     "create_prompt_from_hash_ids",
     "decode_prompt",
+    "fill_hash_id_table",
     "generate_token_ids",
     "get_missing_columns",
 ]

--- a/src/guidellm/data/deserializers/trace_common.py
+++ b/src/guidellm/data/deserializers/trace_common.py
@@ -7,7 +7,7 @@ requested input_length for replay benchmarks."""
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Protocol
 
 import numpy as np
@@ -44,6 +44,7 @@ __all__ = [
     "create_distinct_token_block",
     "create_prompt_from_hash_ids",
     "decode_prompt",
+    "fill_hash_id_table",
     "generate_token_ids",
     "get_missing_columns",
 ]
@@ -119,6 +120,42 @@ def create_distinct_token_block(
     raise ValueError(
         f"Failed to generate distinct synthetic token block after {attempt} attempts"
     )
+
+
+def fill_hash_id_table(
+    ids: Sequence[int],
+    hash_id_table: dict[int, tuple[int, ...]],
+    sibling_token_blocks: dict[Any, set[tuple[int, ...]]],
+    processor: PreTrainedTokenizerBase,
+    faker: Faker,
+    tokens_for_hash_id: Callable[[int, int], int],
+) -> None:
+    """Ensure each id has a distinct sibling-aware token block in ``hash_id_table``.
+
+    Unseen hash IDs are allocated with :func:`create_distinct_token_block` so
+    siblings under the same previous id receive different token blocks.
+    Existing entries are left unchanged.
+
+    :param ids: Ordered hash IDs for one prompt.
+    :param hash_id_table: Mapping of hash ID to token block. Mutated in place.
+    :param sibling_token_blocks: Token blocks already used per previous hash ID.
+        Mutated in place.
+    :param processor: Tokenizer used to generate synthetic token blocks.
+    :param faker: Random text source for synthetic tokens.
+    :param tokens_for_hash_id: ``(idx, hash_id) -> block size`` for unseen IDs.
+    """
+    for idx, hash_id in enumerate(ids):
+        if hash_id not in hash_id_table:
+            prev_id = None if idx == 0 else ids[idx - 1]
+            sibling_token_blocks.setdefault(prev_id, set())
+            block = create_distinct_token_block(
+                tokens_for_hash_id(idx, hash_id),
+                sibling_token_blocks[prev_id],
+                processor,
+                faker,
+            )
+            hash_id_table[hash_id] = block
+            sibling_token_blocks[prev_id].add(block)
 
 
 class TraceFormatBase(Protocol):

--- a/src/guidellm/data/deserializers/trace_mooncake.py
+++ b/src/guidellm/data/deserializers/trace_mooncake.py
@@ -24,8 +24,8 @@ from guidellm.data.deserializers.trace_common import (
     TraceDatasetDeserializer,
     TraceFormatBase,
     TraceFormatRegistry,
-    create_distinct_token_block,
     create_prompt_from_hash_ids,
+    fill_hash_id_table,
     get_missing_columns,
 )
 from guidellm.data.schemas import InvalidRowError
@@ -99,18 +99,14 @@ class MooncakeTraceFormat(TraceFormatBase):
         """Before generating the prompt, this first generates a block of tokens for
         each hash ID that has not already been seen."""
         ids = row[self.config.hash_ids_column]
-        for idx, hash_id in enumerate(ids):
-            if hash_id not in self.hash_id_table:
-                prev_id = None if idx == 0 else ids[idx - 1]
-                num_tokens = _calculate_required_prompt_tokens(
-                    self.config, row, hash_id
-                )
-                self.sibling_token_blocks.setdefault(prev_id, set())
-                self.hash_id_table[hash_id] = create_distinct_token_block(
-                    num_tokens,
-                    self.sibling_token_blocks[prev_id],
-                    processor,
-                    faker,
-                )
-                self.sibling_token_blocks[prev_id].add(self.hash_id_table[hash_id])
+        fill_hash_id_table(
+            ids,
+            self.hash_id_table,
+            self.sibling_token_blocks,
+            processor,
+            faker,
+            lambda _idx, hash_id: _calculate_required_prompt_tokens(
+                self.config, row, hash_id
+            ),
+        )
         return create_prompt_from_hash_ids(ids, self.hash_id_table, processor)

--- a/src/guidellm/data/deserializers/trace_weka.py
+++ b/src/guidellm/data/deserializers/trace_weka.py
@@ -36,9 +36,9 @@ from guidellm.data.deserializers.trace_common import (
     TraceFormatBase,
     TraceFormatRegistry,
     _validate_api_row,
-    create_distinct_token_block,
     create_prompt_from_hash_ids,
     decode_prompt,
+    fill_hash_id_table,
     generate_token_ids,
     get_missing_columns,
 )
@@ -214,7 +214,9 @@ class WEKATraceFormat(TraceFormatBase):
     blocks in a prompt. The relationships of IDs forms a tree, where every first ID
     in a prompt has a parent node of `None`. Parent nodes can have an unbounded
     number of children. Two hash IDs can represent identical blocks of tokens so long
-    as they do not share the same parent (previous ID).
+    as they do not share the same parent (previous ID). Per-row ``hash_id_scope``
+    of ``"global"`` or omitted shares that table across conversations; ``"local"``
+    isolates it to the current conversation.
 
     Declared ``type: "subagent"`` groups become isolated child chains that
     spawn from the preceding parent API turn (``history_context="new"``) and
@@ -244,7 +246,7 @@ class WEKATraceFormat(TraceFormatBase):
         self.sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
         # Filled by each ``__iter__`` pass so mixed subagent/API schemas are
         # not forced through a single HuggingFace Arrow table.
-        self._conversations: list[tuple[str, list[dict[str, Any]]]] = []
+        self._conversations: list[tuple[str, list[dict[str, Any]], str | None]] = []
         self._tools_json = _serialized_tools(config.tools)
         self._tool_response_sampler: Iterator[int] | None = None
         self.requests_col = _find_requests_column(dataset)
@@ -260,13 +262,11 @@ class WEKATraceFormat(TraceFormatBase):
             # File order is spawn/join topology for every request list,
             # including nested subagent groups. Do not sort by timestamp.
             requests = [dict(item) for item in row[self.requests_col]]
+            raw_scope = row.get("hash_id_scope")
+            hash_id_scope = str(raw_scope) if raw_scope is not None else None
             index = len(self._conversations)
-            self._conversations.append((conv_id, requests))
+            self._conversations.append((conv_id, requests, hash_id_scope))
             yield Dataset.from_dict({"_weka_index": [index]})
-
-    def reset(self) -> None:
-        self.hash_id_table = {}
-        self.sibling_token_blocks = {}
 
     def required_columns(self) -> Features:
         return Features(
@@ -312,32 +312,45 @@ class WEKATraceFormat(TraceFormatBase):
             )
 
     def create_prompt(
-        self, row: dict, processor: PreTrainedTokenizerBase, faker: Faker
+        self,
+        row: dict,
+        processor: PreTrainedTokenizerBase,
+        faker: Faker,
+        hash_id_table: dict[int, tuple[int, ...]] | None = None,
+        sibling_token_blocks: dict[Any, set[tuple[int, ...]]] | None = None,
     ) -> str:
         """Before generating the prompt, this first generates a block of tokens for
         each hash ID that has not already been seen.
 
         Hash IDs that are partially filled are discarded to match the specification.
         Remainder of the prompt is created after the creation via hash IDs token
-        blocks."""
+        blocks.
+
+        :param hash_id_table: Token blocks keyed by hash ID. Instance storage for
+            global scope, or a throwaway dict for local scope. Defaults to the
+            instance table.
+        :param sibling_token_blocks: Distinctness set per previous hash ID, matching
+            ``hash_id_table``'s lifetime. Defaults to the instance set.
+        """
+        if hash_id_table is None:
+            hash_id_table = self.hash_id_table
+        if sibling_token_blocks is None:
+            sibling_token_blocks = self.sibling_token_blocks
         ids = row[self.config.hash_ids_column]
         n_in = row[self.config.prompt_tokens_column]
         block_size = self.config.hash_id_block_size
         expected = n_in / block_size
         if math.floor(expected) != len(ids) and math.ceil(expected) == len(ids):
             ids.pop()
-        for idx, hash_id in enumerate(ids):
-            if hash_id not in self.hash_id_table:
-                prev_id = None if idx == 0 else ids[idx - 1]
-                self.sibling_token_blocks.setdefault(prev_id, set())
-                self.hash_id_table[hash_id] = create_distinct_token_block(
-                    block_size,
-                    self.sibling_token_blocks[prev_id],
-                    processor,
-                    faker,
-                )
-                self.sibling_token_blocks[prev_id].add(self.hash_id_table[hash_id])
-        prompt = create_prompt_from_hash_ids(ids, self.hash_id_table, processor)
+        fill_hash_id_table(
+            ids,
+            hash_id_table,
+            sibling_token_blocks,
+            processor,
+            faker,
+            lambda _idx, _hash_id: block_size,
+        )
+        prompt = create_prompt_from_hash_ids(ids, hash_id_table, processor)
         remainder = _generate_remaining_prompt(n_in % block_size, processor, faker)
         if not prompt:
             return remainder
@@ -351,7 +364,15 @@ class WEKATraceFormat(TraceFormatBase):
         processor: PreTrainedTokenizerBase,
         faker: Faker,
     ) -> ConversationGraphData:
-        conv_id, requests = self._unpack_conversation(conversation)
+        conv_id, requests, hash_id_scope = self._unpack_conversation(conversation)
+        # Local scope uses throwaway tables so this conversation cannot reuse
+        # or pollute the instance-level hash storage used by global/unset rows.
+        if hash_id_scope == "local":
+            hash_id_table: dict[int, tuple[int, ...]] = {}
+            sibling_token_blocks: dict[Any, set[tuple[int, ...]]] = {}
+        else:
+            hash_id_table = self.hash_id_table
+            sibling_token_blocks = self.sibling_token_blocks
         specs, _last = self._emit_chain(
             requests,
             agent_id="default",
@@ -370,7 +391,13 @@ class WEKATraceFormat(TraceFormatBase):
         turns: list[ConversationTurnData] = []
         for spec in specs:
             _validate_api_row(spec.row, self.config, self.validate_row)
-            prompt = self.create_prompt(spec.row, processor, faker)
+            prompt = self.create_prompt(
+                spec.row,
+                processor,
+                faker,
+                hash_id_table,
+                sibling_token_blocks,
+            )
             columns: dict[str, Any] = {
                 "text_column": [prompt],
                 "prompt_tokens_count_column": [
@@ -427,22 +454,23 @@ class WEKATraceFormat(TraceFormatBase):
 
     def _unpack_conversation(
         self, conversation: Dataset
-    ) -> tuple[str, list[dict[str, Any]]]:
+    ) -> tuple[str, list[dict[str, Any]], str | None]:
         """Look up the nested request list for a conversation stub from ``__iter__``.
 
         The ``requests`` column mixes API request records with
         ``type: "subagent"`` groups, which cannot share one Arrow schema, so
         ``__iter__`` does not put that list into the yielded Dataset. It
-        appends ``(conversation_id, requests)`` to ``self._conversations``
-        and yields a Dataset with a single row and a single column,
-        ``_weka_index``.
+        appends ``(conversation_id, requests, hash_id_scope)`` to
+        ``self._conversations`` and yields a Dataset with a single row and a
+        single column, ``_weka_index``.
 
         ``conversation[0]`` is the only row in the yielded Dataset.
         ``_weka_index`` is the integer index of the matching entry in
         ``self._conversations``.
 
         :param conversation: One-row Dataset yielded by ``__iter__``.
-        :return: ``(conversation_id, requests)`` for that conversation.
+        :return: ``(conversation_id, requests, hash_id_scope)`` for that
+            conversation. ``hash_id_scope`` is ``None`` when the field is omitted.
         """
         index = int(conversation[0]["_weka_index"])
         return self._conversations[index]

--- a/tests/unit/data/deserializers/test_trace_weka.py
+++ b/tests/unit/data/deserializers/test_trace_weka.py
@@ -552,9 +552,63 @@ class TestWEKATraceFormat:
         assert timestamps2[0] == 0.0
 
     @pytest.mark.sanity
-    def test_multi_conversation_resets_hash_id_state(
+    @pytest.mark.parametrize("hash_id_scope", [None, "global"])
+    def test_multi_conversation_global_hash_id_scope_reuses_blocks(
+        self,
+        tmp_path: Path,
+        deserializer,
+        default_block_size,
+        hash_id_scope: str | None,
+    ):
+        """Unset and explicit global scope share hash ID token blocks across
+        conversations.
+
+        ## WRITTEN BY AI ##
+        """
+        n_rows = 2
+        n_virtual_rows = 2
+        n_in = default_block_size * 2
+        non_wrapper = [TraceColumnGenerator("id", lambda i: f'"conv{i}"')]
+        if hash_id_scope is not None:
+            non_wrapper.append(
+                TraceColumnGenerator("hash_id_scope", lambda _: f'"{hash_id_scope}"')
+            )
+        trace = write_trace(
+            tmp_path,
+            generate_weka_trace(
+                n_rows,
+                n_virtual_rows,
+                non_wrapper,
+                [
+                    TraceColumnGenerator("t", lambda i: i),
+                    TraceColumnGenerator("in", lambda _: n_in),
+                    TraceColumnGenerator("out", lambda _: 5),
+                    TraceColumnGenerator("hash_ids", lambda i: [1, i + 2]),
+                ],
+            ),
+        )
+        ds = deserializer(
+            config=WEKATraceFormatArgs(source=trace_file_source(trace)),
+            processor_factory=compatible_processor,
+            random_seed=42,
+        )
+        ds_iter = iter(ds)
+        conv1 = load_graph_turns(next(ds_iter))
+        conv2 = load_graph_turns(next(ds_iter))
+        prompts1 = [turn.columns["text_column"][0] for turn in conv1]
+        prompts2 = [turn.columns["text_column"][0] for turn in conv2]
+        root_blocks = [prompt[: n_in // 2] for prompt in prompts1 + prompts2]
+        assert all_equal(root_blocks)
+        assert prompts1 == prompts2
+
+    @pytest.mark.sanity
+    def test_multi_conversation_local_hash_id_scope_isolates_blocks(
         self, tmp_path: Path, deserializer, default_block_size
     ):
+        """Local scope discards hash ID token blocks after each conversation.
+
+        ## WRITTEN BY AI ##
+        """
         n_rows = 2
         n_virtual_rows = 2
         n_in = default_block_size * 2
@@ -563,7 +617,10 @@ class TestWEKATraceFormat:
             generate_weka_trace(
                 n_rows,
                 n_virtual_rows,
-                [TraceColumnGenerator("id", lambda i: f'"conv{i}"')],
+                [
+                    TraceColumnGenerator("id", lambda i: f'"conv{i}"'),
+                    TraceColumnGenerator("hash_id_scope", lambda _: '"local"'),
+                ],
                 [
                     TraceColumnGenerator("t", lambda i: i),
                     TraceColumnGenerator("in", lambda _: n_in),
@@ -583,6 +640,42 @@ class TestWEKATraceFormat:
         prompts1 = [turn.columns["text_column"][0] for turn in conv1]
         prompts2 = [turn.columns["text_column"][0] for turn in conv2]
         assert prompts1[0] != prompts2[0]
+        assert prompts1[0][: n_in // 2] == prompts1[1][: n_in // 2]
+
+    @pytest.mark.regression
+    def test_mixed_hash_id_scopes(self, tmp_path: Path) -> None:
+        """Global hashes survive local rows, whose turns share only local hashes.
+
+        ## WRITTEN BY AI ##
+        """
+        rows = []
+        for index, scope in enumerate(["global", "local", None, "local", "global"]):
+            row = {
+                "id": f"conv{index}",
+                "requests": [
+                    {"t": turn, "in": 4, "out": 2, "hash_ids": [1]} for turn in range(2)
+                ],
+            }
+            if scope is not None:
+                row["hash_id_scope"] = scope
+            rows.append(row)
+        trace = write_trace(tmp_path, "\n".join(json.dumps(row) for row in rows))
+        dataset = DatasetDeserializerFactory.deserialize(
+            config=WEKATraceFormatArgs(
+                source=trace_file_source(trace), hash_id_block_size=4
+            ),
+            processor_factory=compatible_processor,
+            random_seed=42,
+        )
+        prompts = [
+            [turn.columns["text_column"][0] for turn in load_graph_turns(row)]
+            for row in dataset
+        ]
+        assert all(first == second for first, second in prompts)
+        assert prompts[0] == prompts[2] == prompts[4]
+        assert prompts[1] != prompts[0]
+        assert prompts[3] != prompts[0]
+        assert prompts[1] != prompts[3]
 
     @pytest.mark.sanity
     def test_zero_prompt_tokens_empty_hash_ids(self, tmp_path: Path, deserializer):


### PR DESCRIPTION
## Summary

Add logic for the trace format to specify global or local hash IDs for each conversation

## Details

- Also consolidates some redundant logic
- Also updates documentation.
- I utilized some test logic from #1117 

## Test Plan

The tests should handle it well enough. It's not easy to gain insights into the hash IDs otherwise.

## Related Issues

- Closes #1117 

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit e16676b7b499203da496e8bc3b0e73447f241ffd
Author: Jared O'Connell <joconnel@redhat.com>
Date:   Thu Sep 10 16:21:00 2026 -0400

    Add logic for global and local hash IDs for trace formats
    
    Generated-by: Cursor AI Grok 4.6
    Co-authored-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
    Signed-off-by: Jared O'Connell <joconnel@redhat.com>

---------

Co-authored-by: git-jxj <65210887+git-jxj@users.noreply.github.com>
Generated-by: Cursor AI Grok 4.6
Signed-off-by: Jared O'Connell <joconnel@redhat.com>
