### PR TITLE
Add RTF and RTFx metrics for audio workloads

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -103,6 +103,16 @@ Dispatch Delay and Scheduled Latency only apply to some of the scheduling strate
 - **Definition**: For the WebSocket backend, the mean of received-token timestamps minus the mean of sent-packet timestamps.
 - **Use Case**: Estimates the average send-to-receive lag across a request. It is approximate, since it assumes sent packets and received tokens line up evenly in time.
 
+### Real-Time Factor (RTF)
+
+- **Definition**: For audio workloads such as transcription, the ratio of end-to-end request latency to the duration of the input audio. A value of 0.25 means a 60-second recording was transcribed in 15 seconds.
+- **Use Case**: The standard measure of transcription speed. Values below 1.0 mean the server keeps up with real-time audio; values above 1.0 mean it falls behind, so a live stream would back up. Reported only for requests carrying input audio.
+
+### Inverse Real-Time Factor (RTFx)
+
+- **Definition**: The reciprocal of RTF, expressing how many seconds of audio are processed per second of wall-clock time.
+- **Use Case**: The same measurement expressed so that higher is better, which is how transcription throughput is usually quoted. An RTFx of 4.0 means the server processes audio four times faster than real time.
+
 ## Statistical Summaries
 
 GuideLLM provides detailed statistical summaries for each of the above metrics using the `StatusDistributionSummary` and `DistributionSummary` models. These summaries include the following statistics:

--- a/src/guidellm/benchmark/outputs/console.py
+++ b/src/guidellm/benchmark/outputs/console.py
@@ -228,6 +228,7 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
         self.print_image_table(report)
         self.print_video_table(report)
         self.print_audio_table(report)
+        self.print_audio_latency_table(report)
         self.print_tool_call_table(report)
         self.print_request_counts_table(report)
         self.print_request_latency_table(report)
@@ -362,6 +363,51 @@ class GenerativeBenchmarkerConsole(GenerativeBenchmarkerOutput):
                 ("seconds", "Seconds"),
                 ("bytes", "Bytes"),
             ],
+        )
+
+    def print_audio_latency_table(self, report: GenerativeBenchmarksReport):
+        """
+        Print Real-Time Factor metrics, if any benchmark processed input audio.
+
+        Skipped entirely for workloads without input audio, where RTF is
+        undefined.
+
+        :param report: The benchmark report containing audio metrics
+        """
+        if not any(
+            benchmark.metrics.audio.real_time_factor is not None
+            for benchmark in report.benchmarks
+        ):
+            return
+
+        columns = ConsoleTableColumnsCollection()
+
+        for benchmark in report.benchmarks:
+            columns.add_value(
+                benchmark.config.strategy.type_,
+                group="Benchmark",
+                name="Strategy",
+                type_="text",
+            )
+            columns.add_stats(
+                benchmark.metrics.audio.real_time_factor,
+                group="RTF",
+                name="Ratio",
+                precision=3,
+            )
+            columns.add_stats(
+                benchmark.metrics.audio.inverse_real_time_factor,
+                group="RTFx",
+                name="Ratio",
+                precision=3,
+            )
+
+        headers, values = columns.get_table_data()
+        self.console.print("\n")
+        self.console.print_table(
+            headers,
+            values,
+            title="Audio Real-Time Factor (Completed Requests)",
         )
 
     def print_tool_call_table(self, report: GenerativeBenchmarksReport):

--- a/src/guidellm/benchmark/outputs/csv.py
+++ b/src/guidellm/benchmark/outputs/csv.py
@@ -611,6 +611,27 @@ class GenerativeBenchmarkerCSV(GenerativeBenchmarkerOutput):
                     io_type.capitalize(),
                 )
 
