### PR TITLE
Do not default to sweep profile

### DIFF
--- a/src/guidellm/schemas/benchmark/entrypoints.py
+++ b/src/guidellm/schemas/benchmark/entrypoints.py
@@ -164,7 +164,6 @@ class BenchmarkArgs(ReloadableBaseModel):
         json_schema_extra={"argument_alias": "backend"},
     )
     profile: ProfileArgs = Field(  # type: ignore[assignment]
-        default_factory=lambda: default_kind("sweep"),
         description="Profile configuration to control benchmark execution.",
         examples=[{"kind": "sweep", "sweep_size": [10.0]}],
         json_schema_extra={"argument_alias": "profile"},


### PR DESCRIPTION
## Summary

Defaulting a profile is more confusing than it is helpful. The user should have to be more active in determining what profile they want to run.

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [ ] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

> NOTE: the `Generated-by` or `Assisted-by` trailers should be used in git commit messages when code or tests were generated or substantially modified by an AI agent, as described in the project's [`DEVELOPING.md`](https://github.com/vllm-project/guidellm/blob/main/DEVELOPING.md) file.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit a93d5d2ac0e726c3677876519fb27fd06240a7ac
Author: Samuel Monson <smonson@redhat.com>
Date:   Thu Sep 10 16:27:39 2026 -0400

    Drop the default to sweep profile
    
    Defaulting a profile is more confusing than it is helpful. The user
    should have to be more active in determining what profile they want to
    run.
    
    Signed-off-by: Samuel Monson <smonson@redhat.com>

---------

Signed-off-by: Samuel Monson <smonson@redhat.com>
