### PR TITLE
Fix invalid format placeholder in mock server error logging

### DIFF
--- a/src/guidellm/mock_server/server.py
+++ b/src/guidellm/mock_server/server.py
@@ -312,7 +312,7 @@ class MockServer:
 
         @self.app.exception(Exception)
         async def generic_error_handler(_request: Request, exception: Exception):
-            logger.error("Unhandled exception: {}", exception)
+            logger.error("Unhandled exception: %s", exception)
             return response.json(
                 {
                     "error": {


### PR DESCRIPTION
## Summary

<!--
Include a short paragraph of the changes introduced in this PR.
If this PR requires additional context or rationale, explain why
the changes are necessary.
-->

Fixes an invalid log format placeholder in the mock server's generic exception
handler so unhandled exceptions log cleanly instead of raising a secondary
`TypeError` from inside the logging module.

## Details

<!--
Provide a detailed list of all changes introduced in this pull request.
-->
- [x] `generic_error_handler` in `src/guidellm/mock_server/server.py` logged unhandled exceptions with `logger.error("Unhandled exception: {}", exception)`. `logger` is `sanic.log.logger`, which expects `%s`-style placeholders. 
- [x] Changed `{}` to `%s` so the exception logs cleanly. The JSON 500 response returned to the client is unaffected either way.

## Test Plan

<!--
List the steps needed to test this PR.
-->
- Called `logger.error("Unhandled exception: %s", exception)` directly against `sanic.log.logger` and confirmed it formats cleanly with no `TypeError`.
- `tox -e lint-check`
- `tox -e type-check`

## Related Issues

<!--
Link any relevant issues that this PR addresses.
-->
- Resolves #

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [ ] Includes tests generated or substantially modified by an AI agent

<!-- begin:squash-data -->

---

# git log

commit 2de9ef7c4c1005cb9ec129fe66a76f6c570763af
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 12 11:52:06 2026 +0100

    Fix invalid format placeholder in mock server error logging
    
    `generic_error_handler` logged unhandled exceptions with `logger.error("Unhandled exception: {}", exception)`.
    The `logger` is a stdlib `logging.Logger`, which expects `%s`-style placeholders, not `{}`. Every
    unhandled exception therefore raised a secondary `TypeError` from inside the logging module
    itself, burying the real traceback under logging-internals noise.
    
    Change `{}` to `%s` so the exception logs cleanly.
    
    Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
    Generated-by: Claude Sonnet 5
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>

---------

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Generated-by: Claude Sonnet 5
Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