+        # Real-Time Factor is a single per-request ratio rather than an
+        # input/output/total triple, so it is emitted outside the loop above.
+        if modality == "audio":
+            for metric_name, display_name in (
+                ("real_time_factor", "RTF"),
+                ("inverse_real_time_factor", "RTFx"),
+            ):
+                dist_summary = getattr(modality_summary, metric_name, None)
+                if dist_summary is None or not self._has_distribution_data(
+                    dist_summary
+                ):
+                    continue
+
+                self._add_stats_for_metric(
+                    headers,
+                    values,
+                    dist_summary,
+                    f"Audio {display_name}",
+                    "Ratio",
+                )
+
     def _has_distribution_data(self, dist_summary: StatusDistributionSummary) -> bool:
         """
         Check if distribution summary contains any data.

--- a/src/guidellm/benchmark/schemas/metrics.py
+++ b/src/guidellm/benchmark/schemas/metrics.py
@@ -11,6 +11,7 @@ performance metrics for request processing and queueing behavior.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Literal
 
 from pydantic import Field
@@ -655,6 +656,22 @@ class GenerativeAudioMetricsSummary(StandardBaseDict):
     bytes: GenerativeMetricsSummary | None = Field(
         description="Byte size metrics and distributions"
     )
+    real_time_factor: StatusDistributionSummary | None = Field(
+        default=None,
+        description=(
+            "Distribution of Real-Time Factor (RTF), the ratio of processing "
+            "time to input audio duration. Values below 1.0 are faster than "
+            "real time. None when no request carried input audio."
+        ),
+    )
+    inverse_real_time_factor: StatusDistributionSummary | None = Field(
+        default=None,
+        description=(
+            "Distribution of inverse Real-Time Factor (RTFx), the seconds of "
+            "audio processed per second of wall-clock time. Values above 1.0 "
+            "are faster than real time. None when no request carried input audio."
+        ),
+    )
 
     @classmethod
     def compile(
@@ -696,6 +713,53 @@ class GenerativeAudioMetricsSummary(StandardBaseDict):
                 incomplete=incomplete,
                 errored=errored,
             ),
+            real_time_factor=cls._compile_ratio(
+                lambda req: req.real_time_factor,
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+            inverse_real_time_factor=cls._compile_ratio(
+                lambda req: req.inverse_real_time_factor,
+                successful=successful,
+                incomplete=incomplete,
+                errored=errored,
+            ),
+        )
+
+    @classmethod
+    def _compile_ratio(
+        cls,
+        function: Callable[[GenerativeRequestStats], float | None],
+        successful: list[GenerativeRequestStats],
+        incomplete: list[GenerativeRequestStats],
+        errored: list[GenerativeRequestStats],
+    ) -> StatusDistributionSummary | None:
+        """
+        Compile a per-request ratio into a distribution, or None when no data.
+
+        Requests without input audio yield None from ``function`` and are
+        excluded rather than coerced to zero, so text-only benchmarks report no
+        distribution at all instead of a distribution of zeros.
+
+        :param function: Extracts the per-request ratio, or None if unavailable
+        :param successful: Successfully completed request statistics
+        :param incomplete: Incomplete/cancelled request statistics
+        :param errored: Failed request statistics
+        :return: Distribution summary, or None if no request produced a value
+        """
+        if not any(
+            function(req) is not None
+            for reqs in (successful, incomplete, errored)
+            for req in reqs
+        ):
+            return None
+
+        return StatusDistributionSummary.from_values_function(
+            function=function,
+            successful=successful,
+            incomplete=incomplete,
+            errored=errored,
         )
 
 

--- a/src/guidellm/schemas/base/request_stats.py
+++ b/src/guidellm/schemas/base/request_stats.py
@@ -320,6 +320,51 @@ class GenerativeRequestStats(StandardBaseDict):
 
     @computed_field  # type: ignore[misc]
     @property
+    def audio_seconds(self) -> float | None:
+        """
+        :return: Duration of the input audio in seconds, or None if unavailable
+        """
+        return self.input_metrics.audio_seconds
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def real_time_factor(self) -> float | None:
+        """
+        Real-Time Factor (RTF) for audio workloads such as transcription.
+
+        Ratio of processing time to the duration of the audio processed. Values
+        below 1.0 mean the request was handled faster than real time.
+
+        :return: End-to-end latency divided by input audio duration, or None if
+            either is unavailable or non-positive
+        """
+        audio_seconds = self.audio_seconds
+        if not audio_seconds or not (latency := self.request_latency):
+            return None
+
+        return latency / audio_seconds
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def inverse_real_time_factor(self) -> float | None:
+        """
+        Inverse Real-Time Factor (RTFx) for audio workloads.
+
+        Reciprocal of :meth:`real_time_factor`, expressing how many seconds of
+        audio were processed per second of wall-clock time. Values above 1.0
+        mean the request was handled faster than real time.
+
+        :return: Input audio duration divided by end-to-end latency, or None if
+            either is unavailable or non-positive
+        """
+        audio_seconds = self.audio_seconds
+        if not audio_seconds or not (latency := self.request_latency):
+            return None
+
+        return audio_seconds / latency
+
+    @computed_field  # type: ignore[misc]
+    @property
     def time_to_first_output_token_ms(self) -> float | None:
         """
         Time to first content (non-reasoning) token in milliseconds.

