### PR TITLE
Fix mock-server Hugging Face tokenizer compatibility

### DIFF
--- a/src/guidellm/mock_server/handlers/chat_completions.py
+++ b/src/guidellm/mock_server/handlers/chat_completions.py
@@ -191,9 +191,10 @@ class ChatCompletionsHandler:
         # Token counts
         prompt_text = self.tokenizer.apply_chat_template(
             req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+            tokenize=False,
         )
-        text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
-        prompt_tokens = text_tokens + multimodal_stats.total_tokens
+        text_tokens = len(self.tokenizer.encode(prompt_text))  # type: ignore[arg-type]
+        prompt_tokens_count = text_tokens + multimodal_stats.total_tokens
         max_tokens = req.max_completion_tokens or req.max_tokens or math.inf
         completion_tokens_count = min(
             sample_number(self.config.output_tokens, self.config.output_tokens_std),
@@ -235,7 +236,7 @@ class ChatCompletionsHandler:
             model=req.model,
             choices=[choice],
             usage=Usage(
-                prompt_tokens=prompt_tokens,
+                prompt_tokens=prompt_tokens_count,
                 completion_tokens=int(completion_tokens_count),
                 prompt_tokens_details=multimodal_stats.prompt_tokens_details(
                     text_tokens
@@ -274,9 +275,12 @@ class ChatCompletionsHandler:
             # Token counts
             prompt_text = self.tokenizer.apply_chat_template(
                 req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+                tokenize=False,
             )
-            text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
-            prompt_tokens = text_tokens + multimodal_stats.total_tokens
+            text_tokens = len(
+                self.tokenizer.encode(prompt_text)  # type: ignore[arg-type]
+            )
+            prompt_tokens_count = text_tokens + multimodal_stats.total_tokens
             prompt_tokens_details = multimodal_stats.prompt_tokens_details(text_tokens)
             max_tokens = req.max_completion_tokens or req.max_tokens or math.inf
             completion_tokens_count = int(
@@ -293,7 +297,7 @@ class ChatCompletionsHandler:
                     stream_response,
                     req,
                     completion_id,
-                    prompt_tokens,
+                    prompt_tokens_count,
                     completion_tokens_count,
                     prompt_tokens_details,
                 )
@@ -302,7 +306,7 @@ class ChatCompletionsHandler:
                     stream_response,
                     req,
                     completion_id,
-                    prompt_tokens,
+                    prompt_tokens_count,
                     completion_tokens_count,
                     prompt_tokens_details,
                 )

--- a/src/guidellm/mock_server/handlers/chat_completions.py
+++ b/src/guidellm/mock_server/handlers/chat_completions.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 from sanic import response
 from sanic.request import Request
 from sanic.response import HTTPResponse, ResponseStream
-from transformers import PreTrainedTokenizer
+from transformers import AutoTokenizer
 
 from guidellm.mock_server.models import (
     ChatCompletionChoice,
@@ -76,7 +76,7 @@ class ChatCompletionsHandler:
         self.tokenizer = (
             MockTokenizer()
             if config.processor is None
-            else PreTrainedTokenizer.from_pretrained(config.processor)
+            else AutoTokenizer.from_pretrained(config.processor)
         )
 
     async def handle(self, request: Request) -> HTTPResponse:
@@ -189,7 +189,9 @@ class ChatCompletionsHandler:
         )
 
         # Token counts
-        prompt_text = self.tokenizer.apply_chat_template(req.messages)
+        prompt_text = self.tokenizer.apply_chat_template(
+            req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+        )
         text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
         prompt_tokens = text_tokens + multimodal_stats.total_tokens
         max_tokens = req.max_completion_tokens or req.max_tokens or math.inf
@@ -270,7 +272,9 @@ class ChatCompletionsHandler:
             )
 
             # Token counts
-            prompt_text = self.tokenizer.apply_chat_template(req.messages)
+            prompt_text = self.tokenizer.apply_chat_template(
+                req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+            )
             text_tokens = len(self.tokenizer(prompt_text))  # type: ignore[arg-type]
             prompt_tokens = text_tokens + multimodal_stats.total_tokens
             prompt_tokens_details = multimodal_stats.prompt_tokens_details(text_tokens)

--- a/src/guidellm/mock_server/handlers/chat_completions.py
+++ b/src/guidellm/mock_server/handlers/chat_completions.py
@@ -190,7 +190,7 @@ class ChatCompletionsHandler:
 
         # Token counts
         prompt_text = self.tokenizer.apply_chat_template(
-            req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+            req.messages,  # type: ignore[arg-type]
             tokenize=False,
         )
         text_tokens = len(self.tokenizer.encode(prompt_text))  # type: ignore[arg-type]
@@ -274,7 +274,7 @@ class ChatCompletionsHandler:
 
             # Token counts
             prompt_text = self.tokenizer.apply_chat_template(
-                req.messages,  # type: ignore[arg-type]  # Transformers typing is narrow
+                req.messages,  # type: ignore[arg-type]
                 tokenize=False,
             )
             text_tokens = len(

--- a/src/guidellm/mock_server/handlers/completions.py
+++ b/src/guidellm/mock_server/handlers/completions.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 from sanic import response
 from sanic.request import Request
 from sanic.response import HTTPResponse, ResponseStream
-from transformers import PreTrainedTokenizer
+from transformers import AutoTokenizer
 
 from guidellm.mock_server.models import (
     CompletionChoice,
@@ -68,7 +68,7 @@ class CompletionsHandler:
         self.tokenizer = (
             MockTokenizer()
             if config.processor is None
-            else PreTrainedTokenizer.from_pretrained(config.processor)
+            else AutoTokenizer.from_pretrained(config.processor)
         )
 
     async def handle(self, request: Request) -> HTTPResponse:

--- a/src/guidellm/mock_server/handlers/completions.py
+++ b/src/guidellm/mock_server/handlers/completions.py
@@ -135,7 +135,7 @@ class CompletionsHandler:
         )
 
         # Token counts
-        prompt_tokens = len(self.tokenizer(req.prompt))
+        prompt_tokens = len(self.tokenizer.encode(req.prompt))
         max_tokens = req.max_tokens or math.inf
         completion_tokens_count = int(
             min(
@@ -195,7 +195,9 @@ class CompletionsHandler:
             )
 
             # Token counts
-            prompt_tokens = len(self.tokenizer(req.prompt))
+            prompt_tokens = len(
+                self.tokenizer.encode(req.prompt)  # type: ignore[arg-type]
+            )
             max_tokens = req.max_tokens or math.inf
             completion_tokens_count = int(
                 min(

--- a/src/guidellm/mock_server/handlers/responses.py
+++ b/src/guidellm/mock_server/handlers/responses.py
@@ -20,7 +20,7 @@ from pydantic import ValidationError
 from sanic import response
 from sanic.request import Request
 from sanic.response import HTTPResponse, ResponseStream
-from transformers import PreTrainedTokenizer
+from transformers import AutoTokenizer
 
 from guidellm.mock_server.models import (
     ErrorDetail,
@@ -55,7 +55,7 @@ class ResponsesHandler:
         self.tokenizer = (
             MockTokenizer()
             if config.processor is None
-            else PreTrainedTokenizer.from_pretrained(config.processor)
+            else AutoTokenizer.from_pretrained(config.processor)
         )
 
     def _extract_input_text(self, req: ResponsesRequest) -> str:

--- a/src/guidellm/mock_server/handlers/responses.py
+++ b/src/guidellm/mock_server/handlers/responses.py
@@ -167,7 +167,7 @@ class ResponsesHandler:
         )
 
         input_text = self._extract_input_text(req)
-        input_tokens = len(self.tokenizer(input_text))  # type: ignore[arg-type]
+        input_tokens = len(self.tokenizer.encode(input_text))
         max_tokens = req.max_output_tokens or math.inf
         output_tokens_count = min(
             sample_number(self.config.output_tokens, self.config.output_tokens_std),
@@ -223,7 +223,7 @@ class ResponsesHandler:
             )
 
             input_text = self._extract_input_text(req)
-            input_tokens = len(self.tokenizer(input_text))  # type: ignore[arg-type]
+            input_tokens = len(self.tokenizer.encode(input_text))
             max_tokens = req.max_output_tokens or math.inf
             output_tokens_count = int(
                 min(

--- a/src/guidellm/mock_server/utils.py
+++ b/src/guidellm/mock_server/utils.py
@@ -61,14 +61,22 @@ class MockTokenizer(PreTrainedTokenizerBase):
             tokens = self.tokenize(text)
             return self.convert_tokens_to_ids(tokens)
         elif isinstance(text, list):
-            # Handle batch processing
             result = []
-            for t in text:
-                result.extend(self.__call__(t))
+            for item in text:
+                result.extend(self.__call__(item))
             return result
         else:
             msg = f"text input must be of type `str` or `list[str]`, got {type(text)}"
             raise ValueError(msg)
+
+    def encode(self, text: TextInput, **_kwargs) -> list[int]:
+        """
+        Encode text as a sequence of token IDs.
+
+        :param text: Input text to encode
+        :return: List of token IDs
+        """
+        return self(text)
 
     def tokenize(self, text: TextInput, **_kwargs) -> list[str]:  # type: ignore[override]
         """

--- a/src/guidellm/mock_server/utils.py
+++ b/src/guidellm/mock_server/utils.py
@@ -62,8 +62,8 @@ class MockTokenizer(PreTrainedTokenizerBase):
             return self.convert_tokens_to_ids(tokens)
         elif isinstance(text, list):
             result = []
-            for item in text:
-                result.extend(self.__call__(item))
+            for t in text:
+                result.extend(self.__call__(t))
             return result
         else:
             msg = f"text input must be of type `str` or `list[str]`, got {type(text)}"
@@ -277,9 +277,7 @@ def create_fake_tokens_str(
     tokens: list[str] = []
 
     while len(tokens) < num_tokens:
-        text = fake.text(
-            max_nb_chars=(num_tokens - len(tokens)) * 30  # oversample
-        )
+        text = fake.text(max_nb_chars=(num_tokens - len(tokens)) * 30)  # oversample
         new_tokens = processor.tokenize(text)
 
         if len(tokens) > 0:

--- a/src/guidellm/mock_server/utils.py
+++ b/src/guidellm/mock_server/utils.py
@@ -238,9 +238,8 @@ def create_fake_text(
     """
     Generate fake text using a tokenizer processor with specified token count.
 
-    Creates text by generating fake tokens and joining them into a string,
-    ensuring the result has the exact number of tokens when processed by
-    the given tokenizer.
+    Creates text by joining decoded chunks generated for the requested
+    simulated token count.
 
     :param num_tokens: Target number of tokens in the generated text
     :param processor: Tokenizer to use for token generation and validation
@@ -258,17 +257,18 @@ def create_fake_tokens_str(
     fake: Faker | None = None,
 ) -> list[str]:
     """
-    Generate fake token strings using a tokenizer processor.
+    Generate detokenized text chunks using a tokenizer processor.
 
-    Creates a list of token strings by generating fake text and tokenizing it
-    until the desired token count is reached. Uses the provided tokenizer
-    for accurate token boundary detection.
+    Creates a list of text chunks by generating fake text and tokenizing it until
+    the desired token count is reached. The complete token sequence is decoded once
+    and divided into the same number of chunks so tokenizer-specific boundary markers
+    are not exposed without changing streaming event counts.
 
     :param num_tokens: Target number of tokens to generate
     :param processor: Tokenizer to use for token generation and validation
     :param seed: Random seed for reproducible token generation
     :param fake: Optional Faker instance for text generation
-    :return: List of token strings with the specified count
+    :return: List of decoded text chunks matching the specified count
     """
     if not fake:
         fake = Faker()
@@ -292,7 +292,20 @@ def create_fake_tokens_str(
         )
         tokens += new_tokens
 
-    return tokens
+    if not tokens:
+        return []
+
+    text = processor.convert_tokens_to_string(tokens)
+    chunk_size, remainder = divmod(len(text), len(tokens))
+    chunks = []
+    start = 0
+    # Split all decoded text across exactly `len(tokens)` transport chunks,
+    # giving the first `remainder` chunks one extra character.
+    for index in range(len(tokens)):
+        end = start + chunk_size + (index < remainder)
+        chunks.append(text[start:end])
+        start = end
+    return chunks
 
 
 def times_generator(mean: float, standard_dev: float) -> Generator[float]:

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 import pytest_asyncio
 from pydantic import ValidationError
+from transformers import AutoTokenizer
 
 from guidellm.mock_server.server import MockServer
 from guidellm.schemas.mock_server.config import MockServerConfig
@@ -19,8 +20,13 @@ from tests.fixtures.tokenizers import MINIMAL_TOKENIZER_DIR
 
 
 # Start server in a separate process
-def _start_server_process(config: MockServerConfig):
+def _start_server_process(
+    config: MockServerConfig,
+    chat_template: str | None = None,
+):
     server = MockServer(config)
+    if chat_template is not None:
+        server.chat_handler.tokenizer.chat_template = chat_template
     # Disable Sanic access logs / MOTD so ANSI formatters do not clobber pytest's TTY.
     server.run(access_log=False)
 
@@ -28,10 +34,12 @@ def _start_server_process(config: MockServerConfig):
 @asynccontextmanager
 async def _run_mock_server(
     config: MockServerConfig,
+    chat_template: str | None = None,
 ) -> AsyncGenerator[str, None]:
     base_url = f"http://{config.host}:{config.port}"
     server_process = multiprocessing.Process(
-        target=_start_server_process, args=(config,)
+        target=_start_server_process,
+        args=(config, chat_template),
     )
     server_process.start()
 
@@ -1121,6 +1129,28 @@ class TestMockServerFailAfterAndConcurrency:
         assert max(durations) >= 0.3
 
 
+@pytest_asyncio.fixture(scope="module")
+async def huggingface_mock_server():
+    """MockServer configured with the vendored Hugging Face tokenizer.
+
+    ## WRITTEN BY AI ##
+    """
+    chat_template = "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+    config = MockServerConfig(
+        host="127.0.0.1",
+        port=8015,
+        model="huggingface-model",
+        processor=str(MINIMAL_TOKENIZER_DIR),
+        output_tokens=1,
+        ttft_ms=0,
+        itl_ms=0,
+    )
+    async with _run_mock_server(config, chat_template) as base_url:
+        tokenizer = AutoTokenizer.from_pretrained(MINIMAL_TOKENIZER_DIR)
+        tokenizer.chat_template = chat_template
+        yield base_url, config, tokenizer
+
+
 @pytest.mark.regression
 def test_initializes_with_huggingface_processor():
     """Test all handlers initialize with a Hugging Face tokenizer.
@@ -1135,3 +1165,59 @@ def test_initializes_with_huggingface_processor():
     assert server.completions_handler.tokenizer is not None
     assert server.responses_handler.tokenizer is not None
     assert server.tokenizer_handler.tokenizer is not None
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "input_field", "max_tokens_field", "usage_field"),
+    [
+        (
+            "/v1/chat/completions",
+            "messages",
+            "max_tokens",
+            "prompt_tokens",
+        ),
+        ("/v1/completions", "prompt", "max_tokens", "prompt_tokens"),
+        ("/v1/responses", "input", "max_output_tokens", "input_tokens"),
+    ],
+    ids=("chat_completions", "completions", "responses"),
+)
+async def test_handles_requests_with_huggingface_processor(
+    huggingface_mock_server,
+    endpoint,
+    input_field,
+    max_tokens_field,
+    usage_field,
+):
+    """Test Hugging Face tokenizers handle and count endpoint prompts.
+
+    ## WRITTEN BY AI ##
+    """
+    server_url, config, tokenizer = huggingface_mock_server
+    prompt = "Hello world " * 20
+    messages = [{"role": "user", "content": prompt}]
+    is_chat = input_field == "messages"
+    input_value = messages if is_chat else prompt
+    prompt_text = (
+        tokenizer.apply_chat_template(messages, tokenize=False)
+        if is_chat
+        else prompt
+    )
+    payload = {
+        "model": config.model,
+        input_field: input_value,
+        max_tokens_field: 1,
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{server_url}{endpoint}",
+            json=payload,
+            timeout=10.0,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["usage"][usage_field] == len(
+        tokenizer.encode(prompt_text)
+    )

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 
 from guidellm.mock_server.server import MockServer
 from guidellm.schemas.mock_server.config import MockServerConfig
+from tests.fixtures.tokenizers import MINIMAL_TOKENIZER_DIR
 
 
 # Start server in a separate process
@@ -1173,3 +1174,19 @@ class TestMockServerFailAfterAndConcurrency:
         # Two non-stream requests each sleep ~ttft (0.2s); serialized => slower
         # request should take at least ~0.3s when they contend for one slot.
         assert max(durations) >= 0.3
+
+
+@pytest.mark.regression
+def test_initializes_with_huggingface_processor():
+    """Test all handlers initialize with a Hugging Face tokenizer.
+
+    ## WRITTEN BY AI ##
+    """
+    config = MockServerConfig(processor=str(MINIMAL_TOKENIZER_DIR))
+
+    server = MockServer(config)
+
+    assert server.chat_handler.tokenizer is not None
+    assert server.completions_handler.tokenizer is not None
+    assert server.responses_handler.tokenizer is not None
+    assert server.tokenizer_handler.tokenizer is not None

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -1200,9 +1200,7 @@ async def test_handles_requests_with_huggingface_processor(
     is_chat = input_field == "messages"
     input_value = messages if is_chat else prompt
     prompt_text = (
-        tokenizer.apply_chat_template(messages, tokenize=False)
-        if is_chat
-        else prompt
+        tokenizer.apply_chat_template(messages, tokenize=False) if is_chat else prompt
     )
     payload = {
         "model": config.model,
@@ -1218,6 +1216,4 @@ async def test_handles_requests_with_huggingface_processor(
         )
 
     assert response.status_code == 200
-    assert response.json()["usage"][usage_field] == len(
-        tokenizer.encode(prompt_text)
-    )
+    assert response.json()["usage"][usage_field] == len(tokenizer.encode(prompt_text))

--- a/tests/unit/mock_server/test_server.py
+++ b/tests/unit/mock_server/test_server.py
@@ -5,6 +5,8 @@ import base64
 import json
 import math
 import multiprocessing
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 import httpx
 import pytest
@@ -23,6 +25,43 @@ def _start_server_process(config: MockServerConfig):
     server.run(access_log=False)
 
 
+@asynccontextmanager
+async def _run_mock_server(
+    config: MockServerConfig,
+) -> AsyncGenerator[str, None]:
+    base_url = f"http://{config.host}:{config.port}"
+    server_process = multiprocessing.Process(
+        target=_start_server_process, args=(config,)
+    )
+    server_process.start()
+
+    async def wait_for_startup() -> None:
+        poll_frequency = 1.0
+        async with httpx.AsyncClient() as client:
+            while True:
+                try:
+                    response = await client.get(f"{base_url}/health", timeout=1.0)
+                    if response.status_code == 200:
+                        return
+                except (httpx.RequestError, httpx.TimeoutException):
+                    pass
+                await asyncio.sleep(poll_frequency)
+                poll_frequency = min(poll_frequency * 1.5, 2.0)
+
+    try:
+        try:
+            await asyncio.wait_for(wait_for_startup(), timeout=30.0)
+        except TimeoutError:
+            pytest.fail(f"MockServer on port {config.port} failed to start")
+        yield base_url
+    finally:
+        server_process.terminate()
+        server_process.join(timeout=5)
+        if server_process.is_alive():
+            server_process.kill()
+            server_process.join(timeout=5)
+
+
 @pytest_asyncio.fixture(scope="class")
 async def mock_server_instance():
     """Instance-level fixture that provides a running server for HTTP testing."""
@@ -35,44 +74,8 @@ async def mock_server_instance():
         itl_ms=1.0,
         request_latency=0.1,
     )
-    base_url = f"http://{config.host}:{config.port}"
-    server_process = multiprocessing.Process(
-        target=_start_server_process, args=(config,)
-    )
-    server_process.start()
-
-    # Wait for server to start up and be ready
-    async def wait_for_startup():
-        poll_frequency = 1.0
-        async with httpx.AsyncClient() as client:
-            while True:
-                try:
-                    response = await client.get(f"{base_url}/health", timeout=1.0)
-                    if response.status_code == 200:
-                        break
-                except (httpx.RequestError, httpx.TimeoutException):
-                    pass
-                await asyncio.sleep(poll_frequency)
-                poll_frequency = min(poll_frequency * 1.5, 2.0)
-
-    timeout = 30.0
-    try:
-        await asyncio.wait_for(wait_for_startup(), timeout)
-    except TimeoutError:
-        server_process.terminate()
-        server_process.join(timeout=5)
-        if server_process.is_alive():
-            server_process.kill()
-            server_process.join(timeout=5)
-        pytest.fail(f"Server failed to start within {timeout} seconds")
-
-    yield base_url, config
-
-    server_process.terminate()
-    server_process.join(timeout=5)
-    if server_process.is_alive():
-        server_process.kill()
-        server_process.join(timeout=5)
+    async with _run_mock_server(config) as base_url:
+        yield base_url, config
 
 
 class TestMockServerConfig:
@@ -1016,37 +1019,8 @@ async def fail_after_mock_server():
         output_tokens=4,
         fail_after_requests=2,
     )
-    base_url = f"http://{config.host}:{config.port}"
-    server_process = multiprocessing.Process(
-        target=_start_server_process, args=(config,)
-    )
-    server_process.start()
-
-    async def wait_for_startup():
-        async with httpx.AsyncClient() as client:
-            while True:
-                try:
-                    response = await client.get(f"{base_url}/health", timeout=1.0)
-                    if response.status_code == 200:
-                        return
-                except (httpx.RequestError, httpx.TimeoutException):
-                    pass
-                await asyncio.sleep(0.2)
-
-    try:
-        await asyncio.wait_for(wait_for_startup(), timeout=30.0)
-    except TimeoutError:
-        server_process.terminate()
-        server_process.join(timeout=5)
-        pytest.fail("fail_after MockServer failed to start")
-
-    yield base_url
-
-    server_process.terminate()
-    server_process.join(timeout=5)
-    if server_process.is_alive():
-        server_process.kill()
-        server_process.join(timeout=5)
+    async with _run_mock_server(config) as base_url:
+        yield base_url
 
 
 @pytest_asyncio.fixture
@@ -1065,37 +1039,8 @@ async def concurrent_limit_mock_server():
         output_tokens=4,
         max_concurrent_requests=1,
     )
-    base_url = f"http://{config.host}:{config.port}"
-    server_process = multiprocessing.Process(
-        target=_start_server_process, args=(config,)
-    )
-    server_process.start()
-
-    async def wait_for_startup():
-        async with httpx.AsyncClient() as client:
-            while True:
-                try:
-                    response = await client.get(f"{base_url}/health", timeout=1.0)
-                    if response.status_code == 200:
-                        return
-                except (httpx.RequestError, httpx.TimeoutException):
-                    pass
-                await asyncio.sleep(0.2)
-
-    try:
-        await asyncio.wait_for(wait_for_startup(), timeout=30.0)
-    except TimeoutError:
-        server_process.terminate()
-        server_process.join(timeout=5)
-        pytest.fail("concurrency MockServer failed to start")
-
-    yield base_url
-
-    server_process.terminate()
-    server_process.join(timeout=5)
-    if server_process.is_alive():
-        server_process.kill()
-        server_process.join(timeout=5)
+    async with _run_mock_server(config) as base_url:
+        yield base_url
 
 
 class TestMockServerFailAfterAndConcurrency:

--- a/tests/unit/mock_server/test_utils.py
+++ b/tests/unit/mock_server/test_utils.py
@@ -1,0 +1,19 @@
+from guidellm.mock_server.utils import MockTokenizer
+
+
+def test_mock_tokenizer_returns_raw_token_ids() -> None:
+    """Test the mock exposes raw token IDs through its encoding interfaces.
+
+    ## WRITTEN BY AI ##
+    """
+    tokenizer = MockTokenizer()
+    messages = [{"role": "user", "content": "hello world"}]
+
+    token_ids = tokenizer("hello world")
+
+    assert token_ids == tokenizer.convert_tokens_to_ids(
+        tokenizer.tokenize("hello world")
+    )
+    assert tokenizer.encode("hello world") == token_ids
+    assert tokenizer.apply_chat_template(messages) == "hello world"
+    assert isinstance(tokenizer.apply_chat_template(messages, tokenize=True), list)

--- a/tests/unit/mock_server/test_utils.py
+++ b/tests/unit/mock_server/test_utils.py
@@ -1,4 +1,13 @@
-from guidellm.mock_server.utils import MockTokenizer
+from unittest.mock import Mock
+
+import pytest
+from transformers import AutoTokenizer
+
+from guidellm.mock_server.utils import (
+    MockTokenizer,
+    create_fake_tokens_str,
+)
+from tests.fixtures.tokenizers import MINIMAL_TOKENIZER_DIR
 
 
 def test_mock_tokenizer_returns_raw_token_ids() -> None:
@@ -17,3 +26,39 @@ def test_mock_tokenizer_returns_raw_token_ids() -> None:
     assert tokenizer.encode("hello world") == token_ids
     assert tokenizer.apply_chat_template(messages) == "hello world"
     assert isinstance(tokenizer.apply_chat_template(messages, tokenize=True), list)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "tokenizer_kind",
+    ["huggingface", "mock"],
+    ids=("huggingface", "mock"),
+)
+def test_fake_token_chunks_are_decoded_correctly(tokenizer_kind) -> None:
+    """Test generated chunks are display text matching the requested token count.
+
+    ## WRITTEN BY AI ##
+    """
+    tokenizer = (
+        AutoTokenizer.from_pretrained(MINIMAL_TOKENIZER_DIR)
+        if tokenizer_kind == "huggingface"
+        else MockTokenizer()
+    )
+    source_text = "Score each cause. Quality matters."
+    num_tokens = len(tokenizer.tokenize(source_text))
+    fake = Mock()
+    fake.text.return_value = source_text
+
+    chunks = create_fake_tokens_str(num_tokens, tokenizer, fake=fake)
+
+    assert len(chunks) == num_tokens
+    assert "".join(chunks) == source_text
+
+
+@pytest.mark.regression
+def test_fake_token_chunks_support_zero_tokens() -> None:
+    """Test zero generated tokens produce no chunks.
+
+    ## WRITTEN BY AI ##
+    """
+    assert create_fake_tokens_str(0, MockTokenizer()) == []


### PR DESCRIPTION
## Summary

Fix mock-server startup and request handling when `--processor` selects a real Hugging Face tokenizer. On upstream `main`, initialization raises `NotImplementedError` from `PreTrainedTokenizer.get_vocab()` before the server can start. After startup is fixed, the handlers also need compatible chat-template calls and token counting, and generated text needs detokenization before being returned to clients.

## Details

- Load configured processors with `AutoTokenizer.from_pretrained(...)` in the chat completions, completions, and Responses handlers.
- Render chat templates as text and count prompt/input tokens through `encode()`, with the same interface supported by the mock tokenizer.
- Convert generated token pieces to display text before splitting them into the requested number of streaming chunks. These chunks represent simulated token events; they are not guaranteed to match the token boundaries of the final text when re-encoded.
- Reuse a server lifecycle context manager for the existing fixtures and the new offline Hugging Face regression tests.

Rebased onto upstream `main` at `4601968d` (September 19, 2026). The tokenizer patch is unchanged by the rebase; the branch now also contains the already-merged logging fix from #1142.

## Test Plan

Validated on macOS with Python 3.12.11:

- `uv run tox -e tests -- tests/unit/mock_server tests/e2e/test_huggingface_tokenizer_offline.py`: **84 passed**. Covers real-tokenizer startup, prompt/input usage for all three endpoints, decoded output chunks, existing mock-server behaviour, and offline tokenizer resolution.
- `uv run tox -e lint-check,type-check`: **passed**, including type checks for 226 source files.
- `uv run tox -e tests`: **3,311 passed, 31 skipped, 188 xfailed**. The run reported a Pydantic deprecation warning and a multiprocessing semaphore-cleanup warning at shutdown; tox exited successfully.

Offline reproduction from the repository root, using the vendored tokenizer:

```bash
uv run python -c 'from guidellm.mock_server.server import MockServer; from guidellm.schemas.mock_server.config import MockServerConfig; MockServer(MockServerConfig(processor="tests/fixtures/tokenizers/minimal"))'
```

The initialization above fails on unmodified upstream `4601968d` with `NotImplementedError` from `PreTrainedTokenizer.get_vocab()`. The PR's initialization regression passes with the same tokenizer. No model download or inference server is required.

## Related Issues

No linked issue. Related logging fix: #1142 (already merged).

---

- [x] "I certify that all code in this PR is my own, except as noted below."

## Use of AI

- [x] Includes code generated or substantially modified by an AI agent
- [x] Includes tests generated or substantially modified by an AI agent

Claude Opus 5 assisted with the original implementation and tests; all five commits now include `Generated-by: Claude Opus 5` alongside their DCO sign-offs. Codex assisted with this rebase, validation, and PR-description update.

<!-- Do not edit below this line -->

<!-- begin:squash-data -->

---

# git log

commit 65b961a64addbda988dff14d5b6e6bb844fd76ef
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Fri Sep 11 17:41:54 2026 +0100

    # Fix mock server Hugging Face tokenizer loading
    
    ## Context
    
    Running the mock server with a Hugging Face tokenizer failed before the server started:
    
    ```bash
    uv run guidellm mock-server --processor Qwen/Qwen2.5-0.5B-Instruct
    ```
    
    The command raised `NotImplementedError` from `PreTrainedTokenizer.get_vocab()`. The mock-server handlers were loading the configured processor through the PreTrainedTokenizer base class.
    
    This changes:
    
    - Uses `AutoTokenizer` to initialize configured processors in mock-server handlers.
    - Add an regression test covering mock-server initialization with tokenizer in MINIMAL_TOKENIZER_DIR
    
    ## Follow-up
    
    The mock server still calls `AutoTokenizer.from_pretrained` once for each of its four handlers and produces four tokenizer objects. Reducing this duplication can be handled in a separate commit.
    
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
    Generated-by: Claude Opus 5

commit 53d4153e44e1cbd1489022c0a6cff6ea660c53cc
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 12 11:36:41 2026 +0100

    Refactor mock server test lifecycle
    
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
    Generated-by: Claude Opus 5

commit 67da762559c6b2c532418f2c5f5991f8c015cbcc
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 12 11:37:44 2026 +0100

    Fix mock server tokenizer interface usage
    
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
    Generated-by: Claude Opus 5

commit cee18403e6bd1f2cfffc12c15c4c84ae74a8a1a4
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 12 13:25:05 2026 +0100

    Decode mock server generated token text
    
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
    Generated-by: Claude Opus 5

commit 355a2a8e353e5e64584b3f5daf5d38404df0f329
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 12 13:58:56 2026 +0100

    Polish mock server tokenizer fixes
    
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
    Generated-by: Claude Opus 5

commit 70b4e33fba19f140567c9943d56b21f20abb09a3
Author: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
Date:   Sat Sep 19 16:54:10 2026 +0100

    Isolate tokenizer startup regression in the server fixture
    
    Use the existing subprocess fixture and health endpoint instead of constructing MockServer in the pytest process. This prevents forked server processes from inheriting a registered Sanic app and failing with a duplicate app name.
    
    Generated-by: OpenAI Codex
    Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>

---------

Generated-by: Claude Opus 5
Generated-by: OpenAI Codex
Signed-off-by: Tayo Ogunbiyi <eyitayoogunbiyi@gmail.com>