--- a/tests/unit/benchmark/schemas/test_metrics.py
+++ b/tests/unit/benchmark/schemas/test_metrics.py
@@ -10,6 +10,7 @@ import pytest
 from guidellm.benchmark.schemas.accumulator import GenerativeBenchmarkAccumulator
 from guidellm.benchmark.schemas.base import BenchmarkConfig
 from guidellm.benchmark.schemas.metrics import (
+    GenerativeAudioMetricsSummary,
     GenerativeMetrics,
     GenerativeMetricsSummary,
     GenerativeToolCallMetricsSummary,
@@ -930,3 +931,86 @@ class TestGoodputConfigWiring:
         del payload["slo"]
 
         assert BenchmarkConfig.model_validate(payload).slo is None
+
+
+def _make_audio_stats(
+    request_id: str, audio_seconds: float | None, latency: float
+) -> GenerativeRequestStats:
+    """Build a request that processed ``audio_seconds`` of audio in ``latency``."""
+    info = RequestInfo(request_id=request_id, status="completed")
+    info.timings.request_start = 0.0
+    info.timings.request_end = latency
+    info.timings.resolve_end = latency
+
+    return GenerativeRequestStats(
+        request_id=request_id,
+        request_args="{}",
+        output="transcript",
+        info=info,
+        input_metrics=UsageMetrics(audio_seconds=audio_seconds),
+        output_metrics=UsageMetrics(text_tokens=5),
+    )
+
+
+class TestAudioRealTimeFactorMetrics:
+    """Aggregation of RTF/RTFx into audio metric distributions."""
+
+    @pytest.mark.smoke
+    def test_compile_distributions(self):
+        """10s of audio at 1s, 2s and 4s latency -> RTF 0.1, 0.2, 0.4."""
+        successful = [
+            _make_audio_stats("a", 10.0, 1.0),
+            _make_audio_stats("b", 10.0, 2.0),
+            _make_audio_stats("c", 10.0, 4.0),
+        ]
+
+        summary = GenerativeAudioMetricsSummary.compile(successful, [], [])
+
+        rtf = summary.real_time_factor
+        rtfx = summary.inverse_real_time_factor
+        assert rtf is not None
+        assert rtfx is not None
+        assert rtf.successful.count == 3
+        assert rtf.successful.mean == pytest.approx((0.1 + 0.2 + 0.4) / 3)
+        assert rtf.successful.min == pytest.approx(0.1)
+        assert rtf.successful.max == pytest.approx(0.4)
+        assert rtfx.successful.mean == pytest.approx((10.0 + 5.0 + 2.5) / 3)
+
+    @pytest.mark.sanity
+    def test_none_for_text_only_benchmarks(self):
+        """No audio anywhere reports no distribution, not a spread of zeros."""
+        successful = [
+            _make_audio_stats("a", None, 1.0),
+            _make_audio_stats("b", None, 2.0),
+        ]
+
+        summary = GenerativeAudioMetricsSummary.compile(successful, [], [])
+
+        assert summary.real_time_factor is None
+        assert summary.inverse_real_time_factor is None
+
+    @pytest.mark.sanity
+    def test_requests_without_audio_are_excluded_not_zeroed(self):
+        """A mixed workload must not drag RTF toward zero with text requests."""
+        successful = [
+            _make_audio_stats("a", 10.0, 2.0),  # RTF 0.2
+            _make_audio_stats("b", None, 2.0),  # no audio, excluded
+            _make_audio_stats("c", 10.0, 1.0),  # RTF 0.1
+        ]
+
+        summary = GenerativeAudioMetricsSummary.compile(successful, [], [])
+
+        rtf = summary.real_time_factor
+        assert rtf is not None
+        assert rtf.successful.count == 2
+        assert rtf.successful.mean == pytest.approx(0.15)
+
+    @pytest.mark.regression
+    def test_fields_are_optional_for_existing_reports(self):
+        """Reports written before RTF existed must still deserialize."""
+        summary = GenerativeAudioMetricsSummary.model_validate(
+            {"tokens": None, "samples": None, "seconds": None, "bytes": None}
+        )
+
+        assert summary.real_time_factor is None
+        assert summary.inverse_real_time_factor is None

--- a/tests/unit/benchmark/test_console_output.py
+++ b/tests/unit/benchmark/test_console_output.py
@@ -218,3 +218,71 @@ class TestServerThroughputTableGoodput:
         assert all(len(column) == 2 for column in values)
         attainment_column = next(column for column in values if "99.0" in column)
         assert attainment_column[1] == "--"
+
+
+def _make_audio_benchmark(
+    rtf: StatusDistributionSummary | None,
+    rtfx: StatusDistributionSummary | None,
+) -> SimpleNamespace:
+    """Build a benchmark stub exposing the audio RTF metrics."""
+    return SimpleNamespace(
+        config=SimpleNamespace(strategy=SimpleNamespace(type_="constant")),
+        metrics=SimpleNamespace(
+            audio=SimpleNamespace(
+                real_time_factor=rtf,
+                inverse_real_time_factor=rtfx,
+            )
+        ),
+    )
+
+
+def _render_audio_latency_table(benchmarks) -> str | None:
+    """Render the RTF table, returning its headers as text or None if skipped."""
+    captured: dict[str, object] = {}
+    output = GenerativeBenchmarkerConsole()
+    output.console.print = lambda *args, **kwargs: None
+    output.console.print_table = lambda headers, values, title=None: captured.update(
+        headers=headers
+    )
+    output.print_audio_latency_table(SimpleNamespace(benchmarks=benchmarks))
+
+    if "headers" not in captured:
+        return None
+
+    return " ".join(str(header) for header in captured["headers"])
+
+
+class TestAudioLatencyTable:
+    """Verify the console RTF table appears only for audio workloads."""
+
+    @pytest.mark.smoke
+    def test_renders_rtf_columns_for_audio_benchmarks(self):
+        distribution = StatusDistributionSummary.from_values([0.1, 0.2, 0.4], [], [])
+        benchmark = _make_audio_benchmark(distribution, distribution)
+
+        headers = _render_audio_latency_table([benchmark])
+
+        assert headers is not None
+        assert "RTF" in headers
+        assert "RTFx" in headers
+
+    @pytest.mark.sanity
+    def test_skipped_entirely_without_audio(self):
+        """Text-only runs must not print an empty Real-Time Factor table."""
+        benchmark = _make_audio_benchmark(None, None)
+
+        assert _render_audio_latency_table([benchmark]) is None
+
+    @pytest.mark.regression
+    def test_renders_when_any_benchmark_has_audio(self):
+        """A mixed report still prints the table for the audio benchmarks."""
+        distribution = StatusDistributionSummary.from_values([0.5], [], [])
+        benchmarks = [
+            _make_audio_benchmark(None, None),
+            _make_audio_benchmark(distribution, distribution),
+        ]
+
+        headers = _render_audio_latency_table(benchmarks)
+
+        assert headers is not None
+        assert "RTF" in headers

--- a/tests/unit/schemas/test_request_stats.py
+++ b/tests/unit/schemas/test_request_stats.py
@@ -288,6 +288,9 @@ class TestGenerativeRequestStats:
             "output_tokens_per_iteration",
             "time_to_last_round_trip_ms",
             "avg_round_trip_time_ms",
+            "audio_seconds",
+            "real_time_factor",
+            "inverse_real_time_factor",
         ):
             assert hasattr(GenerativeRequestStats, prop_name)
 
@@ -883,3 +886,94 @@ class TestGenerativeRequestStats:
             assert got is None
         else:
             assert pytest.approx(exp, rel=1e-6, abs=1e-6) == got
+
+
+class TestAudioRealTimeFactor:
+    """RTF and RTFx for audio workloads such as transcription."""
+
+    @staticmethod
+    def _make_stats(
+        audio_seconds: float | None,
+        request_start: float = 0.0,
+        request_end: float = 2.0,
+    ) -> GenerativeRequestStats:
+        info = RequestInfo(request_id="req", status="completed")
+        info.timings.request_start = request_start
+        info.timings.request_end = request_end
+        info.timings.resolve_end = request_end
+
+        return GenerativeRequestStats(
+            request_id="req",
+            request_args="{}",
+            output="transcript",
+            info=info,
+            input_metrics=UsageMetrics(audio_seconds=audio_seconds),
+            output_metrics=UsageMetrics(text_tokens=5),
+        )
+
+    @pytest.mark.smoke
+    def test_audio_seconds_reads_input_metrics(self):
+        assert self._make_stats(12.5).audio_seconds == 12.5
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        ("audio_seconds", "latency", "expected_rtf", "expected_rtfx"),
+        [
+            (10.0, 2.0, 0.2, 5.0),  # faster than real time
+            (10.0, 20.0, 2.0, 0.5),  # slower than real time
+            (4.0, 4.0, 1.0, 1.0),  # exactly real time
+        ],
+    )
+    def test_real_time_factors(
+        self,
+        audio_seconds: float,
+        latency: float,
+        expected_rtf: float,
+        expected_rtfx: float,
+    ):
+        stats = self._make_stats(audio_seconds, request_end=latency)
+
+        assert stats.real_time_factor == pytest.approx(expected_rtf)
+        assert stats.inverse_real_time_factor == pytest.approx(expected_rtfx)
+
+    @pytest.mark.sanity
+    def test_factors_are_reciprocal(self):
+        stats = self._make_stats(7.5, request_end=3.0)
+
+        assert stats.real_time_factor * stats.inverse_real_time_factor == pytest.approx(
+            1.0
+        )
+
+    @pytest.mark.sanity
+    def test_none_without_audio(self):
+        """Text-only requests report no RTF rather than a misleading zero."""
+        stats = self._make_stats(None)
+
+        assert stats.real_time_factor is None
+        assert stats.inverse_real_time_factor is None
+
+    @pytest.mark.sanity
+    @pytest.mark.parametrize(
+        ("audio_seconds", "request_start", "request_end"),
+        [
+            (0.0, 0.0, 2.0),  # zero-duration audio
+            (10.0, 1.0, 1.0),  # zero latency
+        ],
+    )
+    def test_none_instead_of_zero_division(
+        self, audio_seconds: float, request_start: float, request_end: float
+    ):
+        stats = self._make_stats(
+            audio_seconds, request_start=request_start, request_end=request_end
+        )
+
+        assert stats.real_time_factor is None
+        assert stats.inverse_real_time_factor is None
+
+    @pytest.mark.smoke
+    def test_serialized_in_model_dump(self):
+        dumped = self._make_stats(10.0).model_dump()
+
+        assert dumped["audio_seconds"] == 10.0
+        assert dumped["real_time_factor"] == pytest.approx(0.2)
+        assert dumped["inverse_real_time_factor"] == pytest.approx(5.0)


### PR DESCRIPTION
Resolves #833

Reports Real-Time Factor (RTF) and its inverse (RTFx) for requests that carry input audio, the standard measures of transcription speed. RTF is end-to-end request latency divided by input audio duration; RTFx is the reciprocal, expressing seconds of audio processed per second of wall-clock time. Values below 1.0 RTF (above 1.0 RTFx) mean the server is keeping up with real-time audio.

Everything needed was already plumbed through: `audio_seconds` is populated on `UsageMetrics` by the OpenAI and vLLM backends and the data finalizer, and `request_latency` already exists, so this derives the two ratios from them.

## Changes

- **`GenerativeRequestStats`** — adds `audio_seconds`, `real_time_factor`, and `inverse_real_time_factor` computed fields, following the existing `tokens_per_second` pattern.
- **`GenerativeAudioMetricsSummary`** — compiles both into distributions, so they appear under `metrics.audio` in JSON/YAML reports alongside the existing audio data.
- **Console** — a Real-Time Factor table that is skipped entirely for workloads without input audio.
- **CSV** — RTF/RTFx columns, emitted only when a run carried audio.
- **Docs** — both metrics documented in `docs/guides/metrics.md`.

## Design note

`GenerativeMetricsSummary` is shaped around input/output/total triples, which does not fit a per-request ratio, so RTF and RTFx are plain `StatusDistributionSummary` fields compiled through a small `_compile_ratio` helper.

That helper returns `None` for requests without input audio rather than coercing to `0.0` as some surrounding metrics do. This matters for mixed workloads: coercing would pull RTF toward zero for every text request and silently report the server as faster than it is. Requests without audio are therefore excluded from the distribution, and a text-only benchmark reports no RTF distribution at all rather than a distribution of zeros. Both behaviours are covered by tests.

## Question for maintainers

For streaming and realtime transcription I used **total request latency** as the numerator, on the reading that it is what a user actually waits for. An argument exists for time-to-final-transcript instead. Happy to switch if you prefer the latter — it is a one-line change plus tests.

## Testing

- New unit tests at the request level (ratio arithmetic, reciprocal relationship, zero-duration audio, zero latency, absent audio, serialization), the aggregation level (distribution compilation, text-only runs, mixed workloads, backward-compatible deserialization of reports written before these fields existed), and the console level (table renders for audio, is skipped without it).
- `ruff check`, `ruff format --check`, `mypy` over `src/guidellm` (224 files), and `mdformat` all clean.
- Note: `tests/unit/utils/test_audio.py` could not run locally — `torchcodec` fails to load its native library on macOS, and those 14 failures reproduce on an unmodified tree. The new metrics were verified against synthetic request stats rather than a live transcription run, so validation against a real audio backend would be worthwhile.

<!-- begin:squash-data -->

---

# git log

commit d39e424fbf9f0edf4353fc3dc31bc45474c34981
Author: Tazril Ali <tazril.ali@goripples.com>
Date:   Sat Sep 12 14:36:39 2026 +0530

    Add RTF and RTFx metrics for audio workloads
    
    Report Real-Time Factor (RTF) and its inverse (RTFx) for requests that
    carry input audio, the standard measures of transcription speed. RTF is
    end-to-end request latency divided by input audio duration; RTFx is the
    reciprocal, expressing seconds of audio processed per second of
    wall-clock time.
    
    Requests without input audio yield None rather than zero, so they are
    excluded from the distributions instead of dragging them toward zero,
    and text-only benchmarks report no RTF distribution at all. The console
    table is skipped entirely when no benchmark processed audio.
    
    Resolves #833
    
    Signed-off-by: Tazril Ali <tazril.ali@goripples.com>

---------

Signed-off-by: Tazril Ali <tazril.ali@goripples.com>
